### PR TITLE
Improve Zeitwerk autoloading for CLDR extractors

### DIFF
--- a/lib/foxtail/cldr/extractors.rb
+++ b/lib/foxtail/cldr/extractors.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Foxtail
+  module CLDR
+    # CLDR data extractors
+    #
+    # This module contains extractors for converting CLDR XML data into YAML format
+    # for use in the Foxtail localization system.
+    module Extractors
+    end
+  end
+end

--- a/lib/foxtail/cldr/extractors/date_time_formats_extractor.rb
+++ b/lib/foxtail/cldr/extractors/date_time_formats_extractor.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "base_extractor"
-
 module Foxtail
   module CLDR
     module Extractors

--- a/lib/foxtail/cldr/extractors/locale_alias_extractor.rb
+++ b/lib/foxtail/cldr/extractors/locale_alias_extractor.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "base_extractor"
-
 module Foxtail
   module CLDR
     module Extractors

--- a/lib/foxtail/cldr/extractors/number_formats_extractor.rb
+++ b/lib/foxtail/cldr/extractors/number_formats_extractor.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "base_extractor"
-
 module Foxtail
   module CLDR
     module Extractors

--- a/lib/foxtail/cldr/extractors/plural_rules_extractor.rb
+++ b/lib/foxtail/cldr/extractors/plural_rules_extractor.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "base_extractor"
-
 module Foxtail
   module CLDR
     module Extractors

--- a/lib/tasks/cldr.rake
+++ b/lib/tasks/cldr.rake
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 require "fileutils"
+require "foxtail"
 require "rake/clean"
 require "shellwords"
-require_relative "../foxtail/cldr/extractors/date_time_formats_extractor"
-require_relative "../foxtail/cldr/extractors/locale_alias_extractor"
-require_relative "../foxtail/cldr/extractors/number_formats_extractor"
-require_relative "../foxtail/cldr/extractors/plural_rules_extractor"
 
 # CLDR version configuration
 CLDR_VERSION = "46"

--- a/spec/foxtail/cldr/extractors/date_time_formats_extractor_spec.rb
+++ b/spec/foxtail/cldr/extractors/date_time_formats_extractor_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "tmpdir"
-require_relative "../../../../lib/foxtail/cldr/extractors/date_time_formats_extractor"
 
 RSpec.describe Foxtail::CLDR::Extractors::DateTimeFormatsExtractor do
   let(:fixture_source_dir) { File.join(__dir__, "..", "..", "..", "fixtures", "cldr") }


### PR DESCRIPTION
## Summary
- Remove explicit require statements and improve Zeitwerk autoloading
- Add missing `extractors.rb` file to define the `Foxtail::CLDR::Extractors` namespace
- Simplify require statements throughout the codebase

## Changes
- **New File**: Added `lib/foxtail/cldr/extractors.rb` to define the Extractors namespace
- **Rake Tasks**: Replace individual `require_relative` with single `require "foxtail"`
- **Extractor Classes**: Remove `require_relative "base_extractor"` statements
- **Test Files**: Remove unnecessary `require_relative` statements
- **Code Style**: Fix require order and documentation placement

## Benefits
- **Simplified Usage**: Only `require "foxtail"` needed to access all extractors
- **Zeitwerk Compliant**: Proper autoloading without explicit requires
- **Cleaner Code**: Reduced boilerplate require statements
- **Maintainable**: Easier to add new extractors without managing requires

## Before & After
**Before:**
```ruby
require_relative "../foxtail/cldr/extractors/date_time_formats_extractor"
require_relative "../foxtail/cldr/extractors/locale_alias_extractor"
require_relative "../foxtail/cldr/extractors/number_formats_extractor"
require_relative "../foxtail/cldr/extractors/plural_rules_extractor"
```

**After:**
```ruby
require "foxtail"
# All extractors automatically available via Zeitwerk
```

## Test Results
- 456 tests passing
- 88.21% line coverage  
- All RuboCop violations resolved

🤖 Generated with [Claude Code](https://claude.ai/code)