### PR TITLE
:sparkles: Add custom pattern support to DateTimeFormatter

### DIFF
--- a/spec/foxtail/functions/date_time_formatter_spec.rb
+++ b/spec/foxtail/functions/date_time_formatter_spec.rb
@@ -75,5 +75,55 @@ RSpec.describe Foxtail::Functions::DateTimeFormatter do
         }.to raise_error(ArgumentError)
       end
     end
+
+    context "with custom patterns" do
+      let(:en_locale) { locale("en") }
+      let(:ja_locale) { locale("ja") }
+
+      it "formats with simple custom pattern" do
+        result = formatter.call(test_time, locale: en_locale, pattern: "yyyy-MM-dd")
+        expect(result).to eq("2023-06-15")
+      end
+
+      it "formats with custom pattern including weekday and month names" do
+        result = formatter.call(test_time, locale: en_locale, pattern: "EEEE, MMMM d, yyyy")
+        expect(result).to eq("Thursday, June 15, 2023")
+      end
+
+      it "formats with abbreviated names in custom pattern" do
+        result = formatter.call(test_time, locale: en_locale, pattern: "EEE, MMM d")
+        expect(result).to eq("Thu, Jun 15")
+      end
+
+      it "formats with time components in custom pattern" do
+        result = formatter.call(test_time, locale: en_locale, pattern: "HH:mm:ss")
+        expect(result).to eq("14:30:45")
+      end
+
+      it "formats with 12-hour time in custom pattern" do
+        result = formatter.call(test_time, locale: en_locale, pattern: "h:mm a")
+        expect(result).to eq("2:30 PM")
+      end
+
+      it "formats with complex custom pattern" do
+        result = formatter.call(test_time, locale: en_locale, pattern: "EEEE, d MMMM yyyy 'at' HH:mm")
+        expect(result).to eq("Thursday, 15 June 2023 at 14:30")
+      end
+
+      it "uses locale-specific names in custom patterns" do
+        result = formatter.call(test_time, locale: ja_locale, pattern: "yyyy年MMMMd日(EEEE)")
+        expect(result).to eq("2023年6月15日(木曜日)")
+      end
+
+      it "handles literal text in custom patterns" do
+        result = formatter.call(test_time, locale: en_locale, pattern: "'Today is' EEEE")
+        expect(result).to eq("Today is Thursday")
+      end
+
+      it "handles mixed tokens and literals" do
+        result = formatter.call(test_time, locale: en_locale, pattern: "Date: dd/MM/yyyy Time: HH:mm")
+        expect(result).to eq("Date: 15/06/2023 Time: 14:30")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Add `pattern` option to DateTimeFormatter for custom CLDR patterns
- Implement smart pattern parser with proper tokenization and context awareness
- Support all major CLDR pattern tokens with locale-specific formatting

## Features
✅ **Custom Pattern Support**: Use any CLDR pattern like `"yyyy-MM-dd"`, `"EEEE, MMMM d, yyyy"`
✅ **Smart Tokenization**: Properly distinguishes pattern tokens from literal text (`Date:` vs `a` for AM/PM)
✅ **Unicode Support**: Handles Japanese and other Unicode characters correctly
✅ **Quoted Literals**: Support for quoted text like `"'Today is' EEEE"`
✅ **Comprehensive Coverage**: All major CLDR tokens (EEEE, yyyy, MM, dd, HH, mm, etc.)

## Examples
```ruby
formatter = Foxtail::Functions::DateTimeFormatter.new
time = Time.new(2023, 6, 15, 14, 30, 45)

# Simple patterns
formatter.call(time, locale: locale("en"), pattern: "yyyy-MM-dd")
# => "2023-06-15"

# Complex patterns with names
formatter.call(time, locale: locale("en"), pattern: "EEEE, MMMM d, yyyy")
# => "Thursday, June 15, 2023"

# Time patterns
formatter.call(time, locale: locale("en"), pattern: "h:mm a")
# => "2:30 PM"

# Literal text
formatter.call(time, locale: locale("en"), pattern: "EEEE, d MMMM yyyy 'at' HH:mm")
# => "Thursday, 15 June 2023 at 14:30"

# Locale-specific formatting
formatter.call(time, locale: locale("ja"), pattern: "yyyy年MMMMd日(EEEE)")
# => "2023年6月15日(木曜日)"
```

## Implementation Details
- **Context-Aware Parser**: Distinguishes CLDR tokens from English words (e.g., `Date:` vs standalone `a`)
- **Precedence**: Custom patterns take priority over dateStyle/timeStyle options
- **Backward Compatibility**: Existing dateStyle/timeStyle functionality unchanged
- **Performance**: Efficient tokenization with minimal overhead

## Testing
- 20/20 test cases passing
- Edge cases covered: mixed literals, Unicode text, quoted strings
- Cross-locale testing (English, Japanese)

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)