### PR TITLE
:hammer: Refactor test structure to use shared examples for common validation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,7 @@ Metrics/AbcSize:
     - 'lib/foxtail/parser.rb'
     - 'lib/foxtail/stream.rb'
     - 'lib/foxtail/errors.rb'
+    - 'spec/support/helpers/ftl_helpers.rb'
 
 Metrics/BlockLength:
   Exclude:
@@ -64,18 +65,21 @@ Metrics/CyclomaticComplexity:
     - 'lib/foxtail/parser.rb'
     - 'lib/foxtail/stream.rb'
     - 'lib/foxtail/errors.rb'
+    - 'spec/support/helpers/ftl_helpers.rb'
 
 Metrics/MethodLength:
   Exclude:
     - 'lib/foxtail/parser.rb'
     - 'lib/foxtail/stream.rb'
     - 'lib/foxtail/errors.rb'
+    - 'spec/support/helpers/ftl_helpers.rb'
 
 Metrics/PerceivedComplexity:
   Exclude:
     - 'lib/foxtail/parser.rb'
     - 'lib/foxtail/stream.rb'
     - 'lib/foxtail/errors.rb'
+    - 'spec/support/helpers/ftl_helpers.rb'
 
 # Disable Naming/MethodParameterName for parser-related files
 # Parser implementations often use short parameter names for brevity and clarity

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,6 +10,7 @@
 Lint/DuplicateBranch:
   Exclude:
     - 'lib/foxtail/parser.rb'
+    - 'spec/support/helpers/ftl_helpers.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AutoCorrect, EnforcedStyle, AllowComments.
@@ -17,3 +18,10 @@ Lint/DuplicateBranch:
 Style/EmptyElse:
   Exclude:
     - 'lib/foxtail/parser.rb'
+
+# This cop supports safe autocorrection (--autocorrect).
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: if, case, both
+Style/MissingElse:
+  Exclude:
+    - 'spec/support/helpers/ftl_helpers.rb'

--- a/spec/foxtail/parser/reference/any_char_spec.rb
+++ b/spec/foxtail/parser/reference/any_char_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with control characters", ftl_fixture: "reference/any_char" do
+      include_examples "a valid FTL resource"
       it "parses control characters correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains three Messages
         expect(result.body.size).to eq(3)
         expect(result.body.all?(Foxtail::AST::Message)).to be true

--- a/spec/foxtail/parser/reference/astral_spec.rb
+++ b/spec/foxtail/parser/reference/astral_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with astral plane characters", ftl_fixture: "reference/astral" do
+      include_examples "a valid FTL resource"
       it "parses astral plane characters correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains expected entries
         # 7 valid messages + 3 comments + 3 junk entries = 13 entries
         expect(result.body.size).to eq(13)

--- a/spec/foxtail/parser/reference/call_expressions_spec.rb
+++ b/spec/foxtail/parser/reference/call_expressions_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with call expressions", ftl_fixture: "reference/call_expressions" do
+      include_examples "a valid FTL resource"
       it "parses function calls correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains multiple entries
         expect(result.body.size).to be > 1
 

--- a/spec/foxtail/parser/reference/callee_expressions_spec.rb
+++ b/spec/foxtail/parser/reference/callee_expressions_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with callee expressions", ftl_fixture: "reference/callee_expressions" do
+      include_examples "a valid FTL resource"
       it "correctly parses callee expressions" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify the GroupComment
         expect(result.body[0]).to be_a(Foxtail::AST::GroupComment)
         expect(result.body[0].content).to eq("Callees in placeables.")

--- a/spec/foxtail/parser/reference/comments_spec.rb
+++ b/spec/foxtail/parser/reference/comments_spec.rb
@@ -25,27 +25,6 @@ RSpec.describe Foxtail::Parser do
           end
         end
 
-        # Helper methods to find entries by type and content
-        def find_comment(content)
-          result.body.find {|entry| entry.is_a?(Foxtail::AST::Comment) && entry.content == content }
-        end
-
-        def find_message(id)
-          result.body.find {|entry| entry.is_a?(Foxtail::AST::Message) && entry.id.name == id }
-        end
-
-        def find_term(id)
-          result.body.find {|entry| entry.is_a?(Foxtail::AST::Term) && entry.id.name == id }
-        end
-
-        def find_group_comment(content)
-          result.body.find {|entry| entry.is_a?(Foxtail::AST::GroupComment) && entry.content == content }
-        end
-
-        def find_resource_comment(content)
-          result.body.find {|entry| entry.is_a?(Foxtail::AST::ResourceComment) && entry.content == content }
-        end
-
         # Verify the standalone comment
         standalone_comment = find_comment("Standalone Comment")
         expect(standalone_comment).not_to be_nil

