### PR TITLE
:sparkles: Integrate dry-logger and standardize log output

### DIFF
--- a/foxtail.gemspec
+++ b/foxtail.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
   # Dependencies
   spec.add_dependency "bigdecimal", "~> 3.0"
   spec.add_dependency "dry-inflector", "~> 1.0"
+  spec.add_dependency "dry-logger", "~> 1.0"
   spec.add_dependency "locale", "~> 2.1"
   spec.add_dependency "zeitwerk", "~> 2.6"
 end

--- a/lib/foxtail/cldr.rb
+++ b/lib/foxtail/cldr.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
+require "dry/logger"
+
 module Foxtail
   # CLDR (Common Locale Data Repository) integration
   # Provides ICU-compliant plural rules and datetime formatting data
   module CLDR
+    # Logger instance for CLDR-related operations
+    def self.logger
+      @logger ||= Dry.Logger(:cldr)
+    end
   end
 end

--- a/lib/foxtail/cldr/extractors/base_extractor.rb
+++ b/lib/foxtail/cldr/extractors/base_extractor.rb
@@ -27,14 +27,14 @@ module Foxtail
           validate_source_directory
 
           locale_files = Dir.glob(File.join(source_dir, "common", "main", "*.xml"))
-          log "Extracting #{data_type_name} from #{locale_files.size} locales..."
+          CLDR.logger.info "Extracting #{data_type_name} from #{locale_files.size} locales..."
 
           locale_files.each do |xml_file|
             locale_id = File.basename(xml_file, ".xml")
             extract_locale(locale_id)
           end
 
-          log "#{data_type_name} extraction complete"
+          CLDR.logger.info "#{data_type_name.capitalize} extraction complete (#{locale_files.size} locales)"
         end
 
         # Template method for extracting a specific locale
@@ -88,7 +88,7 @@ module Foxtail
           return if @parent_locales
 
           @parent_locales = @inheritance.load_parent_locales(source_dir)
-          log "Loaded #{@parent_locales.size} parent locale mappings" unless @parent_locales.empty?
+          CLDR.logger.debug "Loaded #{@parent_locales.size} parent locale mappings" unless @parent_locales.empty?
         end
 
         private def parent_locales
@@ -103,7 +103,7 @@ module Foxtail
             doc = REXML::Document.new(File.read(xml_path))
             extract_data_from_xml(doc)
           rescue => e
-            log "Warning: Could not load data for locale #{locale_id}: #{e.message}"
+            CLDR.logger.warn "Could not load data for locale #{locale_id}: #{e.message}"
             nil
           end
         end
@@ -195,11 +195,6 @@ module Foxtail
         # @param data [Object] The extracted data
         private def write_data(locale_id, data)
           raise NotImplementedError, "Subclasses must implement write_data"
-        end
-
-        # Progress logging method for testing support
-        private def log(message)
-          puts message
         end
       end
     end

--- a/lib/foxtail/cldr/extractors/locale_alias_extractor.rb
+++ b/lib/foxtail/cldr/extractors/locale_alias_extractor.rb
@@ -12,14 +12,14 @@ module Foxtail
         end
 
         private def extract_locale_aliases
-          log "Extracting locale aliases..."
+          CLDR.logger.info "Extracting #{data_type_name}..."
 
           aliases = load_locale_aliases_from_supplemental
 
           return if aliases.empty?
 
           write_alias_data(aliases)
-          log "Locale alias extraction complete - extracted #{aliases.size} aliases"
+          CLDR.logger.info "#{data_type_name.capitalize} extraction complete (#{aliases.size} aliases)"
         end
 
         private def load_locale_aliases_from_supplemental
@@ -80,9 +80,12 @@ module Foxtail
               aliases[type] = replacement
             end
           rescue => e
-            log "Warning: Could not load traditional aliases: #{e.message}"
+            CLDR.logger.warn "Could not load traditional aliases: #{e.message}"
           end
 
+          unless aliases.empty?
+            CLDR.logger.debug "Loaded #{aliases.size} traditional aliases from supplementalMetadata.xml"
+          end
           aliases
         end
 
@@ -111,10 +114,12 @@ module Foxtail
               end
             end
           rescue => e
-            log "Warning: Could not load likely subtags: #{e.message}"
+            CLDR.logger.warn "Could not load likely subtags: #{e.message}"
           end
 
