### PR TITLE
Fix double multiplication in NumberFormatter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Run tests with specific example**: `bundle exec rspec spec/path/to/file_spec.rb:line_number`
 
 #### Fluent.js Compatibility Testing
-- **Verify all compatibility**: `bin/verify_compatibility` - Comprehensive test (97/98 passing)
-- **Structure fixtures only**: `bin/verify_compatibility --structure` - 62/62 (100%)
-- **Reference fixtures only**: `bin/verify_compatibility --reference` - 35/36 (97.2%)
-- **Summary only**: `bin/verify_compatibility --summary` - Quick overall result
+- **Compatibility report**: `rake compatibility:report` - Comprehensive compatibility report (97/98 passing)
 - **RSpec directly**: `bundle exec rspec spec/fluent_js_compatibility_spec.rb`
 
 ### Linting & Code Style


### PR DESCRIPTION
## Summary
- Fixed double multiplication bug in NumberFormatter where percent values were being multiplied by 100 twice
- Centralized all multiplication logic in `format_with_pattern` method
- Updated CLAUDE.md with correct compatibility testing commands

## Changes
- Removed percent multiplication from `apply_style_transformations` method
- Consolidated all multipliers (percent, permille, style-based) in `format_with_pattern` 
- Updated documentation to reflect current rake task usage

## Test Results
- All 490 tests pass
- Fluent.js compatibility remains at 97/98 (99.0%)
- No RuboCop violations

Fixes #23

🤖 Generated with [Claude Code](https://claude.ai/code)