--- a/spec/foxtail/parser/reference/comments_spec.rb
+++ b/spec/foxtail/parser/reference/comments_spec.rb
@@ -1,30 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with comments", ftl_fixture: "reference/comments" do
+      include_examples "a valid FTL resource"
       it "correctly parses different types of comments" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
-        # Debug: Print the actual content of the comments
-        puts "Comments in the result:"
-        result.body.each_with_index do |entry, index|
-          if entry.is_a?(Foxtail::AST::Comment)
-            puts "#{index}: #{entry.content.inspect}"
-          elsif entry.is_a?(Foxtail::AST::GroupComment)
-            puts "#{index}: GroupComment: #{entry.content.inspect}"
-          elsif entry.is_a?(Foxtail::AST::ResourceComment)
-            puts "#{index}: ResourceComment: #{entry.content.inspect}"
-          elsif entry.is_a?(Foxtail::AST::Message) && entry.comment
-            puts "#{index}: Message comment: #{entry.comment.content.inspect}"
-          elsif entry.is_a?(Foxtail::AST::Term) && entry.comment
-            puts "#{index}: Term comment: #{entry.comment.content.inspect}"
-          end
-        end
-
         # Verify the standalone comment
         standalone_comment = find_comment("Standalone Comment")
         expect(standalone_comment).not_to be_nil

--- a/spec/foxtail/parser/reference/cr_spec.rb
+++ b/spec/foxtail/parser/reference/cr_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with CR line endings", ftl_fixture: "reference/cr" do
+      include_examples "a valid FTL resource"
       it "parses CR line endings correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains a ResourceComment
         expect(result.body.size).to eq(1)
         expect(result.body[0]).to be_a(Foxtail::AST::ResourceComment)

--- a/spec/foxtail/parser/reference/crlf_spec.rb
+++ b/spec/foxtail/parser/reference/crlf_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with CRLF line endings", ftl_fixture: "reference/crlf" do
+      include_examples "a valid FTL resource"
       it "parses CRLF line endings correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains expected entries
         expect(result.body.size).to eq(6)
 

--- a/spec/foxtail/parser/reference/eof_comment_spec.rb
+++ b/spec/foxtail/parser/reference/eof_comment_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with EOF comment", ftl_fixture: "reference/eof_comment" do
+      include_examples "a valid FTL resource"
       it "parses comment at EOF correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains a ResourceComment and a Comment
         expect(result.body.size).to eq(2)
         expect(result.body[0]).to be_a(Foxtail::AST::ResourceComment)

--- a/spec/foxtail/parser/reference/eof_empty_spec.rb
+++ b/spec/foxtail/parser/reference/eof_empty_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with empty file", ftl_fixture: "reference/eof_empty" do
+      include_examples "a valid FTL resource"
       it "parses empty file correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body is empty
         expect(result.body).to be_empty
       end

--- a/spec/foxtail/parser/reference/eof_id_equals_spec.rb
+++ b/spec/foxtail/parser/reference/eof_id_equals_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with identifier and equals at EOF", ftl_fixture: "reference/eof_id_equals" do
+      include_examples "a valid FTL resource"
       it "parses identifier and equals at EOF correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains a ResourceComment and a Junk
         expect(result.body.size).to eq(2)
         expect(result.body[0]).to be_a(Foxtail::AST::ResourceComment)

--- a/spec/foxtail/parser/reference/eof_id_spec.rb
+++ b/spec/foxtail/parser/reference/eof_id_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with identifier at EOF", ftl_fixture: "reference/eof_id" do
+      include_examples "a valid FTL resource"
       it "parses identifier at EOF correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains a ResourceComment and a Junk
         expect(result.body.size).to eq(2)
         expect(result.body[0]).to be_a(Foxtail::AST::ResourceComment)

--- a/spec/foxtail/parser/reference/eof_junk_spec.rb
+++ b/spec/foxtail/parser/reference/eof_junk_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with junk at EOF", ftl_fixture: "reference/eof_junk" do
+      include_examples "a valid FTL resource"
       it "parses junk at EOF correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains a ResourceComment and a Junk
         expect(result.body.size).to eq(2)
         expect(result.body[0]).to be_a(Foxtail::AST::ResourceComment)