-          log "Loaded #{aliases.size} likely subtag aliases" unless aliases.empty?
+          unless aliases.empty?
+            CLDR.logger.debug "Loaded #{aliases.size} likely subtag aliases from likelySubtags.xml"
+          end
           aliases
         end
 
@@ -128,7 +133,7 @@ module Foxtail
           }
 
           File.write(file_path, yaml_data.to_yaml)
-          log "Wrote locale aliases to #{file_path}"
+          CLDR.logger.debug "Wrote #{data_type_name} to #{file_path}"
         end
 
         private def validate_source_directory

--- a/lib/foxtail/cldr/extractors/number_formats_extractor.rb
+++ b/lib/foxtail/cldr/extractors/number_formats_extractor.rb
@@ -156,7 +156,7 @@ module Foxtail
               fractions[currency] = fraction_data unless fraction_data.empty?
             end
           rescue => e
-            log "Warning: Could not extract currency fractions: #{e.message}"
+            CLDR.logger.warn "Could not extract currency fractions: #{e.message}"
           end
 
           fractions
@@ -234,7 +234,7 @@ module Foxtail
               currencies[code] = currency_data unless currency_data.empty?
             end
           rescue => e
-            log "Warning: Could not extract root currencies: #{e.message}"
+            CLDR.logger.warn "Could not extract root currencies: #{e.message}"
           end
 
           currencies

--- a/lib/foxtail/cldr/extractors/plural_rules_extractor.rb
+++ b/lib/foxtail/cldr/extractors/plural_rules_extractor.rb
@@ -11,11 +11,11 @@ module Foxtail
 
           supplemental_path = File.join(source_dir, "common", "supplemental", "plurals.xml")
           unless File.exist?(supplemental_path)
-            log "Warning: Plural rules file not found: #{supplemental_path}"
+            CLDR.logger.warn "Plural rules file not found: #{supplemental_path}"
             return
           end
 
-          log "Extracting #{data_type_name} from supplemental data..."
+          CLDR.logger.info "Extracting #{data_type_name} from supplemental data..."
 
           doc = REXML::Document.new(File.read(supplemental_path))
           locale_rules_map = extract_all_locales_from_supplemental(doc)
@@ -26,7 +26,7 @@ module Foxtail
             write_data(locale_id, rules_data)
           end
 
-          log "#{data_type_name} extraction complete (#{locale_rules_map.size} locales)"
+          CLDR.logger.info "#{data_type_name.capitalize} extraction complete (#{locale_rules_map.size} locales)"
         end
 
         # Override extract_locale since plural rules come from supplemental data
@@ -35,7 +35,7 @@ module Foxtail
 
           supplemental_path = File.join(source_dir, "common", "supplemental", "plurals.xml")
           unless File.exist?(supplemental_path)
-            log "Warning: Plural rules file not found: #{supplemental_path}"
+            CLDR.logger.warn "Plural rules file not found: #{supplemental_path}"
             return
           end
 
@@ -48,7 +48,7 @@ module Foxtail
               write_data(locale_id, rules_data)
             end
           else
-            log "Warning: No plural rules found for locale: #{locale_id}"
+            CLDR.logger.warn "No plural rules found for locale: #{locale_id}"
           end
         end
         private def data_type_name

--- a/lib/foxtail/cldr/inheritance.rb
+++ b/lib/foxtail/cldr/inheritance.rb
@@ -70,7 +70,7 @@ module Foxtail
             end
           end
         rescue => e
-          log "Warning: Could not load parent locales: #{e.message}"
+          CLDR.logger.warn "Could not load parent locales: #{e.message}"
         end
 
         parents
@@ -87,10 +87,10 @@ module Foxtail
         begin
           yaml_data = YAML.load_file(aliases_path)
           aliases = yaml_data["locale_aliases"] || {}
-          log "Loaded #{aliases.size} locale aliases from #{aliases_path}"
+          CLDR.logger.info "Loaded #{aliases.size} locale aliases from #{aliases_path}"
           aliases
         rescue => e
-          log "Warning: Could not load locale aliases from #{aliases_path}: #{e.message}"
+          CLDR.logger.warn "Could not load locale aliases from #{aliases_path}: #{e.message}"
           {}
         end
       end
