### PR TITLE
Add ruby-lsp development dependency to prevent rbs removal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,9 @@ group :development do
   gem "yard"
 
   gem "rexml" # For CLDR XML parsing in rake tasks
+
+  # Language Server Protocol support
+  gem "ruby-lsp"
 end
 
 group :test do


### PR DESCRIPTION
## Summary

Explicitly adds `ruby-lsp` gem to development dependencies as a workaround for dependency resolution issues where the `rbs` gem gets unexpectedly uninstalled during bundle operations.

## Problem

During development, the `rbs` gem was being removed by Bundler's dependency resolution, causing issues with development tools that rely on it. This happened because `rbs` was only indirectly depended upon and could be resolved away when other gems' dependency constraints changed.

## Solution

Add `ruby-lsp` as an explicit development dependency. Since `ruby-lsp` has `rbs` as a dependency, this ensures that `rbs` remains available in the development environment.

## Changes

- Add `gem "ruby-lsp"` to the development group in Gemfile
- This is a minimal, targeted fix that addresses the immediate issue

## Benefits

- Prevents unexpected removal of `rbs` gem during bundle operations
- Provides additional LSP functionality for Ruby development
- Low-risk change with clear dependency relationship

:robot: Generated with [Claude Code](https://claude.ai/code)