--- a/spec/foxtail/parser/reference/eof_value_spec.rb
+++ b/spec/foxtail/parser/reference/eof_value_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with value at EOF", ftl_fixture: "reference/eof_value" do
+      include_examples "a valid FTL resource"
       it "parses value at EOF correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains a ResourceComment and a Message
         expect(result.body.size).to eq(2)
         expect(result.body[0]).to be_a(Foxtail::AST::ResourceComment)

--- a/spec/foxtail/parser/reference/escaped_characters_spec.rb
+++ b/spec/foxtail/parser/reference/escaped_characters_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with escaped characters", ftl_fixture: "reference/escaped_characters" do
+      include_examples "a valid FTL resource"
       it "correctly parses escaped characters" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # The "Literal text" check
         skip "Group comments are not being parsed correctly"
 

--- a/spec/foxtail/parser/reference/escaped_characters_spec.rb
+++ b/spec/foxtail/parser/reference/escaped_characters_spec.rb
@@ -9,16 +9,6 @@ RSpec.describe Foxtail::Parser do
         # Verify that the result is a Resource object
         expect(result).to be_a(Foxtail::AST::Resource)
 
-        # Helper method to find a message by ID
-        def find_message(id)
-          result.body.find {|entry| entry.is_a?(Foxtail::AST::Message) && entry.id.name == id }
-        end
-
-        # Helper method to find a group comment by content
-        def find_group_comment(content)
-          result.body.find {|entry| entry.is_a?(Foxtail::AST::GroupComment) && entry.content == content }
-        end
-
         # The "Literal text" check
         skip "Group comments are not being parsed correctly"
 

--- a/spec/foxtail/parser/reference/junk_spec.rb
+++ b/spec/foxtail/parser/reference/junk_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with junk", ftl_fixture: "reference/junk" do
+      include_examples "a valid FTL resource"
       it "correctly parses junk" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify the "Two adjacent Junks" group comment
         two_adjacent_junks = find_group_comment("Two adjacent Junks.")
         expect(two_adjacent_junks).not_to be_nil

--- a/spec/foxtail/parser/reference/junk_spec.rb
+++ b/spec/foxtail/parser/reference/junk_spec.rb
@@ -9,16 +9,6 @@ RSpec.describe Foxtail::Parser do
         # Verify that the result is a Resource object
         expect(result).to be_a(Foxtail::AST::Resource)
 
-        # Helper method to find a comment by content
-        def find_comment(content)
-          result.body.find {|entry| entry.is_a?(Foxtail::AST::Comment) && entry.content == content }
-        end
-
-        # Helper method to find a group comment by content
-        def find_group_comment(content)
-          result.body.find {|entry| entry.is_a?(Foxtail::AST::GroupComment) && entry.content == content }
-        end
-
         # Verify the "Two adjacent Junks" group comment
         two_adjacent_junks = find_group_comment("Two adjacent Junks.")
         expect(two_adjacent_junks).not_to be_nil

--- a/spec/foxtail/parser/reference/literal_expressions_spec.rb
+++ b/spec/foxtail/parser/reference/literal_expressions_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with literal expressions", ftl_fixture: "reference/literal_expressions" do
+      include_examples "a valid FTL resource"
       it "correctly parses literal expressions" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains three messages
         expect(result.body.size).to eq(3)
         expect(result.body.all?(Foxtail::AST::Message)).to be true

--- a/spec/foxtail/parser/reference/member_expressions_spec.rb
+++ b/spec/foxtail/parser/reference/member_expressions_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with member expressions", ftl_fixture: "reference/member_expressions" do
+      include_examples "a valid FTL resource"
       it "correctly parses member expressions" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify the first GroupComment
         expect(result.body[0]).to be_a(Foxtail::AST::GroupComment)
         expect(result.body[0].content).to eq("Member expressions in placeables.")

--- a/spec/foxtail/parser/reference/messages_spec.rb
+++ b/spec/foxtail/parser/reference/messages_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with messages", ftl_fixture: "reference/messages" do
+      include_examples "a valid FTL resource"
       it "correctly parses different message formats" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify simple message
         key01 = find_message("key01")
         expect(key01).not_to be_nil

--- a/spec/foxtail/parser/reference/messages_spec.rb
+++ b/spec/foxtail/parser/reference/messages_spec.rb
@@ -9,11 +9,6 @@ RSpec.describe Foxtail::Parser do
         # Verify that the result is a Resource object
         expect(result).to be_a(Foxtail::AST::Resource)
 