@@ -105,24 +105,24 @@ module Foxtail
         # First try to resolve the entire locale_id as an alias
         if aliases[locale_id]
           result = aliases[locale_id]
-          log "Full locale alias resolution: #{locale_id} -> #{result}"
+          CLDR.logger.debug "Full locale alias resolution: #{locale_id} -> #{result}"
           return result
         end
 
         # Handle complex locale identifiers by resolving each component
         if locale_id.include?("_")
           parts = locale_id.split("_")
-          log "Resolving compound locale #{locale_id}: parts = #{parts}"
+          CLDR.logger.debug "Resolving compound locale #{locale_id}: parts = #{parts}"
           resolved_parts = parts.map {|part|
             resolved = aliases[part] || part
-            log "  #{part} -> #{resolved}"
+            CLDR.logger.debug "  #{part} -> #{resolved}"
             resolved
           }
           result = resolved_parts.join("_")
-          log "Final resolved compound locale: #{locale_id} -> #{result}"
+          CLDR.logger.debug "Final resolved compound locale: #{locale_id} -> #{result}"
         else
           result = aliases[locale_id] || locale_id
-          log "Simple locale resolution: #{locale_id} -> #{result} (found: #{aliases.key?(locale_id)})"
+          CLDR.logger.debug "Simple locale resolution: #{locale_id} -> #{result} (found: #{aliases.key?(locale_id)})"
         end
         result
       end
@@ -225,14 +225,9 @@ module Foxtail
           doc = REXML::Document.new(File.read(xml_path))
           extractor.__send__(:extract_data_from_xml, doc)
         rescue => e
-          log "Warning: Could not load data for locale #{locale}: #{e.message}"
+          CLDR.logger.warn "Could not load data for locale #{locale}: #{e.message}"
           nil
         end
-      end
-
-      # Progress logging method for testing support
-      def log(message)
-        puts message
       end
     end
   end

--- a/lib/foxtail/cldr/resolver.rb
+++ b/lib/foxtail/cldr/resolver.rb
@@ -76,7 +76,7 @@ module Foxtail
 
         parent_locales = load_parent_locales_if_needed
         @inheritance_chain = @inheritance.resolve_inheritance_chain_with_parents(@locale_id, parent_locales)
-        log "Inheritance chain for #{@original_locale_id} -> #{@locale_id}: #{@inheritance_chain}"
+        CLDR.logger.debug "Inheritance chain for #{@original_locale_id} -> #{@locale_id}: #{@inheritance_chain}"
         @inheritance_chain
       end
 
@@ -104,19 +104,19 @@ module Foxtail
         return @loaded_locales[cache_key] if @loaded_locales.key?(cache_key)
 
         file_path = File.join(@data_dir, locale_id, "#{data_type}.yml")
-        log "Attempting to load: #{file_path}"
+        CLDR.logger.debug "Attempting to load: #{file_path}"
 
         data = if File.exist?(file_path)
                  begin
                    loaded_data = YAML.load_file(file_path)
-                   log "Successfully loaded #{file_path} for locale #{locale_id}"
+                   CLDR.logger.info "Successfully loaded #{file_path} for locale #{locale_id}"
                    loaded_data
                  rescue => e
-                   log "Warning: Could not load #{file_path}: #{e.message}"
+                   CLDR.logger.warn "Could not load #{file_path}: #{e.message}"
                    nil
                  end
                else
-                 log "File does not exist: #{file_path}"
+                 CLDR.logger.debug "File does not exist: #{file_path}"
                  nil
                end
 
@@ -142,24 +142,20 @@ module Foxtail
         !value.nil? && !(value.is_a?(String) && value.empty?)
       end
 
-      private def log(message)
-        puts message
-      end
-
       # Resolve locale identifier to canonical form using CLDR aliases
       # @param locale_id [String] Original locale identifier (may be an alias)
       # @return [String] Canonical locale identifier
       private def resolve_canonical_locale(locale_id)
         aliases = load_locale_aliases_if_needed
-        log "Loaded #{aliases.size} locale aliases: #{aliases.keys.first(5)}"
+        CLDR.logger.info "Loaded #{aliases.size} locale aliases: #{aliases.keys.first(5)}"
         return locale_id if aliases.empty?
 
         canonical = @inheritance.resolve_locale_alias(locale_id, aliases)
 
         if canonical == locale_id
