### PR TITLE
:wrench: Add workflow self-testing trigger

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -12,8 +12,8 @@ on:
       - 'lib/foxtail/parser.rb'
       - 'lib/foxtail/bundle/ast_converter.rb'
       - 'spec/parser/**'
-      - 'spec/fluent_js_compatibility_spec.rb'
       - 'compat/**'
+      - '.github/workflows/compatibility.yml'
 
   pull_request:
     paths:
@@ -21,8 +21,8 @@ on:
       - 'lib/foxtail/parser.rb'
       - 'lib/foxtail/bundle/ast_converter.rb'
       - 'spec/parser/**'
-      - 'spec/fluent_js_compatibility_spec.rb'
       - 'compat/**'
+      - '.github/workflows/compatibility.yml'
 
   # Allow manual triggering for comprehensive testing
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Add compatibility workflow file itself to path triggers
- Remove reference to non-existent spec file
- Ensure workflow changes are tested before merge

## Changes
- Added `.github/workflows/compatibility.yml` to path triggers for both push and pull_request events
- Removed `spec/fluent_js_compatibility_spec.rb` from path triggers (file no longer exists)

## Rationale
Workflow changes should trigger compatibility tests to ensure the workflow itself remains functional before merging changes.

:robot: Generated with [Claude Code](https://claude.ai/code)