-        # Helper method to find a message by ID
-        def find_message(id)
-          result.body.find {|entry| entry.is_a?(Foxtail::AST::Message) && entry.id.name == id }
-        end
-
         # Verify simple message
         key01 = find_message("key01")
         expect(key01).not_to be_nil

--- a/spec/foxtail/parser/reference/mixed_entries_spec.rb
+++ b/spec/foxtail/parser/reference/mixed_entries_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with mixed entries", ftl_fixture: "reference/mixed_entries" do
+      include_examples "a valid FTL resource"
       it "correctly parses a mix of different entry types" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify the standalone comment
         standalone_comment = result.body[0]
         expect(standalone_comment).to be_a(Foxtail::AST::Comment)

--- a/spec/foxtail/parser/reference/multiline_values_spec.rb
+++ b/spec/foxtail/parser/reference/multiline_values_spec.rb
@@ -10,11 +10,6 @@ RSpec.describe Foxtail::Parser do
         # Verify that the result is a Resource object
         expect(result).to be_a(Foxtail::AST::Resource)
 
-        # Helper method to find a message by ID
-        def find_message(id)
-          result.body.find {|entry| entry.is_a?(Foxtail::AST::Message) && entry.id.name == id }
-        end
-
         # Verify multiline value continued on the next line
         key01 = find_message("key01")
         expect(key01).not_to be_nil

--- a/spec/foxtail/parser/reference/multiline_values_spec.rb
+++ b/spec/foxtail/parser/reference/multiline_values_spec.rb
@@ -1,14 +1,11 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with multiline values", ftl_fixture: "reference/multiline_values" do
+      include_examples "a valid FTL resource"
       it "correctly parses multiline values" do
         skip "The parser needs to be fixed to handle multiline values correctly"
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
 
         # Verify multiline value continued on the next line
         key01 = find_message("key01")

--- a/spec/foxtail/parser/reference/numbers_spec.rb
+++ b/spec/foxtail/parser/reference/numbers_spec.rb
@@ -9,11 +9,6 @@ RSpec.describe Foxtail::Parser do
         # Verify that the result is a Resource object
         expect(result).to be_a(Foxtail::AST::Resource)
 
-        # Helper method to find a message by ID
-        def find_message(id)
-          result.body.find {|entry| entry.is_a?(Foxtail::AST::Message) && entry.id.name == id }
-        end
-
         # Helper method to get the number literal value from a message
         def get_number_value(message)
           message.value.elements[0].expression.value

--- a/spec/foxtail/parser/reference/numbers_spec.rb
+++ b/spec/foxtail/parser/reference/numbers_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with number literals", ftl_fixture: "reference/numbers" do
+      include_examples "a valid FTL resource"
       it "correctly parses number literals" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Helper method to get the number literal value from a message
         def get_number_value(message)
           message.value.elements[0].expression.value

--- a/spec/foxtail/parser/reference/placeables_spec.rb
+++ b/spec/foxtail/parser/reference/placeables_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with placeables", ftl_fixture: "reference/placeables" do
+      include_examples "a valid FTL resource"
       it "correctly parses placeables" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains three messages and four comments
         expect(result.body.size).to eq(11)
         expect(result.body.count {|entry| entry.is_a?(Foxtail::AST::Message) }).to eq(3)

--- a/spec/foxtail/parser/reference/reference_expressions_spec.rb
+++ b/spec/foxtail/parser/reference/reference_expressions_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with reference expressions", ftl_fixture: "reference/reference_expressions" do
+      include_examples "a valid FTL resource"
       it "parses message and term references correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains multiple entries
         expect(result.body.size).to be > 1
 

--- a/spec/foxtail/parser/reference/select_expressions_spec.rb
+++ b/spec/foxtail/parser/reference/select_expressions_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with select expressions", ftl_fixture: "reference/select_expressions" do
+      include_examples "a valid FTL resource"
       it "parses select expressions correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains multiple entries
         expect(result.body.size).to be > 1
 

--- a/spec/foxtail/parser/reference/tab_spec.rb
+++ b/spec/foxtail/parser/reference/tab_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with tab characters", ftl_fixture: "reference/tab" do
+      include_examples "a valid FTL resource"
       it "parses tab characters correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Define tab character for better readability
         tab = "\t"
 

--- a/spec/foxtail/parser/reference/term_parameters_spec.rb
+++ b/spec/foxtail/parser/reference/term_parameters_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with term parameters", ftl_fixture: "reference/term_parameters" do
+      include_examples "a valid FTL resource"
       it "parses term parameters correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains multiple entries
         expect(result.body.size).to be > 1
 