-          log "No alias found for: #{locale_id}"
+          CLDR.logger.debug "No alias found for: #{locale_id}"
         else
-          log "Resolved locale alias: #{locale_id} -> #{canonical}"
+          CLDR.logger.info "Resolved locale alias: #{locale_id} -> #{canonical}"
         end
 
         canonical

--- a/lib/tasks/cldr.rake
+++ b/lib/tasks/cldr.rake
@@ -35,21 +35,21 @@ namespace :cldr do
   desc "Download CLDR core data to tmp directory"
   task :download do
     if Dir.exist?(CLDR_EXTRACT_DIR)
-      puts "CLDR core data already exists at #{CLDR_EXTRACT_DIR}"
-      puts "Remove the directory to re-download."
+      Foxtail::CLDR.logger.info "CLDR core data already exists at #{CLDR_EXTRACT_DIR}"
+      Foxtail::CLDR.logger.info "Remove the directory to re-download."
       next
     end
 
     # Create tmp directory if it doesn't exist
     FileUtils.mkdir_p(TMP_DIR)
 
-    puts "Downloading CLDR core data..."
+    Foxtail::CLDR.logger.info "Downloading CLDR core data..."
 
     # Download with curl using shelljoin for safety
     curl_cmd = ["curl", "-L", "-o", CLDR_ZIP_PATH, CLDR_CORE_URL]
     sh Shellwords.join(curl_cmd)
 
-    puts "Extracting CLDR core data..."
+    Foxtail::CLDR.logger.info "Extracting CLDR core data..."
 
     # Create extraction directory
     FileUtils.mkdir_p(CLDR_EXTRACT_DIR)
@@ -58,7 +58,7 @@ namespace :cldr do
     unzip_cmd = ["unzip", "-q", "-o", CLDR_ZIP_PATH, "-d", CLDR_EXTRACT_DIR]
     sh Shellwords.join(unzip_cmd)
 
-    puts "CLDR core data extracted to #{CLDR_EXTRACT_DIR}"
+    Foxtail::CLDR.logger.info "CLDR core data extracted to #{CLDR_EXTRACT_DIR}"
   end
 
   desc "Extract all CLDR data (uses rake task dependencies)"
@@ -69,7 +69,7 @@ namespace :cldr do
     task locale_aliases: :download do
       # Clean up existing locale_aliases file
       if File.exist?(LOCALE_ALIASES_FILE)
-        puts "Cleaning up existing locale_aliases file..."
+        Foxtail::CLDR.logger.info "Cleaning up existing locale_aliases file..."
         rm LOCALE_ALIASES_FILE, verbose: false
       end
 
@@ -83,8 +83,8 @@ namespace :cldr do
     desc "Extract CLDR data for a specific locale"
     task :locale, [:locale_id] => :download do |_task, args|
       unless args[:locale_id]
-        puts "Usage: rake cldr:extract:locale[locale_id]"
-        puts "Example: rake cldr:extract:locale[en]"
+        Foxtail::CLDR.logger.error "Usage: rake cldr:extract:locale[locale_id]"
+        Foxtail::CLDR.logger.error "Example: rake cldr:extract:locale[en]"
         exit 1
       end
 
@@ -111,7 +111,7 @@ namespace :cldr do
     task plural_rules: :download do
       # Clean up existing plural_rules files
       if PLURAL_RULES_FILES.any?
-        puts "Cleaning up #{PLURAL_RULES_FILES.size} existing plural_rules files..."
+        Foxtail::CLDR.logger.info "Cleaning up #{PLURAL_RULES_FILES.size} existing plural_rules files..."
         rm PLURAL_RULES_FILES, verbose: false
       end
 
@@ -127,7 +127,7 @@ namespace :cldr do
     task number_formats: :download do
       # Clean up existing number_formats files
       if NUMBER_FORMATS_FILES.any?
-        puts "Cleaning up #{NUMBER_FORMATS_FILES.size} existing number_formats files..."
+        Foxtail::CLDR.logger.info "Cleaning up #{NUMBER_FORMATS_FILES.size} existing number_formats files..."
         rm NUMBER_FORMATS_FILES, verbose: false
       end
 
