### PR TITLE
Optimize CLDR extraction system with inflector integration

### DIFF
--- a/data/cldr/parent_locales.yml
+++ b/data/cldr/parent_locales.yml
@@ -1,4 +1,6 @@
 ---
+generated_at: '2025-09-13T13:49:44Z'
+cldr_version: '46'
 parent_locales:
   az_Arab: root
   az_Cyrl: root

--- a/lib/foxtail/cldr.rb
+++ b/lib/foxtail/cldr.rb
@@ -10,5 +10,10 @@ module Foxtail
     def self.logger
       @logger ||= Dry.Logger(:cldr)
     end
+
+    # Set logger instance for CLDR-related operations
+    def self.logger=(new_logger)
+      @logger = new_logger
+    end
   end
 end

--- a/lib/foxtail/cldr/extractor/date_time_formats.rb
+++ b/lib/foxtail/cldr/extractor/date_time_formats.rb
@@ -13,9 +13,6 @@ module Foxtail
 
         QUARTER_DAY_PERIOD_WIDTHS = %w[wide abbreviated].freeze
         private_constant :QUARTER_DAY_PERIOD_WIDTHS
-        private def data_type_name
-          "datetime formats"
-        end
 
         private def extract_data_from_xml(xml_doc)
           # Extract calendar data from gregorian calendar

--- a/lib/foxtail/cldr/extractor/locale_aliases.rb
+++ b/lib/foxtail/cldr/extractor/locale_aliases.rb
@@ -11,15 +11,20 @@ module Foxtail
           extract_locale_aliases
         end
 
+        # Single file extractor - no cleanup needed
+        private def cleanup_obsolete_files
+          # No-op: locale aliases generates a single file, no cleanup needed
+        end
+
         private def extract_locale_aliases
-          CLDR.logger.info "Extracting #{data_type_name}..."
+          CLDR.logger.info "Extracting LocaleAliases..."
 
           aliases = load_locale_aliases_from_supplemental
 
           return if aliases.empty?
 
           write_alias_data(aliases)
-          CLDR.logger.info "#{data_type_name.capitalize} extraction complete (#{aliases.size} aliases)"
+          CLDR.logger.info "LocaleAliases extraction complete (#{aliases.size} aliases)"
         end
 
         private def load_locale_aliases_from_supplemental
@@ -134,12 +139,11 @@ module Foxtail
 
           # Skip writing if only generated_at differs
           if should_skip_write?(file_path, yaml_data)
-            CLDR.logger.debug "Skipping #{file_path} - only generated_at differs"
             return
           end
 
           File.write(file_path, yaml_data.to_yaml)
-          CLDR.logger.debug "Wrote #{data_type_name} to #{file_path}"
+          CLDR.logger.debug "Wrote LocaleAliases to #{relative_path(file_path)}"
         end
 
         private def validate_source_directory
@@ -151,10 +155,6 @@ module Foxtail
         end
 
         # Template method implementations (not used for supplemental data)
-        private def data_type_name
-          "locale aliases"
-        end
-
         private def extract_data_from_xml(_xml_doc)
           # Not used - we override extract_all instead
           nil

--- a/lib/foxtail/cldr/extractor/number_formats.rb
+++ b/lib/foxtail/cldr/extractor/number_formats.rb
@@ -5,10 +5,6 @@ module Foxtail
     module Extractor
       # Extracts number format data from CLDR XML and writes to YAML files
       class NumberFormats < Base
-        private def data_type_name
-          "number formats"
-        end
-
         private def extract_data_from_xml(xml_doc)
           formats = extract_format_patterns(xml_doc)
 

--- a/lib/foxtail/cldr/extractor/parent_locales.rb
+++ b/lib/foxtail/cldr/extractor/parent_locales.rb
@@ -11,6 +11,8 @@ module Foxtail
         # Extract parent locale mappings for all components
         # @return [Hash] Parent locale mappings
         def extract_all