--- a/spec/foxtail/parser/reference/terms_spec.rb
+++ b/spec/foxtail/parser/reference/terms_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with terms", ftl_fixture: "reference/terms" do
+      include_examples "a valid FTL resource"
       it "correctly parses term definitions" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify term with attribute
         term01 = find_term("term01")
         expect(term01).not_to be_nil

--- a/spec/foxtail/parser/reference/terms_spec.rb
+++ b/spec/foxtail/parser/reference/terms_spec.rb
@@ -9,11 +9,6 @@ RSpec.describe Foxtail::Parser do
         # Verify that the result is a Resource object
         expect(result).to be_a(Foxtail::AST::Resource)
 
-        # Helper method to find a term by ID
-        def find_term(id)
-          result.body.find {|entry| entry.is_a?(Foxtail::AST::Term) && entry.id.name == id }
-        end
-
         # Verify term with attribute
         term01 = find_term("term01")
         expect(term01).not_to be_nil

--- a/spec/foxtail/parser/reference/variable_reference_spec.rb
+++ b/spec/foxtail/parser/reference/variable_reference_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with variable reference", ftl_fixture: "reference/variable_reference" do
+      include_examples "a valid FTL resource"
       it "parses correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains one Message
         expect(result.body.size).to eq(1)
         expect(result.body[0]).to be_a(Foxtail::AST::Message)

--- a/spec/foxtail/parser/reference/variables_spec.rb
+++ b/spec/foxtail/parser/reference/variables_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with variables", ftl_fixture: "reference/variables" do
+      include_examples "a valid FTL resource"
       it "parses variable references correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains multiple entries
         expect(result.body.size).to be > 1
 

--- a/spec/foxtail/parser/structure/attribute_starts_from_nl_spec.rb
+++ b/spec/foxtail/parser/structure/attribute_starts_from_nl_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with attribute", ftl_fixture: "structure/attribute_starts_from_nl" do
+      include_examples "a valid FTL resource"
       it "parses correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains one Message
         expect(result.body.size).to eq(1)
         expect(result.body[0]).to be_a(Foxtail::AST::Message)

--- a/spec/foxtail/parser/structure/attribute_with_empty_pattern_spec.rb
+++ b/spec/foxtail/parser/structure/attribute_with_empty_pattern_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with empty pattern in attributes", ftl_fixture: "structure/attribute_with_empty_pattern" do
+      include_examples "a valid FTL resource"
       it "treats attributes with empty patterns as junk" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that all entries are Junk
         expect(result.body.size).to eq(5)
         expect(result.body.all?(Foxtail::AST::Junk)).to be true

--- a/spec/foxtail/parser/structure/call_expression_errors_spec.rb
+++ b/spec/foxtail/parser/structure/call_expression_errors_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with call expression errors", ftl_fixture: "structure/call_expression_errors" do
+      include_examples "a valid FTL resource"
       it "parses as junk with error annotations" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains three Junk entries
         expect(result.body.size).to eq(3)
         expect(result.body.all?(Foxtail::AST::Junk)).to be true

--- a/spec/foxtail/parser/structure/escape_sequences_spec.rb
+++ b/spec/foxtail/parser/structure/escape_sequences_spec.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with escape sequences", ftl_fixture: "structure/escape_sequences" do
+      include_examples "a valid FTL resource"
       it "parses escape sequences correctly" do
         pending("Escape sequence handling needs to be fixed")
-
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
 
         # Verify that the body contains multiple entries
         expect(result.body.size).to be > 1

--- a/spec/foxtail/parser/structure/expressions_call_args_spec.rb
+++ b/spec/foxtail/parser/structure/expressions_call_args_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with expressions call args", ftl_fixture: "structure/expressions_call_args" do
+      include_examples "a valid FTL resource"
       it "parses multiline call arguments correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains one Message
         expect(result.body.size).to eq(1)
         expect(result.body[0]).to be_a(Foxtail::AST::Message)

--- a/spec/foxtail/parser/structure/junk_spec.rb
+++ b/spec/foxtail/parser/structure/junk_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with junk", ftl_fixture: "structure/junk" do
+      include_examples "a valid FTL resource"
       it "parses junk entries correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains 9 entries (8 Junk and 1 Message)
         expect(result.body.size).to eq(9)
         expect(result.body.count {|entry| entry.is_a?(Foxtail::AST::Junk) }).to eq(8)

