### PR TITLE
:hammer: Fix GitHub Actions to checkout submodules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This PR fixes the GitHub Actions workflow to checkout submodules. This will ensure that CI tests run correctly.