+          CLDR.logger.info "Extracting ParentLocales..."
+
           parent_locales_data = {
             "generated_at" => Time.now.utc.iso8601,
             "cldr_version" => ENV.fetch("CLDR_VERSION", "46"),
@@ -22,12 +24,11 @@ module Foxtail
 
           # Skip writing if only generated_at differs
           if should_skip_write?(output_path, parent_locales_data)
-            CLDR.logger.debug "Skipping #{output_path} - only generated_at differs"
             return parent_locales_data
           end
 
           File.write(output_path, YAML.dump(parent_locales_data))
-          CLDR.logger.info "Extracted parent locales data to #{output_path}"
+          CLDR.logger.info "ParentLocales extraction complete"
 
           parent_locales_data
         end
@@ -61,6 +62,10 @@ module Foxtail
           end
 
           parents
+        end
+        # Single file extractor - no cleanup needed
+        private def cleanup_obsolete_files
+          # No-op: parent locales generates a single file, no cleanup needed
         end
 
         private def extract_parent_locales_data

--- a/lib/foxtail/cldr/extractor/plural_rules.rb
+++ b/lib/foxtail/cldr/extractor/plural_rules.rb
@@ -15,7 +15,7 @@ module Foxtail
             return
           end
 
-          CLDR.logger.info "Extracting #{data_type_name} from supplemental data..."
+          CLDR.logger.info "Extracting PluralRules from supplemental data..."
 
           doc = REXML::Document.new(File.read(supplemental_path))
           locale_rules_map = extract_all_locales_from_supplemental(doc)
@@ -26,7 +26,7 @@ module Foxtail
             write_data(locale_id, rules_data)
           end
 
-          CLDR.logger.info "#{data_type_name.capitalize} extraction complete (#{locale_rules_map.size} locales)"
+          CLDR.logger.info "PluralRules extraction complete (#{locale_rules_map.size} locales)"
         end
 
         # Override extract_locale since plural rules come from supplemental data
@@ -50,9 +50,6 @@ module Foxtail
           else
             CLDR.logger.warn "No plural rules found for locale: #{locale_id}"
           end
-        end
-        private def data_type_name
-          "plural rules"
         end
 
         # Not used for plural rules - they come from supplemental data

--- a/lib/foxtail/cldr/repository/resolver.rb
+++ b/lib/foxtail/cldr/repository/resolver.rb
@@ -75,20 +75,17 @@ module Foxtail
         private def inheritance_chain
           return @inheritance_chain if @inheritance_chain
 
-          parent_locales = load_parent_locales_if_needed
           @inheritance_chain = @inheritance.resolve_inheritance_chain_with_parents(@locale_id, parent_locales)
           CLDR.logger.debug "Inheritance chain for #{@original_locale_id} -> #{@locale_id}: #{@inheritance_chain}"
           @inheritance_chain
         end
 
-        private def load_parent_locales_if_needed
-          return @parent_locales if @parent_locales
-
-          begin
-            @parent_locales = @inheritance.load_parent_locales(@data_dir)
+        private def parent_locales
+          @parent_locales ||= begin
+            @inheritance.load_parent_locales(@data_dir)
           rescue ArgumentError => e
             CLDR.logger.warn "#{e.message}. Falling back to algorithmic inheritance."
-            @parent_locales = {}
+            {}
           end
         end
 

--- a/lib/tasks/cldr.rake
+++ b/lib/tasks/cldr.rake
@@ -8,7 +8,7 @@ require "shellwords"
 # Task to set debug logging for CLDR operations
 desc "Set debug logging level for CLDR operations"
 task :set_debug_logging do
-  Foxtail::CLDR.logger.level = :debug
+  Foxtail::CLDR.logger = Dry.Logger(:cldr, level: :debug)
 end
 
 # CLDR version configuration
@@ -86,12 +86,6 @@ namespace :cldr do
   namespace :extract do
     desc "Extract CLDR parent locales from downloaded CLDR core data"
     task parent_locales: %i[set_debug_logging download] do
-      # Clean up existing parent_locales file
-      if File.exist?(PARENT_LOCALES_FILE)
-        Foxtail::CLDR.logger.info "Cleaning up existing parent_locales file..."
-        rm PARENT_LOCALES_FILE, verbose: false
-      end
-
       extractor = Foxtail::CLDR::Extractor::ParentLocales.new(
         source_dir: CLDR_EXTRACT_DIR,
         output_dir: DATA_DIR
@@ -102,12 +96,6 @@ namespace :cldr do
 
     desc "Extract CLDR locale aliases from downloaded CLDR core data"
     task locale_aliases: %i[set_debug_logging download] do
-      # Clean up existing locale_aliases file
-      if File.exist?(LOCALE_ALIASES_FILE)
-        Foxtail::CLDR.logger.info "Cleaning up existing locale_aliases file..."
-        rm LOCALE_ALIASES_FILE, verbose: false
-      end
-
       extractor = Foxtail::CLDR::Extractor::LocaleAliases.new(
         source_dir: CLDR_EXTRACT_DIR,
         output_dir: DATA_DIR
@@ -144,12 +132,6 @@ namespace :cldr do
 
     desc "Extract CLDR plural rules from downloaded CLDR core data"
     task plural_rules: %i[set_debug_logging download parent_locales] do
-      # Clean up existing plural_rules files
-      if PLURAL_RULES_FILES.any?
-        Foxtail::CLDR.logger.info "Cleaning up #{PLURAL_RULES_FILES.size} existing plural_rules files..."
-        rm PLURAL_RULES_FILES, verbose: false
-      end
-
       extractor = Foxtail::CLDR::Extractor::PluralRules.new(
         source_dir: CLDR_EXTRACT_DIR,
         output_dir: DATA_DIR
@@ -160,12 +142,6 @@ namespace :cldr do
 
     desc "Extract CLDR number formats from downloaded CLDR core data"
     task number_formats: %i[set_debug_logging download parent_locales] do
-      # Clean up existing number_formats files
-      if NUMBER_FORMATS_FILES.any?
-        Foxtail::CLDR.logger.info "Cleaning up #{NUMBER_FORMATS_FILES.size} existing number_formats files..."
-        rm NUMBER_FORMATS_FILES, verbose: false
-      end
-
       extractor = Foxtail::CLDR::Extractor::NumberFormats.new(
         source_dir: CLDR_EXTRACT_DIR,
         output_dir: DATA_DIR
@@ -176,12 +152,6 @@ namespace :cldr do
 
     desc "Extract CLDR datetime formats from downloaded CLDR core data"
     task datetime_formats: %i[set_debug_logging download parent_locales] do
-      # Clean up existing datetime_formats files
-      if DATETIME_FORMATS_FILES.any?
-        Foxtail::CLDR.logger.info "Cleaning up #{DATETIME_FORMATS_FILES.size} existing datetime_formats files..."
-        rm DATETIME_FORMATS_FILES, verbose: false
-      end
-
       extractor = Foxtail::CLDR::Extractor::DateTimeFormats.new(
         source_dir: CLDR_EXTRACT_DIR,
         output_dir: DATA_DIR

--- a/spec/foxtail/cldr/extractor/locale_aliases_spec.rb
+++ b/spec/foxtail/cldr/extractor/locale_aliases_spec.rb
@@ -81,6 +81,11 @@ RSpec.describe Foxtail::CLDR::Extractor::LocaleAliases do
     end
 
     context "when file exists with same content" do
+      before do
+        # Allow debug logging throughout the test
+        allow(Foxtail::CLDR.logger).to receive(:debug)
+      end
+
       let(:initial_mtime) do
         # Write initial file
         extractor.__send__(:write_alias_data, test_aliases)
@@ -89,14 +94,15 @@ RSpec.describe Foxtail::CLDR::Extractor::LocaleAliases do
       end
 
       it "skips writing when only generated_at would differ" do
-        allow(Foxtail::CLDR.logger).to receive(:debug)
         initial_mtime # Ensure file exists with recorded mtime
 
         extractor.__send__(:write_alias_data, test_aliases)
 
-        # File modification time should not change
+        # File modification time should not change when skipping
         expect(File.mtime(file_path)).to eq(initial_mtime)
-        expect(Foxtail::CLDR.logger).to have_received(:debug).with(/Skipping.*only generated_at differs/)
+
+        # Should have logged exactly once (from initial write in let block)
+        expect(Foxtail::CLDR.logger).to have_received(:debug).once
       end
     end
 


### PR DESCRIPTION
## Summary
• Add Dry::Inflector to Base extractor for consistent naming and file generation
• Replace manual data_type_name methods with automatic class name derivation  
• Implement shared cache and incremental file cleanup for better performance
• Add dynamic logger replacement capability for rake task customization
• Improve logging with relative paths and reduced noise

## Technical Changes
• **Inflector Integration**: DateTimeFormats → datetime_formats.yml automatic conversion
• **Shared Caching**: Class-level extracted_data_cache prevents infinite loops and improves performance
• **Incremental Updates**: Replace "delete all + regenerate" with targeted obsolete file cleanup
• **Method Simplification**: Remove get_* prefixes, consolidate data_type_name into class names
• **Logger Enhancement**: Add logger= setter for dynamic log level changes in rake tasks
• **Path Display**: Show relative paths in logs instead of absolute paths for cleaner output

## Test Updates
• Update all extractor tests for new logging patterns and caching behavior
• Fix test expectations for class name-based logging instead of data_type_name
• Improve test structure with proper before blocks for allow statements

## Performance Benefits
• Shared cache eliminates redundant processing across extractor instances
• Progress reporting optimized from every 10 to every 100 locales
• Incremental file cleanup reduces unnecessary I/O operations
• Consistent file naming reduces manual maintenance overhead

🤖 Generated with [Claude Code](https://claude.ai/code)