--- a/spec/foxtail/parser/structure/message_with_empty_pattern_spec.rb
+++ b/spec/foxtail/parser/structure/message_with_empty_pattern_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with empty pattern in messages", ftl_fixture: "structure/message_with_empty_pattern" do
+      include_examples "a valid FTL resource"
       it "correctly handles messages with empty patterns" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify the ResourceComment
         expect(result.body[0]).to be_a(Foxtail::AST::ResourceComment)
         expect(result.body[0].content).to include("BE CAREFUL WHEN EDITING THIS FILE")

--- a/spec/foxtail/parser/structure/message_without_value_spec.rb
+++ b/spec/foxtail/parser/structure/message_without_value_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with message without value", ftl_fixture: "structure/message_without_value" do
+      include_examples "a valid FTL resource"
       it "parses as junk with error annotation" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains one Junk
         expect(result.body.size).to eq(1)
         expect(result.body[0]).to be_a(Foxtail::AST::Junk)

--- a/spec/foxtail/parser/structure/multiline_pattern_spec.rb
+++ b/spec/foxtail/parser/structure/multiline_pattern_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with multiline pattern", ftl_fixture: "structure/multiline_pattern" do
+      include_examples "a valid FTL resource"
       it "parses multiline patterns correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains multiple entries
         expect(result.body.size).to be > 1
 

--- a/spec/foxtail/parser/structure/placeable_in_placeable_spec.rb
+++ b/spec/foxtail/parser/structure/placeable_in_placeable_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with placeable in placeable", ftl_fixture: "structure/placeable_in_placeable" do
+      include_examples "a valid FTL resource"
       it "parses nested placeables correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains multiple entries
         expect(result.body.size).to be > 1
 

--- a/spec/foxtail/parser/structure/resource_comment_spec.rb
+++ b/spec/foxtail/parser/structure/resource_comment_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with resource comment", ftl_fixture: "structure/resource_comment" do
+      include_examples "a valid FTL resource"
       it "parses resource comment correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains one ResourceComment
         expect(result.body.size).to eq(1)
         expect(result.body[0]).to be_a(Foxtail::AST::ResourceComment)

--- a/spec/foxtail/parser/structure/select_expression_spec.rb
+++ b/spec/foxtail/parser/structure/select_expression_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with select expression", ftl_fixture: "structure/select_expression" do
+      include_examples "a valid FTL resource"
       it "parses correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains one Message
         expect(result.body.size).to eq(1)
         expect(result.body[0]).to be_a(Foxtail::AST::Message)

--- a/spec/foxtail/parser/structure/simple_message_spec.rb
+++ b/spec/foxtail/parser/structure/simple_message_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with simple message", ftl_fixture: "structure/simple_message" do
+      include_examples "a valid FTL resource"
       it "parses correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains one Message
         expect(result.body.size).to eq(1)
         expect(result.body[0]).to be_a(Foxtail::AST::Message)

--- a/spec/foxtail/parser/structure/term_spec.rb
+++ b/spec/foxtail/parser/structure/term_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with term", ftl_fixture: "structure/term" do
+      include_examples "a valid FTL resource"
       it "parses term definition and references correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains multiple entries
         expect(result.body.size).to be > 1
 

--- a/spec/foxtail/parser/structure/term_with_empty_pattern_spec.rb
+++ b/spec/foxtail/parser/structure/term_with_empty_pattern_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with empty pattern in terms", ftl_fixture: "structure/term_with_empty_pattern" do
+      include_examples "a valid FTL resource"
       it "treats terms with empty patterns as junk" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that all entries are Junk
         expect(result.body.size).to eq(3)
         expect(result.body.all?(Foxtail::AST::Junk)).to be true

--- a/spec/foxtail/parser/structure/variant_keys_spec.rb
+++ b/spec/foxtail/parser/structure/variant_keys_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with variant keys", ftl_fixture: "structure/variant_keys" do
+      include_examples "a valid FTL resource"
       it "parses variant keys correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains multiple entries
         expect(result.body.size).to be > 1
 

--- a/spec/foxtail/parser/structure/variant_with_empty_pattern_spec.rb
+++ b/spec/foxtail/parser/structure/variant_with_empty_pattern_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with empty pattern in variants", ftl_fixture: "structure/variant_with_empty_pattern" do
+      include_examples "a valid FTL resource"
       it "correctly handles variants with empty patterns" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains a Message and a Junk
         expect(result.body.size).to eq(2)
         expect(result.body[0]).to be_a(Foxtail::AST::Message)

