### PR TITLE
Add comprehensive tests for NumberFormatter custom patterns

### DIFF
--- a/lib/foxtail/cldr/number_pattern_parser.rb
+++ b/lib/foxtail/cldr/number_pattern_parser.rb
@@ -210,7 +210,21 @@ module Foxtail
           i += 1
         end
 
+        # Validate the parsed tokens
+        validate_tokens(tokens, pattern)
+
         tokens
+      end
+
+      # Validate parsed tokens for logical consistency
+      private def validate_tokens(tokens, original_pattern)
+        has_percent = tokens.any?(PercentToken)
+        has_permille = tokens.any?(PerMilleToken)
+
+        # Error on conflicting multiplier symbols
+        return unless has_percent && has_permille
+
+        raise ArgumentError, "Pattern cannot contain both percent (%) and permille (‰) symbols: #{original_pattern}"
       end
 
       private def match_quoted_literal(pattern, start_pos)

--- a/lib/foxtail/functions/number_formatter.rb
+++ b/lib/foxtail/functions/number_formatter.rb
@@ -132,6 +132,19 @@ module Foxtail
           format_value = decimal_value
         end
 
+        # Apply pattern-based multipliers only for custom patterns
+        # (Built-in style patterns already handle multipliers in apply_style_transformations)
+        if options[:pattern]
+          has_percent = pattern_tokens.any?(Foxtail::CLDR::NumberPatternParser::PercentToken)
+          has_permille = pattern_tokens.any?(Foxtail::CLDR::NumberPatternParser::PerMilleToken)
+
+          if has_permille
+            format_value *= 1000
+          elsif has_percent
+            format_value *= 100
+          end
+        end
+
         # Build formatted string from tokens
         build_formatted_string(format_value, pattern_tokens, number_formats, options)
       end

--- a/spec/foxtail/cldr/number_pattern_parser_spec.rb
+++ b/spec/foxtail/cldr/number_pattern_parser_spec.rb
@@ -456,5 +456,25 @@ RSpec.describe Foxtail::CLDR::NumberPatternParser do
         expect(token.literal_text).to eq("Don't worry")
       end
     end
+
+    describe "pattern validation" do
+      it "raises error for patterns with conflicting percent and permille symbols" do
+        expect {
+          parser.parse("#0.0%‰")
+        }.to raise_error(ArgumentError, /Pattern cannot contain both percent \(.*?\) and permille \(.*?\)/)
+      end
+
+      it "allows patterns with only percent symbol" do
+        expect { parser.parse("#0.0%") }.not_to raise_error
+      end
+
+      it "allows patterns with only permille symbol" do
+        expect { parser.parse("#0.0‰") }.not_to raise_error
+      end
+
+      it "allows patterns with neither percent nor permille symbol" do
+        expect { parser.parse("#,##0.00") }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Add comprehensive test suite for NumberFormatter custom pattern support (Issue #3 was already implemented, but lacked tests)
- Fix multiple bugs discovered during test implementation
- Improve pattern validation at parser level

## Changes

### :white_check_mark: Test Coverage Improvements
- Added 7 comprehensive test cases for custom pattern functionality:
  - Quirky decimal patterns with unusual grouping (`###,###,##0.000`)
  - Currency symbol placement variations (`#,##0.00¤`)
  - Multiple literal text elements (`'Score:' #0 'points'`)
  - Scientific notation with zero-padding (`000.0E000`)
  - Permille patterns with literal suffixes (`#0.00‰ 'rate'`)
  - Accounting-style negative patterns (`#0.00;[#0.00]`)
  - Pattern precedence over style options
- Added pattern validation tests for conflicting symbols

### :bug: Bug Fixes
- **Permille multiplication**: Fixed custom patterns with ‰ symbols not applying required 1000x multiplier
- **Double multiplication**: Fixed style-based percentages being multiplied twice (0.75 → 7500% instead of 75%)
- **Pattern validation**: Added parser-level validation to reject patterns with conflicting % and ‰ symbols

### :wrench: Code Quality
- Improved separation of concerns (parser handles validation, formatter handles processing)
- Added descriptive error messages for invalid patterns
- Fixed all RuboCop violations

## Test Results

All 398 tests pass ✅
- Line Coverage: 86.54%
- Branch Coverage: 64.27%

## Related Issues

- Closes #3 (custom pattern support was already implemented, now has comprehensive tests)
- References #23 (future refactoring to centralize value transformations)

## Test Plan

```ruby
# Custom patterns now thoroughly tested
formatter.call(1234.567, pattern: "###,###,##0.000", locale: locale("en"))
# => "1,234.567"

formatter.call(0.789, pattern: "#0.00‰ 'rate'", locale: locale("en"))  
# => "789.00‰ rate" (fixed: was "0.78‰ rate")

# Error on invalid patterns
formatter.call(0.123, pattern: "#0.0%‰", locale: locale("en"))
# => ArgumentError: Pattern cannot contain both percent (%) and permille (‰) symbols
```