@@ -143,7 +143,7 @@ namespace :cldr do
     task datetime_formats: :download do
       # Clean up existing datetime_formats files
       if DATETIME_FORMATS_FILES.any?
-        puts "Cleaning up #{DATETIME_FORMATS_FILES.size} existing datetime_formats files..."
+        Foxtail::CLDR.logger.info "Cleaning up #{DATETIME_FORMATS_FILES.size} existing datetime_formats files..."
         rm DATETIME_FORMATS_FILES, verbose: false
       end
 

--- a/spec/foxtail/cldr/extractors/base_extractor_spec.rb
+++ b/spec/foxtail/cldr/extractors/base_extractor_spec.rb
@@ -29,8 +29,6 @@ RSpec.describe Foxtail::CLDR::Extractors::BaseExtractor do
   let(:extractor) { test_extractor_class.new(source_dir: test_source_dir, output_dir: test_output_dir) }
 
   before do
-    # Stub log method to prevent output during tests
-    allow(extractor).to receive(:log)
     # Create test directory structure
     FileUtils.mkdir_p(File.join(test_source_dir, "common", "main"))
     FileUtils.mkdir_p(test_output_dir)
@@ -67,10 +65,9 @@ RSpec.describe Foxtail::CLDR::Extractors::BaseExtractor do
     end
 
     it "processes all locale files" do
-      allow(extractor).to receive(:log)
       extractor.extract_all
-      expect(extractor).to have_received(:log).with("Extracting test data from 3 locales...")
-      expect(extractor).to have_received(:log).with("test data extraction complete")
+      expect(Foxtail::CLDR.logger).to have_received(:info).with("Extracting test data from 3 locales...")
+      expect(Foxtail::CLDR.logger).to have_received(:info).with("Test data extraction complete (3 locales)")
     end
 
     it "creates output files for each locale" do
@@ -142,7 +139,6 @@ RSpec.describe Foxtail::CLDR::Extractors::BaseExtractor do
 
       it "does not create output file when data? returns false" do
         empty_extractor = empty_extractor_class.new(source_dir: test_source_dir, output_dir: test_output_dir)
-        allow(empty_extractor).to receive(:log) # Stub log for empty_extractor too
         File.write(File.join(test_source_dir, "common", "main", "en.xml"), test_xml_content)
 
         empty_extractor.extract_locale("en")

--- a/spec/foxtail/cldr/extractors/date_time_formats_extractor_spec.rb
+++ b/spec/foxtail/cldr/extractors/date_time_formats_extractor_spec.rb
@@ -7,11 +7,6 @@ RSpec.describe Foxtail::CLDR::Extractors::DateTimeFormatsExtractor do
   let(:temp_output_dir) { Dir.mktmpdir }
   let(:extractor) { Foxtail::CLDR::Extractors::DateTimeFormatsExtractor.new(source_dir: fixture_source_dir, output_dir: temp_output_dir) }
 
-  before do
-    # Stub log method to prevent output during tests
-    allow(extractor).to receive(:log)
-  end
-
   after do
     FileUtils.rm_rf(temp_output_dir)
   end

--- a/spec/foxtail/cldr/extractors/locale_alias_extractor_spec.rb
+++ b/spec/foxtail/cldr/extractors/locale_alias_extractor_spec.rb
@@ -7,11 +7,6 @@ RSpec.describe Foxtail::CLDR::Extractors::LocaleAliasExtractor do
   let(:temp_output_dir) { Dir.mktmpdir }
   let(:extractor) { Foxtail::CLDR::Extractors::LocaleAliasExtractor.new(source_dir: fixture_source_dir, output_dir: temp_output_dir) }
 
-  before do
-    # Stub log method to prevent output during tests
-    allow(extractor).to receive(:log)
-  end
-
   after do
     FileUtils.rm_rf(temp_output_dir)
   end

--- a/spec/foxtail/cldr/extractors/number_formats_extractor_spec.rb
+++ b/spec/foxtail/cldr/extractors/number_formats_extractor_spec.rb
@@ -7,11 +7,6 @@ RSpec.describe Foxtail::CLDR::Extractors::NumberFormatsExtractor do
   let(:temp_output_dir) { Dir.mktmpdir }
   let(:extractor) { Foxtail::CLDR::Extractors::NumberFormatsExtractor.new(source_dir: fixture_source_dir, output_dir: temp_output_dir) }
 