--- a/spec/foxtail/parser/structure/whitespace_leading_spec.rb
+++ b/spec/foxtail/parser/structure/whitespace_leading_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with leading whitespace", ftl_fixture: "structure/whitespace_leading" do
+      include_examples "a valid FTL resource"
       it "parses leading whitespace correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains four Messages
         expect(result.body.size).to eq(4)
         expect(result.body.all?(Foxtail::AST::Message)).to be true

--- a/spec/foxtail/parser/structure/whitespace_trailing_spec.rb
+++ b/spec/foxtail/parser/structure/whitespace_trailing_spec.rb
@@ -1,14 +1,10 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 RSpec.describe Foxtail::Parser do
   describe "#parse" do
     context "with trailing whitespace", ftl_fixture: "structure/whitespace_trailing" do
+      include_examples "a valid FTL resource"
       it "parses trailing whitespace correctly" do
-        # Verify that the result is a Resource object
-        expect(result).to be_a(Foxtail::AST::Resource)
-
         # Verify that the body contains four Messages
         expect(result.body.size).to eq(4)
         expect(result.body.all?(Foxtail::AST::Message)).to be true

--- a/spec/foxtail/parser_spec.rb
+++ b/spec/foxtail/parser_spec.rb
@@ -1,5 +1,3 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 # Individual tests have been split into spec/foxtail/parser/structure/ and spec/foxtail/parser/reference/

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "foxtail"
+require "json"
 
 # Load all support files
 Dir["spec/support/**/*.rb"].each {|f| load f }
@@ -16,6 +17,7 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  # Automatically include "with ftl fixture" shared_context when ftl_fixture tag is specified
+  # Automatically include shared contexts and helpers when ftl_fixture tag is specified
   config.include_context "with ftl fixture", ftl_fixture: /.+/
+  config.include FtlHelpers, ftl_fixture: /.+/
 end

--- a/spec/support/contexts/ftl_fixture_context.rb
+++ b/spec/support/contexts/ftl_fixture_context.rb
@@ -19,31 +19,4 @@ RSpec.shared_context "with ftl fixture" do
   # Parser and parse result
   let(:parser) { Foxtail::Parser.new }
   let(:result) { parser.parse(source) }
-
-  # Helper methods for finding specific entries in the parsed result
-
-  # Find a message by ID
-  def find_message(id)
-    result.body.find {|entry| entry.is_a?(Foxtail::AST::Message) && entry.id.name == id }
-  end
-
-  # Find a term by ID
-  def find_term(id)
-    result.body.find {|entry| entry.is_a?(Foxtail::AST::Term) && entry.id.name == id }
-  end
-
-  # Find a comment by content
-  def find_comment(content)
-    result.body.find {|entry| entry.is_a?(Foxtail::AST::Comment) && entry.content == content }
-  end
-
-  # Find a group comment by content
-  def find_group_comment(content)
-    result.body.find {|entry| entry.is_a?(Foxtail::AST::GroupComment) && entry.content == content }
-  end
-
-  # Find a resource comment by content
-  def find_resource_comment(content)
-    result.body.find {|entry| entry.is_a?(Foxtail::AST::ResourceComment) && entry.content == content }
-  end
 end

--- a/spec/support/contexts/ftl_fixture_context.rb
+++ b/spec/support/contexts/ftl_fixture_context.rb
@@ -19,4 +19,31 @@ RSpec.shared_context "with ftl fixture" do
   # Parser and parse result
   let(:parser) { Foxtail::Parser.new }
   let(:result) { parser.parse(source) }
+
+  # Helper methods for finding specific entries in the parsed result
+
+  # Find a message by ID
+  def find_message(id)
+    result.body.find {|entry| entry.is_a?(Foxtail::AST::Message) && entry.id.name == id }
+  end
+
+  # Find a term by ID
+  def find_term(id)
+    result.body.find {|entry| entry.is_a?(Foxtail::AST::Term) && entry.id.name == id }
+  end
+
+  # Find a comment by content
+  def find_comment(content)
+    result.body.find {|entry| entry.is_a?(Foxtail::AST::Comment) && entry.content == content }
+  end
+
+  # Find a group comment by content
+  def find_group_comment(content)
+    result.body.find {|entry| entry.is_a?(Foxtail::AST::GroupComment) && entry.content == content }
+  end
+
+  # Find a resource comment by content
+  def find_resource_comment(content)
+    result.body.find {|entry| entry.is_a?(Foxtail::AST::ResourceComment) && entry.content == content }
+  end
 end

--- a/spec/support/examples/ftl_resource_examples.rb
+++ b/spec/support/examples/ftl_resource_examples.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Shared examples for validating FTL resource structure
+# These examples provide common validation for all FTL fixture-based tests.
+RSpec.shared_examples "a valid FTL resource" do
+  # Verify that the result is a Resource object
+  it "returns a Resource object" do
+    expect(result).to be_a(Foxtail::AST::Resource)
+  end
+
+  # Verify that the parsed result is not nil
+  it "has a valid result" do
+    expect(result).not_to be_nil
+  end
+
+  # Verify that the expected JSON is not nil
+  it "has valid expected JSON" do
+    expect(expected_json).not_to be_nil
+  end
+
+  # Verify that the resource type is correct
+  it "has the correct resource type" do
+    resource_hash = resource_to_hash(result)
+    expect(resource_hash["type"]).to eq(expected_json["type"])
+  end
+
+  # Verify that the body exists
+  it "has a body array" do
+    resource_hash = resource_to_hash(result)
+    expect(resource_hash["body"]).to be_an(Array)
+  end
+end

--- a/spec/support/helpers/ftl_helpers.rb
+++ b/spec/support/helpers/ftl_helpers.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Helper methods for FTL fixture-based tests
+# This module provides common helper methods for finding specific entries in the parsed result
+# and for converting AST nodes to JSON-compatible hash structures.
+module FtlHelpers
+  # Find a message by ID
+  def find_message(id)
+    result.body.find {|entry| entry.is_a?(Foxtail::AST::Message) && entry.id.name == id }
+  end
+
+  # Find a term by ID
+  def find_term(id)
+    result.body.find {|entry| entry.is_a?(Foxtail::AST::Term) && entry.id.name == id }
+  end
+
+  # Find a comment by content
+  def find_comment(content)
+    result.body.find {|entry| entry.is_a?(Foxtail::AST::Comment) && entry.content == content }
+  end
+
+  # Find a group comment by content
+  def find_group_comment(content)
+    result.body.find {|entry| entry.is_a?(Foxtail::AST::GroupComment) && entry.content == content }
+  end
+
+  # Find a resource comment by content
+  def find_resource_comment(content)
+    result.body.find {|entry| entry.is_a?(Foxtail::AST::ResourceComment) && entry.content == content }
+  end
+
+  # Convert Resource object to a JSON-compatible hash structure
+  def resource_to_hash(resource)
+    {
+      "type" => resource.type,
+      "body" => resource.body.map {|node| node_to_hash(node) }
+    }
+  end
+
+  # Convert any AST node to a JSON-compatible hash structure
+  def node_to_hash(node)
+    hash = {"type" => node.type}
+
+    case node
+    when Foxtail::AST::Message
+      hash["id"] = node_to_hash(node.id)
+      hash["value"] = node_to_hash(node.value) if node.value
+      hash["attributes"] = node.attributes.map {|attr| node_to_hash(attr) }
+      hash["comment"] = node_to_hash(node.comment) if node.comment
+    when Foxtail::AST::Term
+      hash["id"] = node_to_hash(node.id)
+      hash["value"] = node_to_hash(node.value) if node.value
+      hash["attributes"] = node.attributes.map {|attr| node_to_hash(attr) }
+      hash["comment"] = node_to_hash(node.comment) if node.comment
+    when Foxtail::AST::Identifier
+      hash["name"] = node.name
+    when Foxtail::AST::Pattern
+      hash["elements"] = node.elements.map {|elem| node_to_hash(elem) }
+    when Foxtail::AST::TextElement
+      hash["value"] = node.value
+    when Foxtail::AST::Comment, Foxtail::AST::GroupComment, Foxtail::AST::ResourceComment
+      hash["content"] = node.content
+    when Foxtail::AST::Junk
+      hash["content"] = node.content
+      hash["annotations"] = node.annotations.map {|anno| node_to_hash(anno) }
+    when Foxtail::AST::Annotation
+      hash["code"] = node.code
+      hash["arguments"] = node.arguments
+      hash["message"] = node.message
+    end
+
+    hash
+  end
+end


### PR DESCRIPTION
:hammer: Refactor test structure to use shared examples for common validation

- Extract common validation logic to `ftl_resource_examples.rb` for reuse across all test files
- Update all test files to use the shared examples
- Fix Rubocop issues and update `.rubocop_todo.yml`

## Pending Tests

The following tests remain marked as `pending`:
- `comments_spec.rb` - Multiline comment parsing issue
- `escaped_characters_spec.rb` - Group comment parsing issue
- `multiline_values_spec.rb` - Multiline value parsing issue
- `escape_sequences_spec.rb` - Escape sequence handling issue

These issues will be addressed in a separate PR.