-  before do
-    # Stub log method to prevent output during tests
-    allow(extractor).to receive(:log)
-  end
-
   after do
     FileUtils.rm_rf(temp_output_dir)
   end

--- a/spec/foxtail/cldr/extractors/plural_rules_extractor_spec.rb
+++ b/spec/foxtail/cldr/extractors/plural_rules_extractor_spec.rb
@@ -7,11 +7,6 @@ RSpec.describe Foxtail::CLDR::Extractors::PluralRulesExtractor do
   let(:temp_output_dir) { Dir.mktmpdir }
   let(:extractor) { Foxtail::CLDR::Extractors::PluralRulesExtractor.new(source_dir: fixture_source_dir, output_dir: temp_output_dir) }
 
-  before do
-    # Stub log method to prevent output during tests
-    allow(extractor).to receive(:log)
-  end
-
   after do
     FileUtils.rm_rf(temp_output_dir)
   end

--- a/spec/foxtail/cldr/inheritance_spec.rb
+++ b/spec/foxtail/cldr/inheritance_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe Foxtail::CLDR::Inheritance do
 
     before do
       FileUtils.mkdir_p(supplemental_dir)
-      allow(inheritance).to receive(:log)
     end
 
     after { FileUtils.rm_rf(temp_dir) }
@@ -172,7 +171,6 @@ RSpec.describe Foxtail::CLDR::Inheritance do
 
     before do
       FileUtils.mkdir_p(main_dir)
-      allow(inheritance).to receive(:log)
     end
 
     after { FileUtils.rm_rf(temp_dir) }

--- a/spec/foxtail/cldr/resolver_spec.rb
+++ b/spec/foxtail/cldr/resolver_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe Foxtail::CLDR::Resolver do
   let(:data_dir) { temp_dir }
   let(:inheritance) { Foxtail::CLDR::Inheritance.instance }
 
-  before do
-    allow(inheritance).to receive(:log)
-  end
-
   after { FileUtils.rm_rf(temp_dir) }
 
   describe "#resolve" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require "simplecov"
 
 require "foxtail"
 require_relative "support/locale_context"
+require_relative "support/logging_context"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -14,11 +15,5 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
-  end
-
-  # Suppress log output during tests
-  config.before do
-    allow(Foxtail::CLDR::Inheritance.instance).to receive(:log)
-    allow_any_instance_of(Foxtail::CLDR::Resolver).to receive(:log)
   end
 end

--- a/spec/support/logging_context.rb
+++ b/spec/support/logging_context.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Shared context for suppressing log output during tests
+RSpec.shared_context "with logging suppressed" do
+  let(:suppressed_logger) { instance_double(Dry::Logger::Dispatcher, info: nil, warn: nil, debug: nil, error: nil) }
+
+  before do
+    allow(Foxtail::CLDR).to receive(:logger).and_return(suppressed_logger)
+  end
+end
+
+# Suppress logging in all specs
+RSpec.configure do |config|
+  config.include_context "with logging suppressed"
+end


### PR DESCRIPTION
## Summary
- Integrate dry-logger for unified logging across the codebase
- Standardize log output format for all CLDR extractors
- Replace manual log methods with structured logging

## Changes
- **Dependency**: Added dry-logger (~> 1.0) to gemspec
- **Logger Setup**: Implemented CLDR.logger using Dry.Logger(:cldr)
- **Code Cleanup**: Replaced all private log methods with appropriate CLDR.logger calls
- **Log Levels**: Used info/warn/debug levels appropriately based on message importance
- **Extractor Standardization**: Unified log message format:
  - Start: "Extracting {type} from X locales..." or "Extracting {type}..."
  - Complete: "{Type} extraction complete (X items)"
  - Details moved to debug level for cleaner output
- **Rake Tasks**: Updated to use CLDR.logger instead of puts
- **Test Infrastructure**: Added shared logging context with instance_double for log suppression

## Test Plan
- [x] All existing tests pass (456 examples, 0 failures)
- [x] RuboCop passes with no violations
- [x] Manual verification of log output formatting
- [x] Rake tasks produce consistent log output

Generated with Claude Code (https://claude.ai/code)