### PR TITLE
:sparkles: Add comprehensive unit style support for Node.js compatibility

### DIFF
--- a/compat/node_intl/tester.rb
+++ b/compat/node_intl/tester.rb
@@ -104,12 +104,30 @@ class NodeIntlTester
                                      "USD"
                                    end
             when "unit"
-              options[:unit] = "kilometer"
+              # Test multiple basic units and compound units
+              case test_values.index(value) % 6
+              when 0
+                options[:unit] = "kilometer"
+              when 1
+                options[:unit] = "meter"
+              when 2
+                options[:unit] = "gram"
+              when 3
+                options[:unit] = "liter"
+              when 4
+                options[:unit] = "celsius"
+              when 5
+                options[:unit] = "kilometer-per-hour"
+              end
               options[:unitDisplay] = "short"
             end
 
             # Generate unique ID
             id_parts = [style, notation, locale.tr("-", "_"), value.to_s.gsub("-", "neg").tr(".", "_")]
+            # Add unit name to ID for unit style
+            if style == "unit" && options[:unit]
+              id_parts << options[:unit].tr("-", "_")
+            end
             id = id_parts.join("_")
 
             @test_cases << {

--- a/data/cldr/de/number_formats.yml
+++ b/data/cldr/de/number_formats.yml
@@ -1,6 +1,6 @@
 ---
 locale: de
-generated_at: '2025-09-14T04:23:55Z'
+generated_at: '2025-09-14T05:42:39Z'
 cldr_version: '46'
 number_formats:
   symbols:
@@ -1322,3 +1322,2586 @@ number_formats:
       display_names:
         other: Simbabwe-Dollar (2008)
         one: Simbabwe-Dollar (2008)
+  units:
+    g-force:
+      long:
+        gender: feminine
+      short:
+        display_name: g-Kraft
+      narrow:
+        display_name: G
+        one: "{0}G"
+        other: "{0}G"
+    meter-per-square-second:
+      long:
+        display_name: Meter pro Quadratsekunde
+        one: "{0} Meter pro Quadratsekunde"
+        one_accusative: "{0} Meter pro Quadratsekunde"
+        one_dative: "{0} Meter pro Quadratsekunde"
+        one_genitive: "{0} Meters pro Quadratsekunde"
+        other: "{0} Meter pro Quadratsekunde"
+        other_accusative: "{0} Meter pro Quadratsekunde"
+        other_dative: "{0} Metern pro Quadratsekunde"
+        other_genitive: "{0} Meter pro Quadratsekunde"
+        gender: masculine
+    revolution:
+      long:
+        display_name: Umdrehung
+        one: "{0} Umdrehung"
+        one_accusative: "{0} Umdrehung"
+        one_dative: "{0} Umdrehung"
+        one_genitive: "{0} Umdrehung"
+        other: "{0} Umdrehungen"
+        other_accusative: "{0} Umdrehungen"
+        other_dative: "{0} Umdrehungen"
+        other_genitive: "{0} Umdrehungen"
+        gender: feminine
+      short:
+        display_name: Umdr.
+        one: "{0} Umdr."
+        other: "{0} Umdr."
+      narrow:
+        display_name: U
+        one: "{0} U"
+        other: "{0} U"
+    radian:
+      long:
+        display_name: Radiant
+        one: "{0} Radiant"
+        one_accusative: "{0} Radiant"
+        one_dative: "{0} Radiant"
+        one_genitive: "{0} Radiant"
+        other: "{0} Radiant"
+        other_accusative: "{0} Radiant"
+        other_dative: "{0} Radiant"
+        other_genitive: "{0} Radiant"
+        gender: masculine
+      narrow:
+        one: "{0}rad"
+        other: "{0}rad"
+    degree:
+      long:
+        one: "{0} Grad"
+        one_accusative: "{0} Grad"
+        one_dative: "{0} Grad"
+        one_genitive: "{0} Grads"
+        other: "{0} Grad"
+        other_accusative: "{0} Grad"
+        other_dative: "{0} Grad"
+        other_genitive: "{0} Grad"
+        gender: neuter
+      short:
+        display_name: Grad
+      narrow:
+        display_name: "°"
+    arc-minute:
+      long:
+        one: "{0} Winkelminute"
+        one_accusative: "{0} Winkelminute"
+        one_dative: "{0} Winkelminute"
+        one_genitive: "{0} Winkelminute"
+        other: "{0} Winkelminuten"
+        other_accusative: "{0} Winkelminuten"
+        other_dative: "{0} Winkelminuten"
+        other_genitive: "{0} Winkelminuten"
+        gender: feminine
+      short:
+        display_name: Winkelminuten
+      narrow:
+        display_name: "′"
+    arc-second:
+      long:
+        one: "{0} Winkelsekunde"
+        one_accusative: "{0} Winkelsekunde"
+        one_dative: "{0} Winkelsekunde"
+        one_genitive: "{0} Winkelsekunde"
+        other: "{0} Winkelsekunden"
+        other_accusative: "{0} Winkelsekunden"
+        other_dative: "{0} Winkelsekunden"
+        other_genitive: "{0} Winkelsekunden"
+        gender: feminine
+      short:
+        display_name: Winkelsekunden
+      narrow:
+        display_name: "″"
+    square-kilometer:
+      long:
+        display_name: Quadratkilometer
+        one: "{0} Quadratkilometer"
+        one_accusative: "{0} Quadratkilometer"
+        one_dative: "{0} Quadratkilometer"
+        one_genitive: "{0} Quadratkilometers"
+        other: "{0} Quadratkilometer"
+        other_accusative: "{0} Quadratkilometer"
+        other_dative: "{0} Quadratkilometern"
+        other_genitive: "{0} Quadratkilometer"
+        gender: masculine
+        per_unit_pattern: "{0} pro Quadratkilometer"
+    hectare:
+      long:
+        one: "{0} Hektar"
+        one_accusative: "{0} Hektar"
+        one_dative: "{0} Hektar"
+        one_genitive: "{0} Hektars"
+        other: "{0} Hektar"
+        other_accusative: "{0} Hektar"
+        other_dative: "{0} Hektar"
+        other_genitive: "{0} Hektar"
+        gender: masculine
+      short:
+        display_name: Hektar
+      narrow:
+        display_name: ha
+    square-meter:
+      long:
+        display_name: Quadratmeter
+        one: "{0} Quadratmeter"
+        one_accusative: "{0} Quadratmeter"
+        one_dative: "{0} Quadratmeter"
+        one_genitive: "{0} Quadratmeters"
+        other: "{0} Quadratmeter"
+        other_accusative: "{0} Quadratmeter"
+        other_dative: "{0} Quadratmetern"
+        other_genitive: "{0} Quadratmeter"
+        gender: masculine
+        per_unit_pattern: "{0} pro Quadratmeter"
+    square-centimeter:
+      long:
+        display_name: Quadratzentimeter
+        one: "{0} Quadratzentimeter"
+        one_accusative: "{0} Quadratzentimeter"
+        one_dative: "{0} Quadratzentimeter"
+        one_genitive: "{0} Quadratzentimeters"
+        other: "{0} Quadratzentimeter"
+        other_accusative: "{0} Quadratzentimeter"
+        other_dative: "{0} Quadratzentimetern"
+        other_genitive: "{0} Quadratzentimeter"
+        gender: masculine
+        per_unit_pattern: "{0} pro Quadratzentimeter"
+    square-mile:
+      long:
+        display_name: Quadratmeilen
+        one: "{0} Quadratmeile"
+        one_accusative: "{0} Quadratmeile"
+        one_dative: "{0} Quadratmeile"
+        one_genitive: "{0} Quadratmeile"
+        other: "{0} Quadratmeilen"
+        other_accusative: "{0} Quadratmeilen"
+        other_dative: "{0} Quadratmeilen"
+        other_genitive: "{0} Quadratmeilen"
+        gender: feminine
+        per_unit_pattern: "{0} pro Quadratmeile"
+    acre:
+      long:
+        display_name: Acres
+        one: "{0} Acre"
+        one_accusative: "{0} Acre"
+        one_dative: "{0} Acre"
+        one_genitive: "{0} Acres"
+        other: "{0} Acres"
+        other_accusative: "{0} Acre"
+        other_dative: "{0} Acre"
+        other_genitive: "{0} Acre"
+        gender: masculine
+      short:
+        display_name: ac
+    square-yard:
+      long:
+        display_name: Quadratyards
+        one: "{0} Quadratyard"
+        other: "{0} Quadratyards"
+    square-foot:
+      long:
+        display_name: Quadratfuß
+        one: "{0} Quadratfuß"
+        one_accusative: "{0} Quadratfuß"
+        one_dative: "{0} Quadratfuß"
+        one_genitive: "{0} Quadratfußes"
+        other: "{0} Quadratfuß"
+        other_accusative: "{0} Quadratfuß"
+        other_dative: "{0} Quadratfuß"
+        other_genitive: "{0} Quadratfuß"
+        gender: masculine
+    square-inch:
+      long:
+        display_name: Quadratzoll
+        one: "{0} Quadratzoll"
+        other: "{0} Quadratzoll"
+        per_unit_pattern: "{0} pro Quadratzoll"
+    dunam:
+      long:
+        one: "{0} Dunam"
+        other: "{0} Dunams"
+      short:
+        display_name: Dunams
+        one: "{0} Dunam"
+        other: "{0} Dunam"
+      narrow:
+        display_name: Dunam
+    karat:
+      long:
+        one: "{0} Karat"
+        one_accusative: "{0} Karat"
+        one_dative: "{0} Karat"
+        one_genitive: "{0} Karats"
+        other: "{0} Karat"
+        other_accusative: "{0} Karat"
+        other_dative: "{0} Karat"
+        other_genitive: "{0} Karat"
+        gender: neuter
+      short:
+        display_name: Karat
+      narrow:
+        display_name: kt
+        one: "{0}kt"
+        other: "{0}kt"
+    milligram-ofglucose-per-deciliter:
+      long:
+        display_name: Milligramm pro Deziliter
+        one: "{0} Milligramm pro Deziliter"
+        one_accusative: "{0} Milligramm pro Deziliter"
+        one_dative: "{0} Milligramm pro Deziliter"
+        one_genitive: "{0} Milligramm pro Deziliter"
+        other: "{0} Milligramm pro Deziliter"
+        other_accusative: "{0} Milligramm pro Deziliter"
+        other_dative: "{0} Milligramm pro Deziliter"
+        other_genitive: "{0} Milligramm pro Deziliter"
+        gender: neuter
+      short:
+        display_name: mg/dl
+        one: "{0} mg/dl"
+        other: "{0} mg/dl"
+      narrow:
+        one: "{0}mg/dl"
+        other: "{0}mg/dl"
+    millimole-per-liter:
+      long:
+        display_name: Millimol pro Liter
+        one: "{0} Millimol pro Liter"
+        one_accusative: "{0} Millimol pro Liter"
+        one_dative: "{0} Millimol pro Liter"
+        one_genitive: "{0} Millimol pro Liter"
+        other: "{0} Millimol pro Liter"
+        other_accusative: "{0} Millimol pro Liter"
+        other_dative: "{0} Millimol pro Liter"
+        other_genitive: "{0} Millimol pro Liter"
+        gender: neuter
+      short:
+        display_name: Millimol/Liter
+        one: "{0} mmol/l"
+        other: "{0} mmol/l"
+      narrow:
+        display_name: mmol/l
+        one: "{0}mmol/l"
+        other: "{0}mmol/l"
+    item:
+      long:
+        display_name: Elemente
+        one: "{0} Element"
+        one_accusative: "{0} Element"
+        one_dative: "{0} Element"
+        one_genitive: "{0} Elements"
+        other: "{0} Elemente"
+        other_accusative: "{0} Elemente"
+        other_dative: "{0} Elementen"
+        other_genitive: "{0} Elemente"
+        gender: neuter
+      short:
+        display_name: Element
+        one: "{0} Element"
+        other: "{0} Elemente"
+      narrow:
+        display_name: Elem.
+        one: "{0} Elem."
+        other: "{0} Elem."
+    permillion:
+      long:
+        display_name: Millionstel
+        one: "{0} Millionstel"
+        one_accusative: "{0} Millionstel"
+        one_dative: "{0} Millionstel"
+        one_genitive: "{0} Millionstels"
+        other: "{0} Millionstel"
+        other_accusative: "{0} Millionstel"
+        other_dative: "{0} Millionsteln"
+        other_genitive: "{0} Millionstel"
+        gender: neuter
+    percent:
+      long:
+        display_name: Prozent
+        one: "{0} Prozent"
+        one_accusative: "{0} Prozent"
+        one_dative: "{0} Prozent"
+        one_genitive: "{0} Prozents"
+        other: "{0} Prozent"
+        other_accusative: "{0} Prozent"
+        other_dative: "{0} Prozent"
+        other_genitive: "{0} Prozent"
+        gender: neuter
+      short:
+        one: "{0} %"
+        other: "{0} %"
+    permille:
+      long:
+        display_name: Promille
+        one: "{0} Promille"
+        one_accusative: "{0} Promille"
+        one_dative: "{0} Promille"
+        one_genitive: "{0} Promille"
+        other: "{0} Promille"
+        other_accusative: "{0} Promille"
+        other_dative: "{0} Promille"
+        other_genitive: "{0} Promille"
+        gender: neuter
+      short:
+        one: "{0} ‰"
+        other: "{0} ‰"
+      narrow:
+        one: "{0}‰"
+        other: "{0}‰"
+    permyriad:
+      long:
+        display_name: Pro-Zehntausend
+        one: "{0} pro Zehntausend"
+        one_accusative: "{0} pro Zehntausend"
+        one_dative: "{0} pro Zehntausend"
+        one_genitive: "{0} pro Zehntausend"
+        other: "{0} pro Zehntausend"
+        other_accusative: "{0} pro Zehntausend"
+        other_dative: "{0} pro Zehntausend"
+        other_genitive: "{0} pro Zehntausend"
+        gender: neuter
+      short:
+        one: "{0} ‱"
+        other: "{0} ‱"
+    mole:
+      long:
+        display_name: Mole
+        one: "{0} Mol"
+        one_accusative: "{0} Mol"
+        one_dative: "{0} Mol"
+        one_genitive: "{0} Mols"
+        other: "{0} Mol"
+        other_accusative: "{0} Mol"
+        other_dative: "{0} Mol"
+        other_genitive: "{0} Mol"
+        gender: neuter
+      narrow:
+        one: "{0}mol"
+        other: "{0}mol"
+    liter-per-kilometer:
+      long:
+        display_name: Liter pro Kilometer
+        one: "{0} Liter pro Kilometer"
+        one_accusative: "{0} Liter pro Kilometer"
+        one_dative: "{0} Liter pro Kilometer"
+        one_genitive: "{0} Liters pro Kilometer"
+        other: "{0} Liter pro Kilometer"
+        other_accusative: "{0} Liter pro Kilometer"
+        other_dative: "{0} Litern pro Kilometer"
+        other_genitive: "{0} Liter pro Kilometer"
+        gender: masculine
+      short:
+        display_name: l/km
+        one: "{0} l/km"
+        other: "{0} l/km"
+      narrow:
+        one: "{0}l/km"
+        other: "{0}l/km"
+    liter-per-100-kilometer:
+      long:
+        display_name: Liter pro 100 Kilometer
+        one: "{0} Liter pro 100 Kilometer"
+        one_accusative: "{0} Liter pro 100 Kilometer"
+        one_dative: "{0} Liter pro 100 Kilometer"
+        one_genitive: "{0} Liters pro 100 Kilometer"
+        other: "{0} Liter pro 100 Kilometer"
+        other_accusative: "{0} Liter pro 100 Kilometer"
+        other_dative: "{0} Litern pro 100 Kilometer"
+        other_genitive: "{0} Liter pro 100 Kilometer"
+        gender: masculine
+      short:
+        display_name: L/100 km
+        one: "{0} L/100 km"
+        other: "{0} L/100 km"
+      narrow:
+        display_name: L/100km
+        one: "{0}L/100km"
+        other: "{0}L/100km"
+    mile-per-gallon:
+      long:
+        display_name: Meilen pro Gallone
+        one: "{0} Meile pro Gallone"
+        one_accusative: "{0} Meile pro Gallone"
+        one_dative: "{0} Meile pro Gallone"
+        one_genitive: "{0} Meile pro Gallone"
+        other: "{0} Meilen pro Gallone"
+        other_accusative: "{0} Meilen pro Gallone"
+        other_dative: "{0} Meilen pro Gallone"
+        other_genitive: "{0} Meilen pro Gallone"
+        gender: feminine
+      short:
+        display_name: mpg
+        one: "{0} mpg"
+        other: "{0} mpg"
+      narrow:
+        one: "{0}mpg"
+        other: "{0}mpg"
+    mile-per-gallon-imperial:
+      long:
+        display_name: Meilen pro Imp. Gallone
+        one: "{0} Meile pro Imp. Gallone"
+        one_accusative: "{0} Meile pro Imp. Gallone"
+        one_dative: "{0} Meile pro Imp. Gallone"
+        one_genitive: "{0} Meile pro Imp. Gallone"
+        other: "{0} Meilen pro Imp. Gallone"
+        other_accusative: "{0} Meilen pro Imp. Gallone"
+        other_dative: "{0} Meilen pro Imp. Gallone"
+        other_genitive: "{0} Meilen pro Imp. Gallone"
+        gender: feminine
+      short:
+        display_name: Meilen/ Imp. Gal.
+      narrow:
+        display_name: mpg UK
+        one: "{0} mpg UK"
+        other: "{0} mpg UK"
+    petabyte:
+      long:
+        display_name: Petabytes
+        one: "{0} Petabyte"
+        one_accusative: "{0} Petabyte"
+        one_dative: "{0} Petabyte"
+        one_genitive: "{0} Petabyte"
+        other: "{0} Petabyte"
+        other_accusative: "{0} Petabyte"
+        other_dative: "{0} Petabyte"
+        other_genitive: "{0} Petabyte"
+        gender: neuter
+    terabyte:
+      long:
+        display_name: Terabytes
+        one: "{0} Terabyte"
+        one_accusative: "{0} Terabyte"
+        one_dative: "{0} Terabyte"
+        one_genitive: "{0} Terabyte"
+        other: "{0} Terabyte"
+        other_accusative: "{0} Terabyte"
+        other_dative: "{0} Terabyte"
+        other_genitive: "{0} Terabyte"
+        gender: neuter
+    terabit:
+      long:
+        display_name: Terabits
+        one: "{0} Terabit"
+        one_accusative: "{0} Terabit"
+        one_dative: "{0} Terabit"
+        one_genitive: "{0} Terabit"
+        other: "{0} Terabit"
+        other_accusative: "{0} Terabit"
+        other_dative: "{0} Terabit"
+        other_genitive: "{0} Terabit"
+        gender: neuter
+    gigabyte:
+      long:
+        display_name: Gigabytes
+        one: "{0} Gigabyte"
+        one_accusative: "{0} Gigabyte"
+        one_dative: "{0} Gigabyte"
+        one_genitive: "{0} Gigabyte"
+        other: "{0} Gigabyte"
+        other_accusative: "{0} Gigabyte"
+        other_dative: "{0} Gigabyte"
+        other_genitive: "{0} Gigabyte"
+        gender: neuter
+      short:
+        display_name: Gigabyte
+        one: "{0} GB"
+        other: "{0} GB"
+      narrow:
+        display_name: GB
+    gigabit:
+      long:
+        display_name: Gigabits
+        one: "{0} Gigabit"
+        one_accusative: "{0} Gigabit"
+        one_dative: "{0} Gigabit"
+        one_genitive: "{0} Gigabit"
+        other: "{0} Gigabit"
+        other_accusative: "{0} Gigabit"
+        other_dative: "{0} Gigabit"
+        other_genitive: "{0} Gigabit"
+        gender: neuter
+      short:
+        display_name: Gigabit
+        one: "{0} Gb"
+        other: "{0} Gb"
+      narrow:
+        display_name: Gb
+    megabyte:
+      long:
+        display_name: Megabytes
+        one: "{0} Megabyte"
+        one_accusative: "{0} Megabyte"
+        one_dative: "{0} Megabyte"
+        one_genitive: "{0} Megabyte"
+        other: "{0} Megabyte"
+        other_accusative: "{0} Megabyte"
+        other_dative: "{0} Megabyte"
+        other_genitive: "{0} Megabyte"
+        gender: neuter
+      short:
+        display_name: Mbyte
+      narrow:
+        display_name: MB
+    megabit:
+      long:
+        display_name: Megabits
+        one: "{0} Megabit"
+        one_accusative: "{0} Megabit"
+        one_dative: "{0} Megabit"
+        one_genitive: "{0} Megabit"
+        other: "{0} Megabit"
+        other_accusative: "{0} Megabit"
+        other_dative: "{0} Megabit"
+        other_genitive: "{0} Megabit"
+        gender: neuter
+      short:
+        display_name: Mbit
+      narrow:
+        display_name: Mb
+    kilobyte:
+      long:
+        display_name: Kilobytes
+        one: "{0} Kilobyte"
+        one_accusative: "{0} Kilobyte"
+        one_dative: "{0} Kilobyte"
+        one_genitive: "{0} Kilobyte"
+        other: "{0} Kilobyte"
+        other_accusative: "{0} Kilobyte"
+        other_dative: "{0} Kilobyte"
+        other_genitive: "{0} Kilobyte"
+        gender: neuter
+      short:
+        display_name: kbyte
+      narrow:
+        display_name: kB
+    kilobit:
+      long:
+        display_name: Kilobits
+        one: "{0} Kilobit"
+        one_accusative: "{0} Kilobit"
+        one_dative: "{0} Kilobit"
+        one_genitive: "{0} Kilobit"
+        other: "{0} Kilobit"
+        other_accusative: "{0} Kilobit"
+        other_dative: "{0} Kilobit"
+        other_genitive: "{0} Kilobit"
+        gender: neuter
+      short:
+        display_name: kbit
+      narrow:
+        display_name: kb
+    byte:
+      long:
+        display_name: Bytes
+        one: "{0} Byte"
+        one_accusative: "{0} Byte"
+        one_dative: "{0} Byte"
+        one_genitive: "{0} Byte"
+        other: "{0} Byte"
+        other_accusative: "{0} Byte"
+        other_dative: "{0} Byte"
+        other_genitive: "{0} Byte"
+        gender: neuter
+      short:
+        display_name: Byte
+        one: "{0} Byte"
+        other: "{0} Byte"
+      narrow:
+        display_name: B
+        one: "{0} B"
+        other: "{0} B"
+    bit:
+      long:
+        display_name: Bits
+        one: "{0} Bit"
+        one_accusative: "{0} Bit"
+        one_dative: "{0} Bit"
+        one_genitive: "{0} Bit"
+        other: "{0} Bit"
+        other_accusative: "{0} Bit"
+        other_dative: "{0} Bit"
+        other_genitive: "{0} Bit"
+        gender: neuter
+      short:
+        display_name: Bit
+        one: "{0} Bit"
+        other: "{0} Bit"
+      narrow:
+        display_name: b
+        one: "{0} b"
+        other: "{0} b"
+    century:
+      long:
+        display_name: Jahrhunderte
+        one: "{0} Jahrhundert"
+        one_accusative: "{0} Jahrhundert"
+        one_dative: "{0} Jahrhundert"
+        one_genitive: "{0} Jahrhunderts"
+        other: "{0} Jahrhunderte"
+        other_accusative: "{0} Jahrhunderte"
+        other_dative: "{0} Jahrhunderten"
+        other_genitive: "{0} Jahrhunderte"
+        gender: neuter
+      short:
+        display_name: Jh.
+        one: "{0} Jh."
+        other: "{0} Jh."
+    decade:
+      long:
+        display_name: Jahrzehnte
+        one: "{0} Jahrzehnt"
+        one_accusative: "{0} Jahrzehnt"
+        one_dative: "{0} Jahrzehnt"
+        one_genitive: "{0} Jahrzehnts"
+        other: "{0} Jahrzehnte"
+        other_accusative: "{0} Jahrzehnte"
+        other_dative: "{0} Jahrzehnten"
+        other_genitive: "{0} Jahrzehnte"
+        gender: neuter
+      short:
+        display_name: Jz.
+        one: "{0} Jz."
+        other: "{0} Jz."
+    year:
+      long:
+        display_name: Jahre
+        one: "{0} Jahr"
+        one_accusative: "{0} Jahr"
+        one_dative: "{0} Jahr"
+        one_genitive: "{0} Jahres"
+        other: "{0} Jahre"
+        other_accusative: "{0} Jahre"
+        other_dative: "{0} Jahren"
+        other_genitive: "{0} Jahre"
+        gender: neuter
+        per_unit_pattern: "{0} pro Jahr"
+      short:
+        display_name: J
+        one: "{0} J"
+        other: "{0} J"
+        per_unit_pattern: "{0}/J"
+    quarter:
+      long:
+        display_name: Quartale
+        one: "{0} Quartal"
+        one_accusative: "{0} Quartal"
+        one_dative: "{0} Quartal"
+        one_genitive: "{0} Quartals"
+        other: "{0} Quartale"
+        other_accusative: "{0} Quartale"
+        other_dative: "{0} Quartalen"
+        other_genitive: "{0} Quartale"
+        gender: neuter
+        per_unit_pattern: "{0}/Quartal"
+      short:
+        display_name: Quart.
+        one: "{0} Quart."
+        other: "{0} Quart."
+        per_unit_pattern: "{0}/Quart."
+      narrow:
+        display_name: Q
+        one: "{0} Q"
+        other: "{0} Q"
+        per_unit_pattern: "{0}/Q"
+    month:
+      long:
+        display_name: Monate
+        one: "{0} Monat"
+        one_accusative: "{0} Monat"
+        one_dative: "{0} Monat"
+        one_genitive: "{0} Monats"
+        other: "{0} Monate"
+        other_accusative: "{0} Monate"
+        other_dative: "{0} Monaten"
+        other_genitive: "{0} Monate"
+        gender: masculine
+        per_unit_pattern: "{0} pro Monat"
+      short:
+        display_name: Mon.
+        one: "{0} Mon."
+        other: "{0} Mon."
+        per_unit_pattern: "{0}/M"
+      narrow:
+        display_name: M
+        one: "{0} M"
+        other: "{0} M"
+    week:
+      long:
+        display_name: Wochen
+        one: "{0} Woche"
+        one_accusative: "{0} Woche"
+        one_dative: "{0} Woche"
+        one_genitive: "{0} Woche"
+        other: "{0} Wochen"
+        other_accusative: "{0} Wochen"
+        other_dative: "{0} Wochen"
+        other_genitive: "{0} Wochen"
+        gender: feminine
+        per_unit_pattern: "{0} pro Woche"
+      short:
+        display_name: Wo.
+        one: "{0} Wo."
+        other: "{0} Wo."
+        per_unit_pattern: "{0}/W"
+      narrow:
+        display_name: W
+        one: "{0} W"
+        other: "{0} W"
+    day:
+      long:
+        display_name: Tage
+        one: "{0} Tag"
+        one_accusative: "{0} Tag"
+        one_dative: "{0} Tag"
+        one_genitive: "{0} Tages"
+        other: "{0} Tage"
+        other_accusative: "{0} Tage"
+        other_dative: "{0} Tagen"
+        other_genitive: "{0} Tage"
+        gender: masculine
+        per_unit_pattern: "{0} pro Tag"
+      short:
+        display_name: Tg.
+        one: "{0} Tg."
+        other: "{0} Tg."
+        per_unit_pattern: "{0}/T"
+      narrow:
+        display_name: T
+        one: "{0} T"
+        other: "{0} T"
+    day-person:
+      long:
+        one: "{0} Tag"
+        one_accusative: "{0} Tag"
+        one_dative: "{0} Tag"
+        one_genitive: "{0} Tages"
+        other: "{0} Tage"
+        other_accusative: "{0} Tage"
+        other_dative: "{0} Tagen"
+        other_genitive: "{0} Tage"
+        gender: masculine
+    hour:
+      long:
+        display_name: Stunden
+        one: "{0} Stunde"
+        one_accusative: "{0} Stunde"
+        one_dative: "{0} Stunde"
+        one_genitive: "{0} Stunde"
+        other: "{0} Stunden"
+        other_accusative: "{0} Stunden"
+        other_dative: "{0} Stunden"
+        other_genitive: "{0} Stunden"
+        gender: feminine
+        per_unit_pattern: "{0} pro Stunde"
+      short:
+        display_name: Std.
+        one: "{0} Std."
+        other: "{0} Std."
+    minute:
+      long:
+        display_name: Minuten
+        one: "{0} Minute"
+        one_accusative: "{0} Minute"
+        one_dative: "{0} Minute"
+        one_genitive: "{0} Minute"
+        other: "{0} Minuten"
+        other_accusative: "{0} Minuten"
+        other_dative: "{0} Minuten"
+        other_genitive: "{0} Minuten"
+        gender: feminine
+        per_unit_pattern: "{0} pro Minute"
+      short:
+        one: "{0} Min."
+        other: "{0} Min."
+    second:
+      long:
+        display_name: Sekunden
+        one: "{0} Sekunde"
+        one_accusative: "{0} Sekunde"
+        one_dative: "{0} Sekunde"
+        one_genitive: "{0} Sekunde"
+        other: "{0} Sekunden"
+        other_accusative: "{0} Sekunden"
+        other_dative: "{0} Sekunden"
+        other_genitive: "{0} Sekunden"
+        gender: feminine
+        per_unit_pattern: "{0} pro Sekunde"
+      short:
+        display_name: Sek.
+        one: "{0} Sek."
+        other: "{0} Sek."
+    millisecond:
+      long:
+        display_name: Millisekunden
+        one: "{0} Millisekunde"
+        one_accusative: "{0} Millisekunde"
+        one_dative: "{0} Millisekunde"
+        one_genitive: "{0} Millisekunde"
+        other: "{0} Millisekunden"
+        other_accusative: "{0} Millisekunden"
+        other_dative: "{0} Millisekunden"
+        other_genitive: "{0} Millisekunden"
+        gender: feminine
+    microsecond:
+      long:
+        display_name: Mikrosekunden
+        one: "{0} Mikrosekunde"
+        one_accusative: "{0} Mikrosekunde"
+        one_dative: "{0} Mikrosekunde"
+        one_genitive: "{0} Mikrosekunde"
+        other: "{0} Mikrosekunden"
+        other_accusative: "{0} Mikrosekunden"
+        other_dative: "{0} Mikrosekunden"
+        other_genitive: "{0} Mikrosekunden"
+        gender: feminine
+    nanosecond:
+      long:
+        display_name: Nanosekunden
+        one: "{0} Nanosekunde"
+        one_accusative: "{0} Nanosekunde"
+        one_dative: "{0} Nanosekunde"
+        one_genitive: "{0} Nanosekunde"
+        other: "{0} Nanosekunden"
+        other_accusative: "{0} Nanosekunden"
+        other_dative: "{0} Nanosekunden"
+        other_genitive: "{0} Nanosekunden"
+        gender: feminine
+    ampere:
+      long:
+        one: "{0} Ampere"
+        one_accusative: "{0} Ampere"
+        one_dative: "{0} Ampere"
+        one_genitive: "{0} Ampere"
+        other: "{0} Ampere"
+        other_accusative: "{0} Ampere"
+        other_dative: "{0} Ampere"
+        other_genitive: "{0} Ampere"
+        gender: neuter
+      short:
+        display_name: Ampere
+      narrow:
+        display_name: A
+        one: "{0}A"
+        other: "{0}A"
+    milliampere:
+      long:
+        display_name: Milliampere
+        one: "{0} Milliampere"
+        one_accusative: "{0} Milliampere"
+        one_dative: "{0} Milliampere"
+        one_genitive: "{0} Milliampere"
+        other: "{0} Milliampere"
+        other_accusative: "{0} Milliampere"
+        other_dative: "{0} Milliampere"
+        other_genitive: "{0} Milliampere"
+        gender: neuter
+      narrow:
+        one: "{0}mA"
+        other: "{0}mA"
+    ohm:
+      long:
+        one: "{0} Ohm"
+        one_accusative: "{0} Ohm"
+        one_dative: "{0} Ohm"
+        one_genitive: "{0} Ohms"
+        other: "{0} Ohm"
+        other_accusative: "{0} Ohm"
+        other_dative: "{0} Ohm"
+        other_genitive: "{0} Ohm"
+        gender: neuter
+      short:
+        display_name: Ohm
+      narrow:
+        display_name: Ω
+        one: "{0}Ω"
+        other: "{0}Ω"
+    volt:
+      long:
+        one: "{0} Volt"
+        one_accusative: "{0} Volt"
+        one_dative: "{0} Volt"
+        one_genitive: "{0} Volts"
+        other: "{0} Volt"
+        other_accusative: "{0} Volt"
+        other_dative: "{0} Volt"
+        other_genitive: "{0} Volt"
+        gender: neuter
+      short:
+        display_name: Volt
+      narrow:
+        display_name: V
+        one: "{0}V"
+        other: "{0}V"
+    kilocalorie:
+      long:
+        display_name: Kilokalorien
+        one: "{0} Kilokalorie"
+        one_accusative: "{0} Kilokalorie"
+        one_dative: "{0} Kilokalorie"
+        one_genitive: "{0} Kilokalorie"
+        other: "{0} Kilokalorien"
+        other_accusative: "{0} Kilokalorien"
+        other_dative: "{0} Kilokalorien"
+        other_genitive: "{0} Kilokalorien"
+        gender: feminine
+    calorie:
+      long:
+        display_name: Kalorien
+        one: "{0} Kalorie"
+        one_accusative: "{0} Kalorie"
+        one_dative: "{0} Kalorie"
+        one_genitive: "{0} Kalorie"
+        other: "{0} Kalorien"
+        other_accusative: "{0} Kalorien"
+        other_dative: "{0} Kalorien"
+        other_genitive: "{0} Kalorien"
+        gender: feminine
+    foodcalorie:
+      long:
+        display_name: Kilokalorien
+        one: "{0} Kilokalorie"
+        one_accusative: "{0} Kilokalorie"
+        one_dative: "{0} Kilokalorie"
+        one_genitive: "{0} Kilokalorie"
+        other: "{0} Kilokalorien"
+        other_accusative: "{0} Kilokalorien"
+        other_dative: "{0} Kilokalorien"
+        other_genitive: "{0} Kilokalorien"
+        gender: feminine
+      short:
+        one: "{0} kcal"
+        other: "{0} kcal"
+    kilojoule:
+      long:
+        one: "{0} Kilojoule"
+        one_accusative: "{0} Kilojoule"
+        one_dative: "{0} Kilojoule"
+        one_genitive: "{0} Kilojoule"
+        other: "{0} Kilojoule"
+        other_accusative: "{0} Kilojoule"
+        other_dative: "{0} Kilojoule"
+        other_genitive: "{0} Kilojoule"
+        gender: neuter
+      short:
+        display_name: Kilojoule
+      narrow:
+        display_name: kJ
+    joule:
+      long:
+        one: "{0} Joule"
+        one_accusative: "{0} Joule"
+        one_dative: "{0} Joule"
+        one_genitive: "{0} Joule"
+        other: "{0} Joule"
+        other_accusative: "{0} Joule"
+        other_dative: "{0} Joule"
+        other_genitive: "{0} Joule"
+        gender: neuter
+      short:
+        display_name: Joule
+        one: "{0} J"
+        other: "{0} J"
+      narrow:
+        display_name: J
+        one: "{0}J"
+        other: "{0}J"
+    kilowatt-hour:
+      long:
+        display_name: Kilowattstunden
+        one: "{0} Kilowattstunde"
+        one_accusative: "{0} Kilowattstunde"
+        one_dative: "{0} Kilowattstunde"
+        one_genitive: "{0} Kilowattstunde"
+        other: "{0} Kilowattstunden"
+        other_accusative: "{0} Kilowattstunden"
+        other_dative: "{0} Kilowattstunden"
+        other_genitive: "{0} Kilowattstunden"
+        gender: feminine
+    electronvolt:
+      long:
+        display_name: Elektronenvolt
+        one: "{0} Elektronenvolt"
+        other: "{0} Elektronenvolt"
+    british-thermal-unit:
+      long:
+        display_name: British thermal units
+        one: "{0} British thermal unit"
+        other: "{0} British thermal units"
+    therm-us:
+      long:
+        display_name: US thermal units
+        one: "{0} US thermal unit"
+        other: "{0} US thermal units"
+    pound-force:
+      long:
+        display_name: Pound-force
+        one: "{0} Pound-force"
+        other: "{0} Pound-force"
+      narrow:
+        one: "{0}lbf"
+        other: "{0}lbf"
+    newton:
+      long:
+        display_name: Newton
+        one: "{0} Newton"
+        one_accusative: "{0} Newton"
+        one_dative: "{0} Newton"
+        one_genitive: "{0} Newtons"
+        other: "{0} Newton"
+        other_accusative: "{0} Newton"
+        other_dative: "{0} Newton"
+        other_genitive: "{0} Newton"
+        gender: neuter
+      narrow:
+        one: "{0}N"
+        other: "{0}N"
+    kilowatt-hour-per-100-kilometer:
+      long:
+        display_name: Kilowattstunde pro 100 Kilometer
+        one: "{0} Kilowattstunde pro 100 Kilometer"
+        one_accusative: "{0} Kilowattstunde pro 100 Kilometer"
+        one_dative: "{0} Kilowattstunde pro 100 Kilometer"
+        one_genitive: "{0} Kilowattstunde pro 100 Kilometer"
+        other: "{0} Kilowattstunden pro 100 Kilometer"
+        other_accusative: "{0} Kilowattstunden pro 100 Kilometer"
+        other_dative: "{0} Kilowattstunden pro 100 Kilometer"
+        other_genitive: "{0} Kilowattstunden pro 100 Kilometer"
+        gender: feminine
+      short:
+        display_name: kWh/100 km
+        one: "{0} kWh/100 km"
+        other: "{0} kWh/100 km"
+      narrow:
+        display_name: kWh/100km
+        one: "{0} kWh/100km"
+        other: "{0} kWh/100km"
+    gigahertz:
+      long:
+        display_name: Gigahertz
+        one: "{0} Gigahertz"
+        one_accusative: "{0} Gigahertz"
+        one_dative: "{0} Gigahertz"
+        one_genitive: "{0} Gigahertz"
+        other: "{0} Gigahertz"
+        other_accusative: "{0} Gigahertz"
+        other_dative: "{0} Gigahertz"
+        other_genitive: "{0} Gigahertz"
+        gender: neuter
+      narrow:
+        one: "{0}GHz"
+        other: "{0}GHz"
+    megahertz:
+      long:
+        display_name: Megahertz
+        one: "{0} Megahertz"
+        one_accusative: "{0} Megahertz"
+        one_dative: "{0} Megahertz"
+        one_genitive: "{0} Megahertz"
+        other: "{0} Megahertz"
+        other_accusative: "{0} Megahertz"
+        other_dative: "{0} Megahertz"
+        other_genitive: "{0} Megahertz"
+        gender: neuter
+      narrow:
+        one: "{0}MHz"
+        other: "{0}MHz"
+    kilohertz:
+      long:
+        display_name: Kilohertz
+        one: "{0} Kilohertz"
+        one_accusative: "{0} Kilohertz"
+        one_dative: "{0} Kilohertz"
+        one_genitive: "{0} Kilohertz"
+        other: "{0} Kilohertz"
+        other_accusative: "{0} Kilohertz"
+        other_dative: "{0} Kilohertz"
+        other_genitive: "{0} Kilohertz"
+        gender: neuter
+      narrow:
+        one: "{0}kHz"
+        other: "{0}kHz"
+    hertz:
+      long:
+        display_name: Hertz
+        one: "{0} Hertz"
+        one_accusative: "{0} Hertz"
+        one_dative: "{0} Hertz"
+        one_genitive: "{0} Hertz"
+        other: "{0} Hertz"
+        other_accusative: "{0} Hertz"
+        other_dative: "{0} Hertz"
+        other_genitive: "{0} Hertz"
+        gender: neuter
+      narrow:
+        one: "{0}Hz"
+        other: "{0}Hz"
+    em:
+      long:
+        gender: neuter
+    pixel:
+      long:
+        display_name: Pixel
+        one: "{0} Pixel"
+        one_accusative: "{0} Pixel"
+        one_dative: "{0} Pixel"
+        one_genitive: "{0} Pixels"
+        other: "{0} Pixel"
+        other_accusative: "{0} Pixel"
+        other_dative: "{0} Pixeln"
+        other_genitive: "{0} Pixel"
+        gender: neuter
+    megapixel:
+      long:
+        display_name: Megapixel
+        one: "{0} Megapixel"
+        one_accusative: "{0} Megapixel"
+        one_dative: "{0} Megapixel"
+        one_genitive: "{0} Megapixels"
+        other: "{0} Megapixel"
+        other_accusative: "{0} Megapixel"
+        other_dative: "{0} Megapixeln"
+        other_genitive: "{0} Megapixel"
+        gender: neuter
+    pixel-per-centimeter:
+      long:
+        display_name: Pixel pro Zentimeter
+        one: "{0} Pixel pro Zentimeter"
+        one_accusative: "{0} Pixel pro Zentimeter"
+        one_dative: "{0} Pixel pro Zentimeter"
+        one_genitive: "{0} Pixels pro Zentimeter"
+        other: "{0} Pixel pro Zentimeter"
+        other_accusative: "{0} Pixel pro Zentimeter"
+        other_dative: "{0} Pixeln pro Zentimeter"
+        other_genitive: "{0} Pixel pro Zentimeter"
+        gender: neuter
+    pixel-per-inch:
+      long:
+        display_name: Pixel pro Inch
+        one: "{0} Pixel pro Inch"
+        other: "{0} Pixel pro Inch"
+    dot-per-centimeter:
+      long:
+        display_name: Dots pro Zentimeter
+        one: "{0} Dot pro Zentimeter"
+        other: "{0} Dots pro Zentimeter"
+      short:
+        display_name: dpcm
+        one: "{0} dpcm"
+        other: "{0} dpcm"
+    dot-per-inch:
+      long:
+        display_name: Dots pro Inch
+        one: "{0} Dot pro Inch"
+        other: "{0} Dots pro Inch"
+      short:
+        display_name: dpi
+        one: "{0} dpi"
+        other: "{0} dpi"
+    dot:
+      long:
+        one: "{0} Dot"
+        other: "{0} Dots"
+      short:
+        display_name: Dots
+        one: "{0} d"
+        other: "{0} d"
+      narrow:
+        display_name: d
+    earth-radius:
+      long:
+        display_name: Erdradius
+        one: "{0} Erdradius"
+        other: "{0} Erdradien"
+    kilometer:
+      long:
+        display_name: Kilometer
+        one: "{0} Kilometer"
+        one_accusative: "{0} Kilometer"
+        one_dative: "{0} Kilometer"
+        one_genitive: "{0} Kilometers"
+        other: "{0} Kilometer"
+        other_accusative: "{0} Kilometer"
+        other_dative: "{0} Kilometern"
+        other_genitive: "{0} Kilometer"
+        gender: masculine
+        per_unit_pattern: "{0} pro Kilometer"
+    meter:
+      long:
+        one: "{0} Meter"
+        one_accusative: "{0} Meter"
+        one_dative: "{0} Meter"
+        one_genitive: "{0} Meters"
+        other: "{0} Meter"
+        other_accusative: "{0} Meter"
+        other_dative: "{0} Metern"
+        other_genitive: "{0} Meter"
+        gender: masculine
+        per_unit_pattern: "{0} pro Meter"
+      short:
+        display_name: Meter
+    decimeter:
+      long:
+        display_name: Dezimeter
+        one: "{0} Dezimeter"
+        one_accusative: "{0} Dezimeter"
+        one_dative: "{0} Dezimeter"
+        one_genitive: "{0} Dezimeters"
+        other: "{0} Dezimeter"
+        other_accusative: "{0} Dezimeter"
+        other_dative: "{0} Dezimetern"
+        other_genitive: "{0} Dezimeter"
+        gender: masculine
+    centimeter:
+      long:
+        display_name: Zentimeter
+        one: "{0} Zentimeter"
+        one_accusative: "{0} Zentimeter"
+        one_dative: "{0} Zentimeter"
+        one_genitive: "{0} Zentimeters"
+        other: "{0} Zentimeter"
+        other_accusative: "{0} Zentimeter"
+        other_dative: "{0} Zentimetern"
+        other_genitive: "{0} Zentimeter"
+        gender: masculine
+        per_unit_pattern: "{0} pro Zentimeter"
+    millimeter:
+      long:
+        display_name: Millimeter
+        one: "{0} Millimeter"
+        one_accusative: "{0} Millimeter"
+        one_dative: "{0} Millimeter"
+        one_genitive: "{0} Millimeters"
+        other: "{0} Millimeter"
+        other_accusative: "{0} Millimeter"
+        other_dative: "{0} Millimetern"
+        other_genitive: "{0} Millimeter"
+        gender: masculine
+    micrometer:
+      long:
+        display_name: Mikrometer
+        one: "{0} Mikrometer"
+        one_accusative: "{0} Mikrometer"
+        one_dative: "{0} Mikrometer"
+        one_genitive: "{0} Mikrometers"
+        other: "{0} Mikrometer"
+        other_accusative: "{0} Mikrometer"
+        other_dative: "{0} Mikrometern"
+        other_genitive: "{0} Mikrometer"
+        gender: masculine
+    nanometer:
+      long:
+        display_name: Nanometer
+        one: "{0} Nanometer"
+        one_accusative: "{0} Nanometer"
+        one_dative: "{0} Nanometer"
+        one_genitive: "{0} Nanometers"
+        other: "{0} Nanometer"
+        other_accusative: "{0} Nanometer"
+        other_dative: "{0} Nanometern"
+        other_genitive: "{0} Nanometer"
+        gender: masculine
+    picometer:
+      long:
+        one: "{0} Pikometer"
+        one_accusative: "{0} Pikometer"
+        one_dative: "{0} Pikometer"
+        one_genitive: "{0} Pikometers"
+        other: "{0} Pikometer"
+        other_accusative: "{0} Pikometer"
+        other_dative: "{0} Pikometern"
+        other_genitive: "{0} Pikometer"
+        gender: masculine
+      short:
+        display_name: Pikometer
+      narrow:
+        display_name: pm
+    mile:
+      long:
+        one: "{0} Meile"
+        one_accusative: "{0} Meile"
+        one_dative: "{0} Meile"
+        one_genitive: "{0} Meile"
+        other: "{0} Meilen"
+        other_accusative: "{0} Meilen"
+        other_dative: "{0} Meilen"
+        other_genitive: "{0} Meilen"
+        gender: feminine
+      short:
+        display_name: Meilen
+      narrow:
+        display_name: mi
+    yard:
+      long:
+        one: "{0} Yard"
+        one_accusative: "{0} Yard"
+        one_dative: "{0} Yard"
+        one_genitive: "{0} Yards"
+        other: "{0} Yards"
+        other_accusative: "{0} Yards"
+        other_dative: "{0} Yards"
+        other_genitive: "{0} Yards"
+        gender: neuter
+      short:
+        display_name: Yards
+      narrow:
+        display_name: yd
+    foot:
+      long:
+        one: "{0} Fuß"
+        one_accusative: "{0} Fuß"
+        one_dative: "{0} Fuß"
+        one_genitive: "{0} Fußes"
+        other: "{0} Fuß"
+        other_accusative: "{0} Fuß"
+        other_dative: "{0} Fuß"
+        other_genitive: "{0} Fuß"
+        gender: masculine
+        per_unit_pattern: "{0} pro Fuß"
+      short:
+        display_name: Fuß
+      narrow:
+        display_name: ft
+    inch:
+      long:
+        display_name: Zoll
+        one: "{0} Zoll"
+        one_accusative: "{0} Zoll"
+        one_dative: "{0} Zoll"
+        one_genitive: "{0} Zolls"
+        other: "{0} Zoll"
+        other_accusative: "{0} Zoll"
+        other_dative: "{0} Zoll"
+        other_genitive: "{0} Zoll"
+        gender: masculine
+        per_unit_pattern: "{0} pro Zoll"
+      short:
+        one: "{0} in"
+    parsec:
+      long:
+        display_name: Parsec
+        one: "{0} Parsec"
+        one_accusative: "{0} Parsec"
+        one_dative: "{0} Parsec"
+        one_genitive: "{0} Parsec"
+        other: "{0} Parsec"
+        other_accusative: "{0} Parsec"
+        other_dative: "{0} Parsec"
+        other_genitive: "{0} Parsec"
+        gender: neuter
+    light-year:
+      long:
+        display_name: Lichtjahre
+        one: "{0} Lichtjahr"
+        other: "{0} Lichtjahre"
+      short:
+        display_name: Lj
+        one: "{0} Lj"
+        other: "{0} Lj"
+      narrow:
+        one: "{0}Lj"
+        other: "{0}Lj"
+    astronomical-unit:
+      long:
+        display_name: Astronomische Einheiten
+        one: "{0} Astronomische Einheit"
+        other: "{0} Astronomische Einheiten"
+      short:
+        display_name: AE
+        one: "{0} AE"
+        other: "{0} AE"
+      narrow:
+        one: "{0}AE"
+        other: "{0}AE"
+    furlong:
+      long:
+        display_name: Furlongs
+        one: "{0} Furlong"
+        other: "{0} Furlong"
+      short:
+        display_name: Furlong
+      narrow:
+        one: "{0}fur"
+        other: "{0}fur"
+    fathom:
+      long:
+        display_name: Nautischer Faden
+        one: "{0} Faden"
+        other: "{0} Faden"
+      short:
+        display_name: Faden
+        one: "{0} fm"
+        other: "{0} fm"
+      narrow:
+        one: "{0}fm"
+        other: "{0}fm"
+    nautical-mile:
+      long:
+        display_name: Seemeilen
+        one: "{0} Seemeile"
+        other: "{0} Seemeilen"
+      short:
+        display_name: sm
+        one: "{0} sm"
+        other: "{0} sm"
+      narrow:
+        one: "{0}sm"
+        other: "{0}sm"
+    mile-scandinavian:
+      long:
+        display_name: skandinavische Meilen
+        one: "{0} skandinavische Meile"
+        one_accusative: "{0} skandinavische Meile"
+        one_dative: "{0} skandinavischen Meile"
+        one_genitive: "{0} skandinavischen Meile"
+        other: "{0} skandinavische Meilen"
+        other_accusative: "{0} skandinavische Meilen"
+        other_dative: "{0} skandinavischen Meilen"
+        other_genitive: "{0} skandinavischen Meilen"
+        gender: feminine
+      narrow:
+        one: "{0}smi"
+        other: "{0}smi"
+    point:
+      long:
+        display_name: DTP-Punkte
+        one: "{0} DTP-Punkt"
+        one_accusative: "{0} DTP-Punkt"
+        one_dative: "{0} DTP-Punkt"
+        one_genitive: "{0} DTP-Punkts"
+        other: "{0} DTP-Punkte"
+        other_accusative: "{0} DTP-Punkte"
+        other_dative: "{0} DTP-Punkten"
+        other_genitive: "{0} DTP-Punkte"
+        gender: masculine
+      short:
+        display_name: p
+        one: "{0} p"
+        other: "{0} p"
+    solar-radius:
+      long:
+        display_name: Sonnenradien
+        one: "{0} Sonnenradius"
+        one_accusative: "{0} Sonnenradius"
+        one_dative: "{0} Sonnenradius"
+        one_genitive: "{0} Sonnenradius"
+        other: "{0} Sonnenradien"
+        other_accusative: "{0} Sonnenradien"
+        other_dative: "{0} Sonnenradien"
+        other_genitive: "{0} Sonnenradien"
+        gender: masculine
+      narrow:
+        one: "{0}R☉"
+        other: "{0}R☉"
+    lux:
+      long:
+        one: "{0} Lux"
+        one_accusative: "{0} Lux"
+        one_dative: "{0} Lux"
+        one_genitive: "{0} Lux"
+        other: "{0} Lux"
+        other_accusative: "{0} Lux"
+        other_dative: "{0} Lux"
+        other_genitive: "{0} Lux"
+        gender: neuter
+      short:
+        display_name: Lux
+      narrow:
+        display_name: lx
+        one: "{0}lx"
+        other: "{0}lx"
+    candela:
+      long:
+        display_name: Candela
+        one: "{0} Candela"
+        one_accusative: "{0} Candela"
+        one_dative: "{0} Candela"
+        one_genitive: "{0} Candela"
+        other: "{0} Candela"
+        other_accusative: "{0} Candela"
+        other_dative: "{0} Candela"
+        other_genitive: "{0} Candela"
+        gender: feminine
+      narrow:
+        one: "{0}cd"
+        other: "{0}cd"
+    lumen:
+      long:
+        display_name: Lumen
+        one: "{0} Lumen"
+        one_accusative: "{0} Lumen"
+        one_dative: "{0} Lumen"
+        one_genitive: "{0} Lumens"
+        other: "{0} Lumen"
+        other_accusative: "{0} Lumen"
+        other_dative: "{0} Lumen"
+        other_genitive: "{0} Lumen"
+        gender: neuter
+      narrow:
+        one: "{0}lm"
+        other: "{0}lm"
+    solar-luminosity:
+      long:
+        display_name: Sonnenleuchtkräfte
+        one: "{0} Sonnenleuchtkraft"
+        one_accusative: "{0} Sonnenleuchtkraft"
+        one_dative: "{0} Sonnenleuchtkraft"
+        one_genitive: "{0} Sonnenleuchtkraft"
+        other: "{0} Sonnenleuchtkräfte"
+        other_accusative: "{0} Sonnenleuchtkräfte"
+        other_dative: "{0} Sonnenleuchtkräften"
+        other_genitive: "{0} Sonnenleuchtkräfte"
+        gender: feminine
+      narrow:
+        one: "{0}L☉"
+        other: "{0}L☉"
+    tonne:
+      long:
+        display_name: Tonnen
+        one: "{0} Tonne"
+        one_accusative: "{0} Tonne"
+        one_dative: "{0} Tonne"
+        one_genitive: "{0} Tonne"
+        other: "{0} Tonnen"
+        other_accusative: "{0} Tonnen"
+        other_dative: "{0} Tonnen"
+        other_genitive: "{0} Tonnen"
+        gender: feminine
+    kilogram:
+      long:
+        display_name: Kilogramm
+        one: "{0} Kilogramm"
+        one_accusative: "{0} Kilogramm"
+        one_dative: "{0} Kilogramm"
+        one_genitive: "{0} Kilogramms"
+        other: "{0} Kilogramm"
+        other_accusative: "{0} Kilogramm"
+        other_dative: "{0} Kilogramm"
+        other_genitive: "{0} Kilogramm"
+        gender: neuter
+        per_unit_pattern: "{0} pro Kilogramm"
+    gram:
+      long:
+        one: "{0} Gramm"
+        one_accusative: "{0} Gramm"
+        one_dative: "{0} Gramm"
+        one_genitive: "{0} Gramms"
+        other: "{0} Gramm"
+        other_accusative: "{0} Gramm"
+        other_dative: "{0} Gramm"
+        other_genitive: "{0} Gramm"
+        gender: neuter
+        per_unit_pattern: "{0} pro Gramm"
+      short:
+        display_name: Gramm
+    milligram:
+      long:
+        display_name: Milligramm
+        one: "{0} Milligramm"
+        one_accusative: "{0} Milligramm"
+        one_dative: "{0} Milligramm"
+        one_genitive: "{0} Milligramms"
+        other: "{0} Milligramm"
+        other_accusative: "{0} Milligramm"
+        other_dative: "{0} Milligramm"
+        other_genitive: "{0} Milligramm"
+        gender: neuter
+    microgram:
+      long:
+        display_name: Mikrogramm
+        one: "{0} Mikrogramm"
+        one_accusative: "{0} Mikrogramm"
+        one_dative: "{0} Mikrogramm"
+        one_genitive: "{0} Mikrogramms"
+        other: "{0} Mikrogramm"
+        other_accusative: "{0} Mikrogramm"
+        other_dative: "{0} Mikrogramm"
+        other_genitive: "{0} Mikrogramm"
+        gender: neuter
+    ton:
+      long:
+        display_name: Short Tons
+        one: "{0} Short Ton"
+        other: "{0} Short Tons"
+      short:
+        display_name: tn. sh.
+        one: "{0} tn. sh."
+        other: "{0} tn. sh."
+      narrow:
+        display_name: Tons
+        one: "{0} tn"
+        other: "{0} tn"
+    stone:
+      long:
+        one: "{0} Stone"
+        other: "{0} Stones"
+      short:
+        display_name: Stones
+    pound:
+      long:
+        display_name: Pfund
+        one: "{0} Pfund"
+        one_accusative: "{0} Pfund"
+        one_dative: "{0} Pfund"
+        one_genitive: "{0} Pfunds"
+        other: "{0} Pfund"
+        other_accusative: "{0} Pfund"
+        other_dative: "{0} Pfund"
+        other_genitive: "{0} Pfund"
+        gender: neuter
+        per_unit_pattern: "{0} pro Pfund"
+      narrow:
+        display_name: Pfund
+    ounce:
+      long:
+        display_name: Unzen
+        one: "{0} Unze"
+        one_accusative: "{0} Unze"
+        one_dative: "{0} Unze"
+        one_genitive: "{0} Unze"
+        other: "{0} Unzen"
+        other_accusative: "{0} Unzen"
+        other_dative: "{0} Unzen"
+        other_genitive: "{0} Unzen"
+        gender: feminine
+        per_unit_pattern: "{0} pro Unze"
+      narrow:
+        display_name: Unzen
+    ounce-troy:
+      long:
+        display_name: Feinunzen
+        one: "{0} Feinunze"
+        other: "{0} Feinunzen"
+      short:
+        display_name: oz.tr.
+        one: "{0} oz.tr."
+        other: "{0} oz.tr."
+      narrow:
+        one: "{0} oz.tr."
+        other: "{0} oz.tr."
+    carat:
+      long:
+        display_name: Karat
+        one: "{0} Karat"
+        one_accusative: "{0} Karat"
+        one_dative: "{0} Karat"
+        one_genitive: "{0} Karats"
+        other: "{0} Karat"
+        other_accusative: "{0} Karat"
+        other_dative: "{0} Karat"
+        other_genitive: "{0} Karat"
+        gender: neuter
+      short:
+        display_name: Kt
+        one: "{0} Kt"
+        other: "{0} Kt"
+      narrow:
+        display_name: Karat
+    dalton:
+      long:
+        display_name: Dalton
+        one: "{0} Dalton"
+        one_accusative: "{0} Dalton"
+        one_dative: "{0} Dalton"
+        one_genitive: "{0} Dalton"
+        other: "{0} Dalton"
+        other_accusative: "{0} Dalton"
+        other_dative: "{0} Dalton"
+        other_genitive: "{0} Dalton"
+        gender: neuter
+    earth-mass:
+      long:
+        display_name: Erdmassen
+        one: "{0} Erdmasse"
+        one_accusative: "{0} Erdmasse"
+        one_dative: "{0} Erdmasse"
+        one_genitive: "{0} Erdmasse"
+        other: "{0} Erdmassen"
+        other_accusative: "{0} Erdmassen"
+        other_dative: "{0} Erdmassen"
+        other_genitive: "{0} Erdmassen"
+        gender: feminine
+    solar-mass:
+      long:
+        display_name: Sonnenmassen
+        one: "{0} Sonnenmasse"
+        one_accusative: "{0} Sonnenmasse"
+        one_dative: "{0} Sonnenmasse"
+        one_genitive: "{0} Sonnenmasse"
+        other: "{0} Sonnenmassen"
+        other_accusative: "{0} Sonnenmassen"
+        other_dative: "{0} Sonnenmassen"
+        other_genitive: "{0} Sonnenmassen"
+        gender: feminine
+    grain:
+      long:
+        one: "{0} Gran"
+        one_accusative: "{0} Gran"
+        one_dative: "{0} Gran"
+        one_genitive: "{0} Grans"
+        other: "{0} Gran"
+        other_accusative: "{0} Gran"
+        other_dative: "{0} Gran"
+        other_genitive: "{0} Gran"
+        gender: neuter
+      short:
+        display_name: Gran
+        one: "{0} gr"
+        other: "{0} gr"
+      narrow:
+        display_name: gr
+    gigawatt:
+      long:
+        display_name: Gigawatt
+        one: "{0} Gigawatt"
+        one_accusative: "{0} Gigawatt"
+        one_dative: "{0} Gigawatt"
+        one_genitive: "{0} Gigawatts"
+        other: "{0} Gigawatt"
+        other_accusative: "{0} Gigawatt"
+        other_dative: "{0} Gigawatt"
+        other_genitive: "{0} Gigawatt"
+        gender: neuter
+    megawatt:
+      long:
+        display_name: Megawatt
+        one: "{0} Megawatt"
+        one_accusative: "{0} Megawatt"
+        one_dative: "{0} Megawatt"
+        one_genitive: "{0} Megawatts"
+        other: "{0} Megawatt"
+        other_accusative: "{0} Megawatt"
+        other_dative: "{0} Megawatt"
+        other_genitive: "{0} Megawatt"
+        gender: neuter
+    kilowatt:
+      long:
+        display_name: Kilowatt
+        one: "{0} Kilowatt"
+        one_accusative: "{0} Kilowatt"
+        one_dative: "{0} Kilowatt"
+        one_genitive: "{0} Kilowatts"
+        other: "{0} Kilowatt"
+        other_accusative: "{0} Kilowatt"
+        other_dative: "{0} Kilowatt"
+        other_genitive: "{0} Kilowatt"
+        gender: neuter
+    watt:
+      long:
+        one: "{0} Watt"
+        one_accusative: "{0} Watt"
+        one_dative: "{0} Watt"
+        one_genitive: "{0} Watts"
+        other: "{0} Watt"
+        other_accusative: "{0} Watt"
+        other_dative: "{0} Watt"
+        other_genitive: "{0} Watt"
+        gender: neuter
+      short:
+        display_name: Watt
+      narrow:
+        display_name: W
+    milliwatt:
+      long:
+        display_name: Milliwatt
+        one: "{0} Milliwatt"
+        one_accusative: "{0} Milliwatt"
+        one_dative: "{0} Milliwatt"
+        one_genitive: "{0} Milliwatts"
+        other: "{0} Milliwatt"
+        other_accusative: "{0} Milliwatt"
+        other_dative: "{0} Milliwatt"
+        other_genitive: "{0} Milliwatt"
+        gender: neuter
+    horsepower:
+      long:
+        display_name: Pferdestärke
+        one: "{0} Pferdestärke"
+        other: "{0} Pferdestärken"
+      short:
+        display_name: PS
+        one: "{0} PS"
+        other: "{0} PS"
+    millimeter-ofhg:
+      long:
+        display_name: Millimeter Quecksilbersäule
+        one: "{0} Millimeter Quecksilbersäule"
+        one_accusative: "{0} Millimeter Quecksilbersäule"
+        one_dative: "{0} Millimeter Quecksilbersäule"
+        one_genitive: "{0} Millimeter Quecksilbersäule"
+        other: "{0} Millimeter Quecksilbersäule"
+        other_accusative: "{0} Millimeter Quecksilbersäule"
+        other_dative: "{0} Millimeter Quecksilbersäule"
+        other_genitive: "{0} Millimeter Quecksilbersäule"
+        gender: masculine
+    pound-force-per-square-inch:
+      long:
+        display_name: Pfund pro Quadratzoll
+        one: "{0} Pfund pro Quadratzoll"
+        other: "{0} Pfund pro Quadratzoll"
+    inch-ofhg:
+      long:
+        display_name: Zoll Quecksilbersäule
+        one: "{0} Zoll Quecksilbersäule"
+        other: "{0} Zoll Quecksilbersäule"
+    bar:
+      long:
+        display_name: Bar
+        one: "{0} Bar"
+        one_accusative: "{0} Bar"
+        one_dative: "{0} Bar"
+        one_genitive: "{0} Bars"
+        other: "{0} Bar"
+        other_accusative: "{0} Bar"
+        other_dative: "{0} Bar"
+        other_genitive: "{0} Bar"
+        gender: neuter
+    millibar:
+      long:
+        one: "{0} Millibar"
+        one_accusative: "{0} Millibar"
+        one_dative: "{0} Millibar"
+        one_genitive: "{0} Millibars"
+        other: "{0} Millibar"
+        other_accusative: "{0} Millibar"
+        other_dative: "{0} Millibar"
+        other_genitive: "{0} Millibar"
+        gender: neuter
+      short:
+        display_name: Millibar
+    atmosphere:
+      long:
+        display_name: Atmosphären
+        one: "{0} Atmosphäre"
+        one_accusative: "{0} Atmosphäre"
+        one_dative: "{0} Atmosphäre"
+        one_genitive: "{0} Atmosphäre"
+        other: "{0} Atmosphären"
+        other_accusative: "{0} Atmosphären"
+        other_dative: "{0} Atmosphären"
+        other_genitive: "{0} Atmosphären"
+        gender: feminine
+    pascal:
+      long:
+        display_name: Pascal
+        one: "{0} Pascal"
+        one_accusative: "{0} Pascal"
+        one_dative: "{0} Pascal"
+        one_genitive: "{0} Pascals"
+        other: "{0} Pascal"
+        other_accusative: "{0} Pascal"
+        other_dative: "{0} Pascal"
+        other_genitive: "{0} Pascal"
+        gender: neuter
+    hectopascal:
+      long:
+        display_name: Hektopascal
+        one: "{0} Hektopascal"
+        one_accusative: "{0} Hektopascal"
+        one_dative: "{0} Hektopascal"
+        one_genitive: "{0} Hektopascals"
+        other: "{0} Hektopascal"
+        other_accusative: "{0} Hektopascal"
+        other_dative: "{0} Hektopascal"
+        other_genitive: "{0} Hektopascal"
+        gender: neuter
+    kilopascal:
+      long:
+        display_name: Kilopascal
+        one: "{0} Kilopascal"
+        one_accusative: "{0} Kilopascal"
+        one_dative: "{0} Kilopascal"
+        one_genitive: "{0} Kilopascals"
+        other: "{0} Kilopascal"
+        other_accusative: "{0} Kilopascal"
+        other_dative: "{0} Kilopascal"
+        other_genitive: "{0} Kilopascal"
+        gender: neuter
+    megapascal:
+      long:
+        display_name: Megapascal
+        one: "{0} Megapascal"
+        one_accusative: "{0} Megapascal"
+        one_dative: "{0} Megapascal"
+        one_genitive: "{0} Megapascals"
+        other: "{0} Megapascal"
+        other_accusative: "{0} Megapascal"
+        other_dative: "{0} Megapascal"
+        other_genitive: "{0} Megapascal"
+        gender: neuter
+    kilometer-per-hour:
+      long:
+        display_name: Kilometer pro Stunde
+        one: "{0} Kilometer pro Stunde"
+        one_accusative: "{0} Kilometer pro Stunde"
+        one_dative: "{0} Kilometer pro Stunde"
+        one_genitive: "{0} Kilometers pro Stunde"
+        other: "{0} Kilometer pro Stunde"
+        other_accusative: "{0} Kilometer pro Stunde"
+        other_dative: "{0} Kilometern pro Stunde"
+        other_genitive: "{0} Kilometer pro Stunde"
+        gender: masculine
+    meter-per-second:
+      long:
+        display_name: Meter pro Sekunde
+        one: "{0} Meter pro Sekunde"
+        one_accusative: "{0} Meter pro Sekunde"
+        one_dative: "{0} Meter pro Sekunde"
+        one_genitive: "{0} Meters pro Sekunde"
+        other: "{0} Meter pro Sekunde"
+        other_accusative: "{0} Meter pro Sekunde"
+        other_dative: "{0} Metern pro Sekunde"
+        other_genitive: "{0} Meter pro Sekunde"
+        gender: masculine
+    mile-per-hour:
+      long:
+        display_name: Meilen pro Stunde
+        one: "{0} Meile pro Stunde"
+        one_accusative: "{0} Meile pro Stunde"
+        one_dative: "{0} Meile pro Stunde"
+        one_genitive: "{0} Meile pro Stunde"
+        other: "{0} Meilen pro Stunde"
+        other_accusative: "{0} Meilen pro Stunde"
+        other_dative: "{0} Meilen pro Stunde"
+        other_genitive: "{0} Meilen pro Stunde"
+        gender: feminine
+    knot:
+      long:
+        display_name: Knoten
+        one: "{0} Knoten"
+        other: "{0} Knoten"
+    beaufort:
+      long:
+        display_name: Beaufort
+        one: Beaufort {0}
+        one_accusative: Beaufort {0}
+        one_dative: Beaufort {0}
+        one_genitive: Beaufort {0}
+        other: Beaufort {0}
+        other_accusative: Beaufort {0}
+        other_dative: Beaufort {0}
+        other_genitive: Beaufort {0}
+        gender: neuter
+    generic:
+      long:
+        one: "{0} Grad"
+        one_accusative: "{0} Grad"
+        one_dative: "{0} Grad"
+        one_genitive: "{0} Grads"
+        other: "{0} Grad"
+        other_accusative: "{0} Grad"
+        other_dative: "{0} Grad"
+        other_genitive: "{0} Grad"
+        gender: neuter
+    celsius:
+      long:
+        display_name: Grad Celsius
+        one: "{0} Grad Celsius"
+        one_accusative: "{0} Grad Celsius"
+        one_dative: "{0} Grad Celsius"
+        one_genitive: "{0} Grads Celsius"
+        other: "{0} Grad Celsius"
+        other_accusative: "{0} Grad Celsius"
+        other_dative: "{0} Grad Celsius"
+        other_genitive: "{0} Grad Celsius"
+        gender: neuter
+      short:
+        one: "{0} °C"
+        other: "{0} °C"
+    fahrenheit:
+      long:
+        display_name: Grad Fahrenheit
+        one: "{0} Grad Fahrenheit"
+        one_accusative: "{0} Grad Fahrenheit"
+        one_dative: "{0} Grad Fahrenheit"
+        one_genitive: "{0} Grads Fahrenheit"
+        other: "{0} Grad Fahrenheit"
+        other_accusative: "{0} Grad Fahrenheit"
+        other_dative: "{0} Grad Fahrenheit"
+        other_genitive: "{0} Grad Fahrenheit"
+        gender: neuter
+      short:
+        one: "{0} °F"
+        other: "{0} °F"
+      narrow:
+        one: "{0}°F"
+        other: "{0}°F"
+    kelvin:
+      long:
+        display_name: Kelvin
+        one: "{0} Kelvin"
+        one_accusative: "{0} Kelvin"
+        one_dative: "{0} Kelvin"
+        one_genitive: "{0} Kelvins"
+        other: "{0} Kelvin"
+        other_accusative: "{0} Kelvin"
+        other_dative: "{0} Kelvin"
+        other_genitive: "{0} Kelvin"
+        gender: neuter
+    pound-force-foot:
+      long:
+        display_name: Foot-pound
+        one: "{0} Foot-pound"
+        other: "{0} Foot-pound"
+      narrow:
+        one: "{0}lbf⋅ft"
+        other: "{0}lbf⋅ft"
+    newton-meter:
+      long:
+        display_name: Newtonmeter
+        one: "{0} Newtonmeter"
+        one_accusative: "{0} Newtonmeter"
+        one_dative: "{0} Newtonmeter"
+        one_genitive: "{0} Newtonmeters"
+        other: "{0} Newtonmeter"
+        other_accusative: "{0} Newtonmeter"
+        other_dative: "{0} Newtonmetern"
+        other_genitive: "{0} Newtonmeter"
+        gender: masculine
+      narrow:
+        one: "{0}N⋅m"
+        other: "{0}N⋅m"
+    cubic-kilometer:
+      long:
+        display_name: Kubikkilometer
+        one: "{0} Kubikkilometer"
+        one_accusative: "{0} Kubikkilometer"
+        one_dative: "{0} Kubikkilometer"
+        one_genitive: "{0} Kubikkilometers"
+        other: "{0} Kubikkilometer"
+        other_accusative: "{0} Kubikkilometer"
+        other_dative: "{0} Kubikkilometern"
+        other_genitive: "{0} Kubikkilometer"
+        gender: masculine
+    cubic-meter:
+      long:
+        display_name: Kubikmeter
+        one: "{0} Kubikmeter"
+        one_accusative: "{0} Kubikmeter"
+        one_dative: "{0} Kubikmeter"
+        one_genitive: "{0} Kubikmeters"
+        other: "{0} Kubikmeter"
+        other_accusative: "{0} Kubikmeter"
+        other_dative: "{0} Kubikmetern"
+        other_genitive: "{0} Kubikmeter"
+        gender: masculine
+        per_unit_pattern: "{0} pro Kubikmeter"
+    cubic-centimeter:
+      long:
+        display_name: Kubikzentimeter
+        one: "{0} Kubikzentimeter"
+        one_accusative: "{0} Kubikzentimeter"
+        one_dative: "{0} Kubikzentimeter"
+        one_genitive: "{0} Kubikzentimeters"
+        other: "{0} Kubikzentimeter"
+        other_accusative: "{0} Kubikzentimeter"
+        other_dative: "{0} Kubikzentimetern"
+        other_genitive: "{0} Kubikzentimeter"
+        gender: masculine
+        per_unit_pattern: "{0} pro Kubikzentimeter"
+    cubic-mile:
+      long:
+        display_name: Kubikmeilen
+        one: "{0} Kubikmeile"
+        one_accusative: "{0} Kubikmeile"
+        one_dative: "{0} Kubikmeile"
+        one_genitive: "{0} Kubikmeile"
+        other: "{0} Kubikmeilen"
+        other_accusative: "{0} Kubikmeilen"
+        other_dative: "{0} Kubikmeilen"
+        other_genitive: "{0} Kubikmeilen"
+        gender: feminine
+    cubic-yard:
+      long:
+        display_name: Kubikyards
+        one: "{0} Kubikyard"
+        other: "{0} Kubikyards"
+    cubic-foot:
+      long:
+        display_name: Kubikfuß
+        one: "{0} Kubikfuß"
+        one_accusative: "{0} Kubikfuß"
+        one_dative: "{0} Kubikfuß"
+        one_genitive: "{0} Kubikfußes"
+        other: "{0} Kubikfuß"
+        other_accusative: "{0} Kubikfuß"
+        other_dative: "{0} Kubikfuß"
+        other_genitive: "{0} Kubikfuß"
+        gender: masculine
+    cubic-inch:
+      long:
+        display_name: Kubikzoll
+        one: "{0} Kubikzoll"
+        other: "{0} Kubikzoll"
+    megaliter:
+      long:
+        display_name: Megaliter
+        one: "{0} Megaliter"
+        one_accusative: "{0} Megaliter"
+        one_dative: "{0} Megaliter"
+        one_genitive: "{0} Megaliters"
+        other: "{0} Megaliter"
+        other_accusative: "{0} Megaliter"
+        other_dative: "{0} Megalitern"
+        other_genitive: "{0} Megaliter"
+        gender: masculine
+      short:
+        display_name: Ml
+        one: "{0} Ml"
+        other: "{0} Ml"
+    hectoliter:
+      long:
+        display_name: Hektoliter
+        one: "{0} Hektoliter"
+        one_accusative: "{0} Hektoliter"
+        one_dative: "{0} Hektoliter"
+        one_genitive: "{0} Hektoliters"
+        other: "{0} Hektoliter"
+        other_accusative: "{0} Hektoliter"
+        other_dative: "{0} Hektolitern"
+        other_genitive: "{0} Hektoliter"
+        gender: masculine
+      short:
+        display_name: hl
+        one: "{0} hl"
+        other: "{0} hl"
+    liter:
+      long:
+        one: "{0} Liter"
+        one_accusative: "{0} Liter"
+        one_dative: "{0} Liter"
+        one_genitive: "{0} Liters"
+        other: "{0} Liter"
+        other_accusative: "{0} Liter"
+        other_dative: "{0} Litern"
+        other_genitive: "{0} Liter"
+        gender: masculine
+        per_unit_pattern: "{0} pro Liter"
+      short:
+        display_name: Liter
+      narrow:
+        display_name: l
+    deciliter:
+      long:
+        display_name: Deziliter
+        one: "{0} Deziliter"
+        one_accusative: "{0} Deziliter"
+        one_dative: "{0} Deziliter"
+        one_genitive: "{0} Deziliters"
+        other: "{0} Deziliter"
+        other_accusative: "{0} Deziliter"
+        other_dative: "{0} Dezilitern"
+        other_genitive: "{0} Deziliter"
+        gender: masculine
+      short:
+        display_name: dl
+        one: "{0} dl"
+        other: "{0} dl"
+    centiliter:
+      long:
+        display_name: Zentiliter
+        one: "{0} Zentiliter"
+        one_accusative: "{0} Zentiliter"
+        one_dative: "{0} Zentiliter"
+        one_genitive: "{0} Zentiliters"
+        other: "{0} Zentiliter"
+        other_accusative: "{0} Zentiliter"
+        other_dative: "{0} Zentilitern"
+        other_genitive: "{0} Zentiliter"
+        gender: masculine
+      short:
+        display_name: cl
+        one: "{0} cl"
+        other: "{0} cl"
+    milliliter:
+      long:
+        display_name: Milliliter
+        one: "{0} Milliliter"
+        one_accusative: "{0} Milliliter"
+        one_dative: "{0} Milliliter"
+        one_genitive: "{0} Milliliters"
+        other: "{0} Milliliter"
+        other_accusative: "{0} Milliliter"
+        other_dative: "{0} Millilitern"
+        other_genitive: "{0} Milliliter"
+        gender: masculine
+      short:
+        display_name: ml
+        one: "{0} ml"
+        other: "{0} ml"
+    pint-metric:
+      long:
+        display_name: metrische Pints
+        one: "{0} metrisches Pint"
+        one_accusative: "{0} metrische Pint"
+        one_dative: "{0} metrischen Pint"
+        one_genitive: "{0} metrischen Pints"
+        other: "{0} metrische Pints"
+        other_accusative: "{0} metrischen Pints"
+        other_dative: "{0} metrischen Pints"
+        other_genitive: "{0} metrischen Pints"
+        gender: neuter
+    cup-metric:
+      long:
+        display_name: metrische Tassen
+        one: "{0} metrische Tasse"
+        one_accusative: "{0} metrische Tasse"
+        one_dative: "{0} metrischen Tasse"
+        one_genitive: "{0} metrischen Tasse"
+        other: "{0} metrische Tassen"
+        other_accusative: "{0} metrischen Tassen"
+        other_dative: "{0} metrischen Tassen"
+        other_genitive: "{0} metrischen Tassen"
+        gender: feminine
+      short:
+        display_name: Ta
+        one: "{0} Ta"
+        other: "{0} Ta"
+    acre-foot:
+      long:
+        one: "{0} Acre-Foot"
+        other: "{0} Acre-Feet"
+      short:
+        display_name: Acre-Feet
+      narrow:
+        display_name: ac ft
+    bushel:
+      long:
+        one: "{0} Bushel"
+        other: "{0} Bushel"
+      short:
+        display_name: Bushel
+    gallon:
+      long:
+        display_name: Gallone
+        one: "{0} Gallone"
+        one_accusative: "{0} Gallone"
+        one_dative: "{0} Gallone"
+        one_genitive: "{0} Gallone"
+        other: "{0} Gallonen"
+        other_accusative: "{0} Gallonen"
+        other_dative: "{0} Gallonen"
+        other_genitive: "{0} Gallonen"
+        gender: feminine
+        per_unit_pattern: "{0} pro Gallone"
+      short:
+        display_name: gal
+        one: "{0} gal"
+        other: "{0} gal"
+        per_unit_pattern: "{0}/gal"
+    gallon-imperial:
+      long:
+        display_name: Imp. Gallonen
+        one: "{0} Imp. Gallone"
+        one_accusative: "{0} Imp. Gallone"
+        one_dative: "{0} Imp. Gallone"
+        one_genitive: "{0} Imp. Gallone"
+        other: "{0} Imp. Gallonen"
+        other_accusative: "{0} Imp. Gallonen"
+        other_dative: "{0} Imp. Gallonen"
+        other_genitive: "{0} Imp. Gallonen"
+        gender: feminine
+        per_unit_pattern: "{0} pro Imp. Gallone"
+      short:
+        one: "{0} Imp. gal"
+        other: "{0} Imp. gal"
+        per_unit_pattern: "{0} pro Imp. gal"
+      narrow:
+        display_name: Imp.gal
+        one: "{0} Imp.gal"
+        other: "{0} Imp.gal"
+        per_unit_pattern: "{0}/Imp.gal"
+    quart:
+      long:
+        display_name: Quarts
+        one: "{0} Quart"
+        one_accusative: "{0} Quart"
+        one_dative: "{0} Quart"
+        one_genitive: "{0} Quart"
+        other: "{0} Quart"
+        other_accusative: "{0} Quart"
+        other_dative: "{0} Quart"
+        other_genitive: "{0} Quart"
+        gender: neuter
+    pint:
+      long:
+        display_name: Pints
+        one: "{0} Pint"
+        one_accusative: "{0} Pint"
+        one_dative: "{0} Pint"
+        one_genitive: "{0} Pints"
+        other: "{0} Pints"
+        other_accusative: "{0} Pints"
+        other_dative: "{0} Pints"
+        other_genitive: "{0} Pints"
+        gender: neuter
+    cup:
+      long:
+        display_name: Tassen
+        one: "{0} Tasse"
+        one_accusative: "{0} Tasse"
+        one_dative: "{0} Tasse"
+        one_genitive: "{0} Tasse"
+        other: "{0} Tassen"
+        other_accusative: "{0} Tassen"
+        other_dative: "{0} Tassen"
+        other_genitive: "{0} Tassen"
+        gender: feminine
+      short:
+        display_name: Cups
+        one: "{0} Cup"
+        other: "{0} Cups"
+    fluid-ounce:
+      long:
+        display_name: Flüssigunzen
+        one: "{0} Flüssigunze"
+        one_accusative: "{0} Flüssigunze"
+        one_dative: "{0} Flüssigunze"
+        one_genitive: "{0} Flüssigunze"
+        other: "{0} Flüssigunzen"
+        other_accusative: "{0} Flüssigunzen"
+        other_dative: "{0} Flüssigunzen"
+        other_genitive: "{0} Flüssigunzen"
+        gender: feminine
+      short:
+        display_name: fl oz
+        one: "{0} fl oz"
+        other: "{0} fl oz"
+    fluid-ounce-imperial:
+      long:
+        display_name: Imp. Flüssigunzen
+        one: "{0} Imp. Flüssigunze"
+        one_accusative: "{0} Imp. Flüssigunze"
+        one_dative: "{0} Imp. Flüssigunze"
+        one_genitive: "{0} Imp. Flüssigunze"
+        other: "{0} Imp. Flüssigunzen"
+        other_accusative: "{0} Imp. Flüssigunzen"
+        other_dative: "{0} Imp. Flüssigunzen"
+        other_genitive: "{0} Imp. Flüssigunzen"
+        gender: feminine
+      short:
+        display_name: Imp.fl.oz.
+        one: "{0} Imp.fl.oz."
+        other: "{0} Imp.fl.oz."
+      narrow:
+        display_name: Im.fl.oz
+        one: "{0} Im.fl.oz"
+        other: "{0} Im.fl.oz"
+    tablespoon:
+      long:
+        display_name: Esslöffel
+        one: "{0} Esslöffel"
+        one_accusative: "{0} Esslöffel"
+        one_dative: "{0} Esslöffel"
+        one_genitive: "{0} Esslöffels"
+        other: "{0} Esslöffel"
+        other_accusative: "{0} Esslöffel"
+        other_dative: "{0} Esslöffeln"
+        other_genitive: "{0} Esslöffel"
+        gender: masculine
+      short:
+        display_name: EL
+        one: "{0} EL"
+        other: "{0} EL"
+    teaspoon:
+      long:
+        display_name: Teelöffel
+        one: "{0} Teelöffel"
+        one_accusative: "{0} Teelöffel"
+        one_dative: "{0} Teelöffel"
+        one_genitive: "{0} Teelöffels"
+        other: "{0} Teelöffel"
+        other_accusative: "{0} Teelöffel"
+        other_dative: "{0} Teelöffeln"
+        other_genitive: "{0} Teelöffel"
+        gender: masculine
+      short:
+        display_name: TL
+        one: "{0} TL"
+        other: "{0} TL"
+    barrel:
+      long:
+        display_name: Barrel
+        one: "{0} Barrel"
+        other: "{0} Barrel"
+      narrow:
+        one: "{0}bbl"
+        other: "{0}bbl"
+    dessert-spoon:
+      long:
+        display_name: Dessertlöffel
+        one: "{0} Dessertlöffel"
+        one_accusative: "{0} Dessertlöffel"
+        one_dative: "{0} Dessertlöffel"
+        one_genitive: "{0} Dessertlöffels"
+        other: "{0} Dessertlöffel"
+        other_accusative: "{0} Dessertlöffel"
+        other_dative: "{0} Dessertlöffeln"
+        other_genitive: "{0} Dessertlöffel"
+        gender: masculine
+      short:
+        display_name: DL
+        one: "{0} DL"
+        other: "{0} DL"
+    dessert-spoon-imperial:
+      long:
+        display_name: Imp. Dessertlöffel
+        one: "{0} Imp. Dessertlöffel"
+        one_accusative: "{0} Imp. Dessertlöffel"
+        one_dative: "{0} Imp. Dessertlöffel"
+        one_genitive: "{0} Imp. Dessertlöffels"
+        other: "{0} Imp. Dessertlöffel"
+        other_accusative: "{0} Imp. Dessertlöffel"
+        other_dative: "{0} Imp. Dessertlöffeln"
+        other_genitive: "{0} Imp. Dessertlöffel"
+        gender: masculine
+      short:
+        display_name: Imp. DL
+        one: "{0} Imp. DL"
+        other: "{0} Imp. DL"
+      narrow:
+        one: "{0} Imp.DL"
+        other: "{0} Imp.DL"
+    drop:
+      long:
+        display_name: Tropfen
+        one: "{0} Tropfen"
+        one_accusative: "{0} Tropfen"
+        one_dative: "{0} Tropfen"
+        one_genitive: "{0} Tropfens"
+        other: "{0} Tropfen"
+        other_accusative: "{0} Tropfen"
+        other_dative: "{0} Tropfen"
+        other_genitive: "{0} Tropfen"
+        gender: masculine
+      short:
+        display_name: Trpf.
+        one: "{0} Trpf."
+        other: "{0} Trpf."
+      narrow:
+        display_name: Tr.
+        one: "{0} Tr."
+        other: "{0} Tr."
+    dram:
+      long:
+        display_name: Dram
+        one: "{0} Dram"
+        one_accusative: "{0} Dram"
+        one_dative: "{0} Dram"
+        one_genitive: "{0} Dram"
+        other: "{0} Dram"
+        other_accusative: "{0} Dram"
+        other_dative: "{0} Dram"
+        other_genitive: "{0} Dram"
+        gender: neuter
+      short:
+        display_name: Flüssigdram
+        one: "{0} Fl.-Dram"
+        other: "{0} Fl.-Dram"
+      narrow:
+        display_name: fl.dr.
+        one: "{0} fl.dr."
+        other: "{0} fl.dr."
+    jigger:
+      long:
+        one: "{0} Jigger"
+        one_accusative: "{0} Jigger"
+        one_dative: "{0} Jigger"
+        one_genitive: "{0} Jiggers"
+        other: "{0} Jigger"
+        other_accusative: "{0} Jigger"
+        other_dative: "{0} Jigger"
+        other_genitive: "{0} Jigger"
+        gender: masculine
+      short:
+        display_name: Jigger
+        one: "{0} Jigger"
+        other: "{0} Jigger"
+    pinch:
+      long:
+        one: "{0} Prise"
+        one_accusative: "{0} Prise"
+        one_dative: "{0} Prise"
+        one_genitive: "{0} Prise"
+        other: "{0} Prisen"
+        other_accusative: "{0} Prisen"
+        other_dative: "{0} Prisen"
+        other_genitive: "{0} Prisen"
+        gender: feminine
+      short:
+        display_name: Prise
+        one: "{0} Pr."
+        other: "{0} Pr."
+      narrow:
+        display_name: Pr.
+        one: "{0} Pr"
+        other: "{0} Pr"
+    quart-imperial:
+      long:
+        display_name: Imp. Quart
+        one: "{0} Imp. Quart"
+        one_accusative: "{0} Imp. Quart"
+        one_dative: "{0} Imp. Quart"
+        one_genitive: "{0} Imp. Quart"
+        other: "{0} Imp. Quart"
+        other_accusative: "{0} Imp. Quart"
+        other_dative: "{0} Imp. Quart"
+        other_genitive: "{0} Imp. Quart"
+        gender: neuter
+      short:
+        display_name: Imp.qt.
+        one: "{0} Imp.qt."
+        other: "{0} Imp.qt."
+      narrow:
+        display_name: Imp.qt
+        one: "{0} Imp.qt"
+        other: "{0} Imp.qt"
+    portion-per-1e9:
+      long:
+        display_name: Milliardstel
+        one: "{0} Milliardstel"
+        one_accusative: "{0} Milliardstel"
+        one_dative: "{0} Milliardstel"
+        one_genitive: "{0} Milliardstels"
+        other: "{0} Milliardstel"
+        other_accusative: "{0} Milliardstel"
+        other_dative: "{0} Milliardsteln"
+        other_genitive: "{0} Milliardstel"
+        gender: neuter
+      short:
+        display_name: Milliardstel
+        one: "{0} Milliardstel"
+        other: "{0} Milliardstel"
+    night:
+      long:
+        display_name: Übernachtungen
+        one: "{0} Übernachtung"
+        one_accusative: "{0} Übernachtung"
+        one_dative: "{0} Übernachtung"
+        one_genitive: "{0} Übernachtung"
+        other: "{0} Übernachtungen"
+        other_accusative: "{0} Übernachtungen"
+        other_dative: "{0} Übernachtungen"
+        other_genitive: "{0} Übernachtungen"
+        gender: feminine
+        per_unit_pattern: "{0} pro Übernachtung"
+      short:
+        display_name: Nächte
+        one: "{0} Nacht"
+        other: "{0} Nächte"
+        per_unit_pattern: "{0}/Nacht"
+      narrow:
+        display_name: Nächte
+        one: "{0}Nacht"
+        other: "{0}Nächte"
+        per_unit_pattern: "{0}/Nacht"

--- a/data/cldr/en/number_formats.yml
+++ b/data/cldr/en/number_formats.yml
@@ -1,6 +1,6 @@
 ---
 locale: en
-generated_at: '2025-09-14T02:07:25Z'
+generated_at: '2025-09-14T05:39:04Z'
 cldr_version: '46'
 number_formats:
   currency_formats:
@@ -1303,3 +1303,2283 @@ number_formats:
       display_names:
         other: Zimbabwean dollars (2008)
         one: Zimbabwean dollar (2008)
+  units:
+    g-force:
+      long:
+        display_name: g-force
+        one: "{0} g-force"
+        other: "{0} g-force"
+      short:
+        one: "{0} G"
+      narrow:
+        display_name: g-force
+        one: "{0}G"
+        other: "{0}Gs"
+    meter-per-square-second:
+      long:
+        display_name: meters per second squared
+        one: "{0} meter per second squared"
+        other: "{0} meters per second squared"
+      short:
+        display_name: meters/sec²
+        one: "{0} m/s²"
+      narrow:
+        display_name: m/s²
+        one: "{0}m/s²"
+        other: "{0}m/s²"
+    revolution:
+      long:
+        display_name: revolutions
+        one: "{0} revolution"
+        other: "{0} revolutions"
+      short:
+        one: "{0} rev"
+      narrow:
+        display_name: rev
+        one: "{0}rev"
+        other: "{0}rev"
+    radian:
+      long:
+        display_name: radians
+        one: "{0} radian"
+        other: "{0} radians"
+      short:
+        display_name: radians
+        one: "{0} rad"
+      narrow:
+        display_name: rad
+        one: "{0}rad"
+        other: "{0}rad"
+    degree:
+      long:
+        display_name: degrees
+        one: "{0} degree"
+        other: "{0} degrees"
+      short:
+        display_name: degrees
+        one: "{0} deg"
+        other: "{0} deg"
+      narrow:
+        display_name: deg
+        one: "{0}°"
+        other: "{0}°"
+    arc-minute:
+      long:
+        display_name: arcminutes
+        one: "{0} arcminute"
+        other: "{0} arcminutes"
+      short:
+        display_name: arcmins
+        one: "{0} arcmin"
+        other: "{0} arcmins"
+      narrow:
+        display_name: arcmin
+        one: "{0}′"
+        other: "{0}′"
+    arc-second:
+      long:
+        display_name: arcseconds
+        one: "{0} arcsecond"
+        other: "{0} arcseconds"
+      short:
+        display_name: arcsecs
+        one: "{0} arcsec"
+        other: "{0} arcsecs"
+      narrow:
+        display_name: arcsec
+        one: "{0}″"
+        other: "{0}″"
+    square-kilometer:
+      long:
+        display_name: square kilometers
+        one: "{0} square kilometer"
+        other: "{0} square kilometers"
+        per_unit_pattern: "{0} per square kilometer"
+      short:
+        one: "{0} km²"
+      narrow:
+        display_name: km²
+        one: "{0}km²"
+        other: "{0}km²"
+        per_unit_pattern: "{0}/km²"
+    hectare:
+      long:
+        display_name: hectares
+        one: "{0} hectare"
+        other: "{0} hectares"
+      short:
+        display_name: hectares
+        one: "{0} ha"
+      narrow:
+        display_name: hectare
+        one: "{0}ha"
+        other: "{0}ha"
+    square-meter:
+      long:
+        display_name: square meters
+        one: "{0} square meter"
+        other: "{0} square meters"
+        per_unit_pattern: "{0} per square meter"
+      short:
+        display_name: meters²
+        one: "{0} m²"
+      narrow:
+        display_name: meters²
+        one: "{0}m²"
+        other: "{0}m²"
+        per_unit_pattern: "{0}/m²"
+    square-centimeter:
+      long:
+        display_name: square centimeters
+        one: "{0} square centimeter"
+        other: "{0} square centimeters"
+        per_unit_pattern: "{0} per square centimeter"
+      short:
+        one: "{0} cm²"
+      narrow:
+        display_name: cm²
+        one: "{0}cm²"
+        other: "{0}cm²"
+        per_unit_pattern: "{0}/cm²"
+    square-mile:
+      long:
+        display_name: square miles
+        one: "{0} square mile"
+        other: "{0} square miles"
+        per_unit_pattern: "{0} per square mile"
+      short:
+        display_name: sq miles
+        one: "{0} sq mi"
+        other: "{0} sq mi"
+      narrow:
+        display_name: mi²
+        one: "{0}mi²"
+        other: "{0}mi²"
+        per_unit_pattern: "{0}/mi²"
+    acre:
+      long:
+        display_name: acres
+        one: "{0} acre"
+        other: "{0} acres"
+      short:
+        display_name: acres
+        one: "{0} ac"
+      narrow:
+        display_name: acre
+        one: "{0}ac"
+        other: "{0}ac"
+    square-yard:
+      long:
+        display_name: square yards
+        one: "{0} square yard"
+        other: "{0} square yards"
+      short:
+        display_name: yards²
+        one: "{0} yd²"
+      narrow:
+        display_name: yd²
+        one: "{0}yd²"
+        other: "{0}yd²"
+    square-foot:
+      long:
+        display_name: square feet
+        one: "{0} square foot"
+        other: "{0} square feet"
+      short:
+        display_name: sq feet
+        one: "{0} sq ft"
+        other: "{0} sq ft"
+      narrow:
+        display_name: ft²
+        one: "{0}ft²"
+        other: "{0}ft²"
+    square-inch:
+      long:
+        display_name: square inches
+        one: "{0} square inch"
+        other: "{0} square inches"
+        per_unit_pattern: "{0} per square inch"
+      short:
+        display_name: inches²
+        one: "{0} in²"
+      narrow:
+        display_name: in²
+        one: "{0}in²"
+        other: "{0}in²"
+        per_unit_pattern: "{0}/in²"
+    dunam:
+      long:
+        display_name: dunams
+        one: "{0} dunam"
+        other: "{0} dunams"
+      short:
+        display_name: dunams
+        one: "{0} dunam"
+      narrow:
+        display_name: dunam
+        one: "{0}dunam"
+        other: "{0}dunam"
+    karat:
+      long:
+        display_name: karats
+        one: "{0} karat"
+        other: "{0} karats"
+      short:
+        display_name: karats
+        one: "{0} kt"
+      narrow:
+        display_name: karat
+        one: "{0}kt"
+        other: "{0}kt"
+    milligram-ofglucose-per-deciliter:
+      long:
+        display_name: milligrams per deciliter
+        one: "{0} milligram per deciliter"
+        other: "{0} milligrams per deciliter"
+      short:
+        one: "{0} mg/dL"
+      narrow:
+        display_name: mg/dL
+        one: "{0}mg/dL"
+        other: "{0}mg/dL"
+    millimole-per-liter:
+      long:
+        display_name: millimoles per liter
+        one: "{0} millimole per liter"
+        other: "{0} millimoles per liter"
+      short:
+        display_name: millimol/liter
+        one: "{0} mmol/L"
+      narrow:
+        display_name: mmol/L
+        one: "{0}mmol/L"
+        other: "{0}mmol/L"
+    item:
+      long:
+        display_name: items
+        one: "{0} item"
+        other: "{0} items"
+      short:
+        one: "{0} item"
+        other: "{0} items"
+      narrow:
+        display_name: item
+        one: "{0}item"
+        other: "{0}items"
+    permillion:
+      long:
+        display_name: parts per million
+        one: "{0} part per million"
+        other: "{0} parts per million"
+      short:
+        display_name: parts/million
+        one: "{0} ppm"
+      narrow:
+        display_name: ppm
+        one: "{0}ppm"
+        other: "{0}ppm"
+    percent:
+      long:
+        display_name: percent
+        one: "{0} percent"
+        other: "{0} percent"
+      short:
+        display_name: percent
+        one: "{0}%"
+      narrow:
+        display_name: "%"
+        one: "{0}%"
+        other: "{0}%"
+    permille:
+      long:
+        display_name: permille
+        one: "{0} permille"
+        other: "{0} permille"
+      short:
+        display_name: permille
+        one: "{0}‰"
+      narrow:
+        display_name: "‰"
+        one: "{0}‰"
+        other: "{0}‰"
+    permyriad:
+      long:
+        display_name: permyriad
+        one: "{0} permyriad"
+        other: "{0} permyriad"
+      short:
+        display_name: permyriad
+        one: "{0}‱"
+      narrow:
+        display_name: "‱"
+        one: "{0}‱"
+        other: "{0}‱"
+    mole:
+      long:
+        display_name: moles
+        one: "{0} mole"
+        other: "{0} moles"
+      short:
+        display_name: mole
+        one: "{0} mol"
+      narrow:
+        display_name: mol
+        one: "{0}mol"
+        other: "{0}mol"
+    liter-per-kilometer:
+      long:
+        display_name: liters per kilometer
+        one: "{0} liter per kilometer"
+        other: "{0} liters per kilometer"
+      short:
+        display_name: liters/km
+        one: "{0} L/km"
+      narrow:
+        display_name: L/km
+        one: "{0}L/km"
+        other: "{0}L/km"
+    liter-per-100-kilometer:
+      long:
+        display_name: liters per 100 kilometers
+        one: "{0} liter per 100 kilometers"
+        other: "{0} liters per 100 kilometers"
+      short:
+        display_name: L/100 km
+        one: "{0} L/100 km"
+        other: "{0} L/100 km"
+      narrow:
+        display_name: L/100km
+        one: "{0}L/100km"
+        other: "{0}L/100km"
+    mile-per-gallon:
+      long:
+        display_name: miles per gallon
+        one: "{0} mile per gallon"
+        other: "{0} miles per gallon"
+      short:
+        display_name: miles/gal
+        one: "{0} mpg"
+        other: "{0} mpg"
+      narrow:
+        display_name: mpg
+        one: "{0}mpg"
+        other: "{0}mpg"
+    mile-per-gallon-imperial:
+      long:
+        display_name: miles per Imp. gallon
+        one: "{0} mile per Imp. gallon"
+        other: "{0} miles per Imp. gallon"
+      short:
+        display_name: miles/gal Imp.
+        one: "{0} mpg Imp."
+      narrow:
+        display_name: mpg UK
+        one: "{0}m/gUK"
+        other: "{0}m/gUK"
+    petabyte:
+      long:
+        display_name: petabytes
+        one: "{0} petabyte"
+        other: "{0} petabytes"
+      short:
+        display_name: PByte
+        one: "{0} PB"
+      narrow:
+        display_name: PB
+        one: "{0}PB"
+        other: "{0}PB"
+    terabyte:
+      long:
+        display_name: terabytes
+        one: "{0} terabyte"
+        other: "{0} terabytes"
+      short:
+        display_name: TByte
+        one: "{0} TB"
+      narrow:
+        display_name: TB
+        one: "{0}TB"
+        other: "{0}TB"
+    terabit:
+      long:
+        display_name: terabits
+        one: "{0} terabit"
+        other: "{0} terabits"
+      short:
+        display_name: Tbit
+        one: "{0} Tb"
+      narrow:
+        display_name: Tb
+        one: "{0}Tb"
+        other: "{0}Tb"
+    gigabyte:
+      long:
+        display_name: gigabytes
+        one: "{0} gigabyte"
+        other: "{0} gigabytes"
+      short:
+        display_name: GByte
+        one: "{0} GB"
+      narrow:
+        display_name: GB
+        one: "{0}GB"
+        other: "{0}GB"
+    gigabit:
+      long:
+        display_name: gigabits
+        one: "{0} gigabit"
+        other: "{0} gigabits"
+      short:
+        display_name: Gbit
+        one: "{0} Gb"
+      narrow:
+        display_name: Gb
+        one: "{0}Gb"
+        other: "{0}Gb"
+    megabyte:
+      long:
+        display_name: megabytes
+        one: "{0} megabyte"
+        other: "{0} megabytes"
+      short:
+        display_name: MByte
+        one: "{0} MB"
+      narrow:
+        display_name: MB
+        one: "{0}MB"
+        other: "{0}MB"
+    megabit:
+      long:
+        display_name: megabits
+        one: "{0} megabit"
+        other: "{0} megabits"
+      short:
+        display_name: Mbit
+        one: "{0} Mb"
+      narrow:
+        display_name: Mb
+        one: "{0}Mb"
+        other: "{0}Mb"
+    kilobyte:
+      long:
+        display_name: kilobytes
+        one: "{0} kilobyte"
+        other: "{0} kilobytes"
+      short:
+        display_name: kByte
+        one: "{0} kB"
+      narrow:
+        display_name: kB
+        one: "{0}kB"
+        other: "{0}kB"
+    kilobit:
+      long:
+        display_name: kilobits
+        one: "{0} kilobit"
+        other: "{0} kilobits"
+      short:
+        display_name: kbit
+        one: "{0} kb"
+      narrow:
+        display_name: kb
+        one: "{0}kb"
+        other: "{0}kb"
+    byte:
+      long:
+        display_name: bytes
+        one: "{0} byte"
+        other: "{0} bytes"
+      short:
+        one: "{0} byte"
+      narrow:
+        display_name: B
+        one: "{0}B"
+        other: "{0}B"
+    bit:
+      long:
+        display_name: bits
+        one: "{0} bit"
+        other: "{0} bits"
+      short:
+        one: "{0} bit"
+      narrow:
+        display_name: bit
+        one: "{0}bit"
+        other: "{0}bit"
+    century:
+      long:
+        display_name: centuries
+        one: "{0} century"
+        other: "{0} centuries"
+      short:
+        one: "{0} c"
+      narrow:
+        display_name: c
+        one: "{0}c"
+        other: "{0}c"
+    decade:
+      long:
+        display_name: decades
+        one: "{0} decade"
+        other: "{0} decades"
+      short:
+        one: "{0} dec"
+      narrow:
+        display_name: dec
+        one: "{0}dec"
+        other: "{0}dec"
+    year:
+      long:
+        display_name: years
+        one: "{0} year"
+        other: "{0} years"
+        per_unit_pattern: "{0} per year"
+      short:
+        display_name: years
+        one: "{0} yr"
+        other: "{0} yrs"
+      narrow:
+        display_name: yr
+        one: "{0}y"
+        other: "{0}y"
+        per_unit_pattern: "{0}/y"
+    quarter:
+      long:
+        display_name: quarters
+        one: "{0} quarter"
+        other: "{0} quarters"
+        per_unit_pattern: "{0}/q"
+      short:
+        one: "{0} qtr"
+        other: "{0} qtrs"
+      narrow:
+        display_name: qtr
+        one: "{0}q"
+        other: "{0}q"
+        per_unit_pattern: "{0}/q"
+    month:
+      long:
+        display_name: months
+        one: "{0} month"
+        other: "{0} months"
+        per_unit_pattern: "{0} per month"
+      short:
+        display_name: months
+        one: "{0} mth"
+        other: "{0} mths"
+      narrow:
+        display_name: month
+        one: "{0}m"
+        other: "{0}m"
+        per_unit_pattern: "{0}/m"
+    week:
+      long:
+        display_name: weeks
+        one: "{0} week"
+        other: "{0} weeks"
+        per_unit_pattern: "{0} per week"
+      short:
+        display_name: weeks
+        one: "{0} wk"
+        other: "{0} wks"
+      narrow:
+        display_name: wk
+        one: "{0}w"
+        other: "{0}w"
+        per_unit_pattern: "{0}/w"
+    day:
+      long:
+        display_name: days
+        one: "{0} day"
+        other: "{0} days"
+        per_unit_pattern: "{0} per day"
+      short:
+        display_name: days
+        one: "{0} day"
+        other: "{0} days"
+      narrow:
+        display_name: day
+        one: "{0}d"
+        other: "{0}d"
+        per_unit_pattern: "{0}/d"
+    hour:
+      long:
+        display_name: hours
+        one: "{0} hour"
+        other: "{0} hours"
+        per_unit_pattern: "{0} per hour"
+      short:
+        display_name: hours
+        one: "{0} hr"
+        other: "{0} hr"
+      narrow:
+        display_name: hour
+        one: "{0}h"
+        other: "{0}h"
+        per_unit_pattern: "{0}/h"
+    minute:
+      long:
+        display_name: minutes
+        one: "{0} minute"
+        other: "{0} minutes"
+        per_unit_pattern: "{0} per minute"
+      short:
+        display_name: mins
+        one: "{0} min"
+      narrow:
+        display_name: min
+        one: "{0}m"
+        other: "{0}m"
+        per_unit_pattern: "{0}/min"
+    second:
+      long:
+        display_name: seconds
+        one: "{0} second"
+        other: "{0} seconds"
+        per_unit_pattern: "{0} per second"
+      short:
+        display_name: secs
+        one: "{0} sec"
+        other: "{0} sec"
+      narrow:
+        display_name: sec
+        one: "{0}s"
+        other: "{0}s"
+        per_unit_pattern: "{0}/s"
+    millisecond:
+      long:
+        display_name: milliseconds
+        one: "{0} millisecond"
+        other: "{0} milliseconds"
+      short:
+        display_name: millisecs
+        one: "{0} ms"
+      narrow:
+        display_name: msec
+        one: "{0}ms"
+        other: "{0}ms"
+    microsecond:
+      long:
+        display_name: microseconds
+        one: "{0} microsecond"
+        other: "{0} microseconds"
+      short:
+        display_name: μsecs
+        one: "{0} μs"
+      narrow:
+        display_name: μsec
+        one: "{0}μs"
+        other: "{0}μs"
+    nanosecond:
+      long:
+        display_name: nanoseconds
+        one: "{0} nanosecond"
+        other: "{0} nanoseconds"
+      short:
+        display_name: nanosecs
+        one: "{0} ns"
+      narrow:
+        display_name: ns
+        one: "{0}ns"
+        other: "{0}ns"
+    ampere:
+      long:
+        display_name: amperes
+        one: "{0} ampere"
+        other: "{0} amperes"
+      short:
+        display_name: amps
+        one: "{0} A"
+      narrow:
+        display_name: amp
+        one: "{0}A"
+        other: "{0}A"
+    milliampere:
+      long:
+        display_name: milliamperes
+        one: "{0} milliampere"
+        other: "{0} milliamperes"
+      short:
+        display_name: milliamps
+        one: "{0} mA"
+      narrow:
+        display_name: mA
+        one: "{0}mA"
+        other: "{0}mA"
+    ohm:
+      long:
+        display_name: ohms
+        one: "{0} ohm"
+        other: "{0} ohms"
+      short:
+        display_name: ohms
+        one: "{0} Ω"
+      narrow:
+        display_name: ohm
+        one: "{0}Ω"
+        other: "{0}Ω"
+    volt:
+      long:
+        display_name: volts
+        one: "{0} volt"
+        other: "{0} volts"
+      short:
+        display_name: volts
+        one: "{0} V"
+      narrow:
+        display_name: volt
+        one: "{0}V"
+        other: "{0}V"
+    kilocalorie:
+      long:
+        display_name: kilocalories
+        one: "{0} kilocalorie"
+        other: "{0} kilocalories"
+      short:
+        one: "{0} kcal"
+      narrow:
+        display_name: kcal
+        one: "{0}kcal"
+        other: "{0}kcal"
+    calorie:
+      long:
+        display_name: calories
+        one: "{0} calorie"
+        other: "{0} calories"
+      short:
+        one: "{0} cal"
+      narrow:
+        display_name: cal
+        one: "{0}cal"
+        other: "{0}cal"
+    foodcalorie:
+      long:
+        display_name: Calories
+        one: "{0} Calorie"
+        other: "{0} Calories"
+      short:
+        display_name: Cal
+        one: "{0} Cal"
+        other: "{0} Cal"
+      narrow:
+        display_name: Cal
+        one: "{0}Cal"
+        other: "{0}Cal"
+    kilojoule:
+      long:
+        display_name: kilojoules
+        one: "{0} kilojoule"
+        other: "{0} kilojoules"
+      short:
+        display_name: kilojoule
+        one: "{0} kJ"
+      narrow:
+        display_name: kJ
+        one: "{0}kJ"
+        other: "{0}kJ"
+    joule:
+      long:
+        display_name: joules
+        one: "{0} joule"
+        other: "{0} joules"
+      short:
+        display_name: joules
+        one: "{0} J"
+      narrow:
+        display_name: joule
+        one: "{0}J"
+        other: "{0}J"
+    kilowatt-hour:
+      long:
+        display_name: kilowatt-hours
+        one: "{0} kilowatt hour"
+        other: "{0} kilowatt-hours"
+      short:
+        display_name: kW-hour
+        one: "{0} kWh"
+      narrow:
+        display_name: kWh
+        one: "{0}kWh"
+        other: "{0}kWh"
+    electronvolt:
+      long:
+        display_name: electronvolts
+        one: "{0} electronvolt"
+        other: "{0} electronvolts"
+      short:
+        display_name: electronvolt
+        one: "{0} eV"
+      narrow:
+        display_name: eV
+        one: "{0}eV"
+        other: "{0}eV"
+    british-thermal-unit:
+      long:
+        display_name: British thermal units
+        one: "{0} British thermal unit"
+        other: "{0} British thermal units"
+      short:
+        display_name: BTU
+        one: "{0} Btu"
+      narrow:
+        display_name: BTU
+        one: "{0}Btu"
+        other: "{0}Btu"
+    therm-us:
+      long:
+        display_name: US therms
+        one: "{0} US therm"
+        other: "{0} US therms"
+      short:
+        one: "{0} US therm"
+        other: "{0} US therms"
+      narrow:
+        display_name: US therm
+        one: "{0}US therm"
+        other: "{0}US therms"
+    pound-force:
+      long:
+        display_name: pounds of force
+        one: "{0} pound of force"
+        other: "{0} pounds of force"
+      short:
+        display_name: pound-force
+        one: "{0} lbf"
+      narrow:
+        display_name: lbf
+        one: "{0}lbf"
+        other: "{0}lbf"
+    newton:
+      long:
+        display_name: newtons
+        one: "{0} newton"
+        other: "{0} newtons"
+      short:
+        display_name: newton
+        one: "{0} N"
+      narrow:
+        display_name: "N"
+        one: "{0}N"
+        other: "{0}N"
+    kilowatt-hour-per-100-kilometer:
+      long:
+        display_name: kilowatt-hours per 100 kilometers
+        one: "{0} kilowatt-hour per 100 kilometers"
+        other: "{0} kilowatt-hours per 100 kilometers"
+      short:
+        one: "{0} kWh/100km"
+      narrow:
+        display_name: kWh/100km
+        one: "{0}kWh/100km"
+        other: "{0}kWh/100km"
+    gigahertz:
+      long:
+        display_name: gigahertz
+        one: "{0} gigahertz"
+        other: "{0} gigahertz"
+      short:
+        one: "{0} GHz"
+      narrow:
+        display_name: GHz
+        one: "{0}GHz"
+        other: "{0}GHz"
+    megahertz:
+      long:
+        display_name: megahertz
+        one: "{0} megahertz"
+        other: "{0} megahertz"
+      short:
+        one: "{0} MHz"
+      narrow:
+        display_name: MHz
+        one: "{0}MHz"
+        other: "{0}MHz"
+    kilohertz:
+      long:
+        display_name: kilohertz
+        one: "{0} kilohertz"
+        other: "{0} kilohertz"
+      short:
+        one: "{0} kHz"
+      narrow:
+        display_name: kHz
+        one: "{0}kHz"
+        other: "{0}kHz"
+    hertz:
+      long:
+        display_name: hertz
+        one: "{0} hertz"
+        other: "{0} hertz"
+      short:
+        one: "{0} Hz"
+      narrow:
+        display_name: Hz
+        one: "{0}Hz"
+        other: "{0}Hz"
+    em:
+      long:
+        display_name: typographic ems
+        one: "{0} em"
+        other: "{0} ems"
+      short:
+        one: "{0} em"
+      narrow:
+        display_name: em
+        one: "{0}em"
+        other: "{0}em"
+    pixel:
+      long:
+        display_name: pixels
+        one: "{0} pixel"
+        other: "{0} pixels"
+      short:
+        display_name: pixels
+        one: "{0} px"
+      narrow:
+        display_name: px
+        one: "{0}px"
+        other: "{0}px"
+    megapixel:
+      long:
+        display_name: megapixels
+        one: "{0} megapixel"
+        other: "{0} megapixels"
+      short:
+        display_name: megapixels
+        one: "{0} MP"
+      narrow:
+        display_name: MP
+        one: "{0}MP"
+        other: "{0}MP"
+    pixel-per-centimeter:
+      long:
+        display_name: pixels per centimeter
+        one: "{0} pixel per centimeter"
+        other: "{0} pixels per centimeter"
+      short:
+        one: "{0} ppcm"
+      narrow:
+        display_name: ppcm
+        one: "{0}ppcm"
+        other: "{0}ppcm"
+    pixel-per-inch:
+      long:
+        display_name: pixels per inch
+        one: "{0} pixel per inch"
+        other: "{0} pixels per inch"
+      short:
+        one: "{0} ppi"
+      narrow:
+        display_name: ppi
+        one: "{0}ppi"
+        other: "{0}ppi"
+    dot-per-centimeter:
+      long:
+        display_name: dots per centimeter
+        one: "{0} dot per centimeter"
+        other: "{0} dots per centimeter"
+      short:
+        display_name: dpcm
+        one: "{0} dpcm"
+        other: "{0} dpcm"
+      narrow:
+        display_name: dpcm
+        one: "{0}dpcm"
+        other: "{0}dpcm"
+    dot-per-inch:
+      long:
+        display_name: dots per inch
+        one: "{0} dot per inch"
+        other: "{0} dots per inch"
+      short:
+        display_name: dpi
+        one: "{0} dpi"
+        other: "{0} dpi"
+      narrow:
+        display_name: dpi
+        one: "{0}dpi"
+        other: "{0}dpi"
+    dot:
+      long:
+        display_name: dots
+        one: "{0} dot"
+        other: "{0} dots"
+      short:
+        display_name: dots
+        one: "{0} dot"
+        other: "{0} dots"
+      narrow:
+        display_name: dot
+        one: "{0}dot"
+        other: "{0}dot"
+    earth-radius:
+      long:
+        display_name: earth radius
+        one: "{0} earth radius"
+        other: "{0} earth radius"
+      short:
+        display_name: earth radius
+        one: "{0} R⊕"
+      narrow:
+        display_name: R⊕
+        one: "{0}R⊕"
+        other: "{0}R⊕"
+    kilometer:
+      long:
+        display_name: kilometers
+        one: "{0} kilometer"
+        other: "{0} kilometers"
+        per_unit_pattern: "{0} per kilometer"
+      short:
+        one: "{0} km"
+      narrow:
+        display_name: km
+        one: "{0}km"
+        other: "{0}km"
+        per_unit_pattern: "{0}/km"
+    meter:
+      long:
+        display_name: meters
+        one: "{0} meter"
+        other: "{0} meters"
+        per_unit_pattern: "{0} per meter"
+      short:
+        display_name: m
+        one: "{0} m"
+      narrow:
+        display_name: m
+        one: "{0}m"
+        other: "{0}m"
+        per_unit_pattern: "{0}/m"
+    decimeter:
+      long:
+        display_name: decimeters
+        one: "{0} decimeter"
+        other: "{0} decimeters"
+      short:
+        one: "{0} dm"
+      narrow:
+        display_name: dm
+        one: "{0}dm"
+        other: "{0}dm"
+    centimeter:
+      long:
+        display_name: centimeters
+        one: "{0} centimeter"
+        other: "{0} centimeters"
+        per_unit_pattern: "{0} per centimeter"
+      short:
+        one: "{0} cm"
+      narrow:
+        display_name: cm
+        one: "{0}cm"
+        other: "{0}cm"
+        per_unit_pattern: "{0}/cm"
+    millimeter:
+      long:
+        display_name: millimeters
+        one: "{0} millimeter"
+        other: "{0} millimeters"
+      short:
+        one: "{0} mm"
+      narrow:
+        display_name: mm
+        one: "{0}mm"
+        other: "{0}mm"
+    micrometer:
+      long:
+        display_name: micrometers
+        one: "{0} micrometer"
+        other: "{0} micrometers"
+      short:
+        display_name: μmeters
+        one: "{0} μm"
+      narrow:
+        display_name: μm
+        one: "{0}μm"
+        other: "{0}μm"
+    nanometer:
+      long:
+        display_name: nanometers
+        one: "{0} nanometer"
+        other: "{0} nanometers"
+      short:
+        one: "{0} nm"
+      narrow:
+        display_name: nm
+        one: "{0}nm"
+        other: "{0}nm"
+    picometer:
+      long:
+        display_name: picometers
+        one: "{0} picometer"
+        other: "{0} picometers"
+      short:
+        one: "{0} pm"
+      narrow:
+        display_name: pm
+        one: "{0}pm"
+        other: "{0}pm"
+    mile:
+      long:
+        display_name: miles
+        one: "{0} mile"
+        other: "{0} miles"
+      short:
+        display_name: miles
+        one: "{0} mi"
+      narrow:
+        display_name: mi
+        one: "{0}mi"
+        other: "{0}mi"
+    yard:
+      long:
+        display_name: yards
+        one: "{0} yard"
+        other: "{0} yards"
+      short:
+        display_name: yards
+        one: "{0} yd"
+      narrow:
+        display_name: yd
+        one: "{0}yd"
+        other: "{0}yd"
+    foot:
+      long:
+        display_name: feet
+        one: "{0} foot"
+        other: "{0} feet"
+        per_unit_pattern: "{0} per foot"
+      short:
+        display_name: feet
+        one: "{0} ft"
+      narrow:
+        display_name: ft
+        one: "{0}′"
+        other: "{0}′"
+        per_unit_pattern: "{0}/ft"
+    inch:
+      long:
+        display_name: inches
+        one: "{0} inch"
+        other: "{0} inches"
+        per_unit_pattern: "{0} per inch"
+      short:
+        display_name: inches
+        one: "{0} in"
+      narrow:
+        display_name: in
+        one: "{0}″"
+        other: "{0}″"
+        per_unit_pattern: "{0}/in"
+    parsec:
+      long:
+        display_name: parsecs
+        one: "{0} parsec"
+        other: "{0} parsecs"
+      short:
+        display_name: parsecs
+        one: "{0} pc"
+      narrow:
+        display_name: parsec
+        one: "{0}pc"
+        other: "{0}pc"
+    light-year:
+      long:
+        display_name: light years
+        one: "{0} light year"
+        other: "{0} light years"
+      short:
+        display_name: light yrs
+        one: "{0} ly"
+      narrow:
+        display_name: ly
+        one: "{0}ly"
+        other: "{0}ly"
+    astronomical-unit:
+      long:
+        display_name: astronomical units
+        one: "{0} astronomical unit"
+        other: "{0} astronomical units"
+      short:
+        one: "{0} au"
+      narrow:
+        display_name: au
+        one: "{0}au"
+        other: "{0}au"
+    furlong:
+      long:
+        display_name: furlongs
+        one: "{0} furlong"
+        other: "{0} furlongs"
+      short:
+        display_name: furlongs
+        one: "{0} fur"
+      narrow:
+        display_name: furlong
+        one: "{0}fur"
+        other: "{0}fur"
+    fathom:
+      long:
+        display_name: fathoms
+        one: "{0} fathom"
+        other: "{0} fathoms"
+      short:
+        display_name: fathoms
+        one: "{0} fth"
+      narrow:
+        display_name: fathom
+        one: "{0}fth"
+        other: "{0}fth"
+    nautical-mile:
+      long:
+        display_name: nautical miles
+        one: "{0} nautical mile"
+        other: "{0} nautical miles"
+      short:
+        one: "{0} nmi"
+      narrow:
+        display_name: nmi
+        one: "{0}nmi"
+        other: "{0}nmi"
+    mile-scandinavian:
+      long:
+        display_name: miles-scandinavian
+        one: "{0} mile-scandinavian"
+        other: "{0} miles-scandinavian"
+      short:
+        one: "{0} smi"
+      narrow:
+        display_name: smi
+        one: "{0}smi"
+        other: "{0}smi"
+    point:
+      long:
+        display_name: points
+        one: "{0} point"
+        other: "{0} points"
+      short:
+        display_name: points
+        one: "{0} pt"
+      narrow:
+        display_name: pts
+        one: "{0}pt"
+        other: "{0}pt"
+    solar-radius:
+      long:
+        display_name: solar radii
+        one: "{0} solar radius"
+        other: "{0} solar radii"
+      short:
+        display_name: solar radii
+        one: "{0} R☉"
+      narrow:
+        display_name: R☉
+        one: "{0}R☉"
+        other: "{0}R☉"
+    lux:
+      long:
+        display_name: lux
+        one: "{0} lux"
+        other: "{0} lux"
+      short:
+        display_name: lux
+        one: "{0} lx"
+      narrow:
+        display_name: lux
+        one: "{0}lx"
+        other: "{0}lx"
+    candela:
+      long:
+        display_name: candela
+        one: "{0} candela"
+        other: "{0} candela"
+      short:
+        display_name: candela
+        one: "{0} cd"
+      narrow:
+        display_name: cd
+        one: "{0}cd"
+        other: "{0}cd"
+    lumen:
+      long:
+        display_name: lumen
+        one: "{0} lumen"
+        other: "{0} lumen"
+      short:
+        display_name: lumen
+        one: "{0} lm"
+      narrow:
+        display_name: lm
+        one: "{0}lm"
+        other: "{0}lm"
+    solar-luminosity:
+      long:
+        display_name: solar luminosities
+        one: "{0} solar luminosity"
+        other: "{0} solar luminosities"
+      short:
+        display_name: solar luminosities
+        one: "{0} L☉"
+      narrow:
+        display_name: L☉
+        one: "{0}L☉"
+        other: "{0}L☉"
+    tonne:
+      long:
+        display_name: metric tons
+        one: "{0} metric ton"
+        other: "{0} metric tons"
+      short:
+        one: "{0} t"
+      narrow:
+        display_name: t
+        one: "{0}t"
+        other: "{0}t"
+    kilogram:
+      long:
+        display_name: kilograms
+        one: "{0} kilogram"
+        other: "{0} kilograms"
+        per_unit_pattern: "{0} per kilogram"
+      short:
+        one: "{0} kg"
+      narrow:
+        display_name: kg
+        one: "{0}kg"
+        other: "{0}kg"
+        per_unit_pattern: "{0}/kg"
+    gram:
+      long:
+        display_name: grams
+        one: "{0} gram"
+        other: "{0} grams"
+        per_unit_pattern: "{0} per gram"
+      short:
+        display_name: grams
+        one: "{0} g"
+      narrow:
+        display_name: gram
+        one: "{0}g"
+        other: "{0}g"
+        per_unit_pattern: "{0}/g"
+    milligram:
+      long:
+        display_name: milligrams
+        one: "{0} milligram"
+        other: "{0} milligrams"
+      short:
+        one: "{0} mg"
+      narrow:
+        display_name: mg
+        one: "{0}mg"
+        other: "{0}mg"
+    microgram:
+      long:
+        display_name: micrograms
+        one: "{0} microgram"
+        other: "{0} micrograms"
+      short:
+        one: "{0} μg"
+      narrow:
+        display_name: μg
+        one: "{0}μg"
+        other: "{0}μg"
+    ton:
+      long:
+        display_name: tons
+        one: "{0} ton"
+        other: "{0} tons"
+      short:
+        display_name: tons
+        one: "{0} tn"
+      narrow:
+        display_name: ton
+        one: "{0}tn"
+        other: "{0}tn"
+    stone:
+      long:
+        display_name: stones
+        one: "{0} stone"
+        other: "{0} stones"
+      short:
+        display_name: stones
+        one: "{0} st"
+      narrow:
+        display_name: stone
+        one: "{0}st"
+        other: "{0}st"
+    pound:
+      long:
+        display_name: pounds
+        one: "{0} pound"
+        other: "{0} pounds"
+        per_unit_pattern: "{0} per pound"
+      short:
+        display_name: pounds
+        one: "{0} lb"
+      narrow:
+        display_name: lb
+        one: "{0}#"
+        other: "{0}#"
+        per_unit_pattern: "{0}/lb"
+    ounce:
+      long:
+        display_name: ounces
+        one: "{0} ounce"
+        other: "{0} ounces"
+        per_unit_pattern: "{0} per ounce"
+      short:
+        one: "{0} oz"
+      narrow:
+        display_name: oz
+        one: "{0}oz"
+        other: "{0}oz"
+        per_unit_pattern: "{0}/oz"
+    ounce-troy:
+      long:
+        display_name: troy ounces
+        one: "{0} troy ounce"
+        other: "{0} troy ounces"
+      short:
+        display_name: oz troy
+        one: "{0} oz t"
+      narrow:
+        display_name: oz t
+        one: "{0}oz t"
+        other: "{0}oz t"
+    carat:
+      long:
+        display_name: carats
+        one: "{0} carat"
+        other: "{0} carats"
+      short:
+        display_name: carats
+        one: "{0} CD"
+      narrow:
+        display_name: carat
+        one: "{0}CD"
+        other: "{0}CD"
+    dalton:
+      long:
+        display_name: daltons
+        one: "{0} dalton"
+        other: "{0} daltons"
+      short:
+        display_name: daltons
+        one: "{0} Da"
+      narrow:
+        display_name: Da
+        one: "{0}Da"
+        other: "{0}Da"
+    earth-mass:
+      long:
+        display_name: Earth masses
+        one: "{0} Earth mass"
+        other: "{0} Earth masses"
+      short:
+        display_name: Earth masses
+        one: "{0} M⊕"
+      narrow:
+        display_name: M⊕
+        one: "{0}M⊕"
+        other: "{0}M⊕"
+    solar-mass:
+      long:
+        display_name: solar masses
+        one: "{0} solar mass"
+        other: "{0} solar masses"
+      short:
+        display_name: solar masses
+        one: "{0} M☉"
+      narrow:
+        display_name: M☉
+        one: "{0}M☉"
+        other: "{0}M☉"
+    grain:
+      long:
+        display_name: grains
+        one: "{0} grain"
+        other: "{0} grains"
+      short:
+        display_name: grains
+        one: "{0} gr"
+        other: "{0} gr"
+      narrow:
+        display_name: gr
+        one: "{0}gr"
+        other: "{0}gr"
+    gigawatt:
+      long:
+        display_name: gigawatts
+        one: "{0} gigawatt"
+        other: "{0} gigawatts"
+      short:
+        one: "{0} GW"
+      narrow:
+        display_name: GW
+        one: "{0}GW"
+        other: "{0}GW"
+    megawatt:
+      long:
+        display_name: megawatts
+        one: "{0} megawatt"
+        other: "{0} megawatts"
+      short:
+        one: "{0} MW"
+      narrow:
+        display_name: MW
+        one: "{0}MW"
+        other: "{0}MW"
+    kilowatt:
+      long:
+        display_name: kilowatts
+        one: "{0} kilowatt"
+        other: "{0} kilowatts"
+      short:
+        one: "{0} kW"
+      narrow:
+        display_name: kW
+        one: "{0}kW"
+        other: "{0}kW"
+    watt:
+      long:
+        display_name: watts
+        one: "{0} watt"
+        other: "{0} watts"
+      short:
+        display_name: watts
+        one: "{0} W"
+      narrow:
+        display_name: watt
+        one: "{0}W"
+        other: "{0}W"
+    milliwatt:
+      long:
+        display_name: milliwatts
+        one: "{0} milliwatt"
+        other: "{0} milliwatts"
+      short:
+        one: "{0} mW"
+      narrow:
+        display_name: mW
+        one: "{0}mW"
+        other: "{0}mW"
+    horsepower:
+      long:
+        display_name: horsepower
+        one: "{0} horsepower"
+        other: "{0} horsepower"
+      short:
+        one: "{0} hp"
+      narrow:
+        display_name: hp
+        one: "{0}hp"
+        other: "{0}hp"
+    millimeter-ofhg:
+      long:
+        display_name: millimeters of mercury
+        one: "{0} millimeter of mercury"
+        other: "{0} millimeters of mercury"
+      short:
+        display_name: mmHg
+        one: "{0} mmHg"
+        other: "{0} mmHg"
+      narrow:
+        display_name: mmHg
+        one: "{0}mmHg"
+        other: "{0}mmHg"
+    pound-force-per-square-inch:
+      long:
+        display_name: pounds-force per square inch
+        one: "{0} pound-force per square inch"
+        other: "{0} pounds-force per square inch"
+      short:
+        one: "{0} psi"
+      narrow:
+        display_name: psi
+        one: "{0}psi"
+        other: "{0}psi"
+    inch-ofhg:
+      long:
+        display_name: inches of mercury
+        one: "{0} inch of mercury"
+        other: "{0} inches of mercury"
+      short:
+        one: "{0} inHg"
+      narrow:
+        display_name: "″ Hg"
+        one: "{0}″ Hg"
+        other: "{0}″ Hg"
+    bar:
+      long:
+        display_name: bars
+        one: "{0} bar"
+        other: "{0} bars"
+      short:
+        one: "{0} bar"
+      narrow:
+        display_name: bar
+        one: "{0}bar"
+        other: "{0}bar"
+    millibar:
+      long:
+        display_name: millibars
+        one: "{0} millibar"
+        other: "{0} millibars"
+      short:
+        one: "{0} mbar"
+      narrow:
+        display_name: mbar
+        one: "{0}mb"
+        other: "{0}mb"
+    atmosphere:
+      long:
+        display_name: atmospheres
+        one: "{0} atmosphere"
+        other: "{0} atmospheres"
+      short:
+        one: "{0} atm"
+      narrow:
+        display_name: atm
+        one: "{0}atm"
+        other: "{0}atm"
+    pascal:
+      long:
+        display_name: pascals
+        one: "{0} pascal"
+        other: "{0} pascals"
+      short:
+        one: "{0} Pa"
+      narrow:
+        display_name: Pa
+        one: "{0}Pa"
+        other: "{0}Pa"
+    hectopascal:
+      long:
+        display_name: hectopascals
+        one: "{0} hectopascal"
+        other: "{0} hectopascals"
+      short:
+        one: "{0} hPa"
+      narrow:
+        display_name: hPa
+        one: "{0}hPa"
+        other: "{0}hPa"
+    kilopascal:
+      long:
+        display_name: kilopascals
+        one: "{0} kilopascal"
+        other: "{0} kilopascals"
+      short:
+        one: "{0} kPa"
+      narrow:
+        display_name: kPa
+        one: "{0}kPa"
+        other: "{0}kPa"
+    megapascal:
+      long:
+        display_name: megapascals
+        one: "{0} megapascal"
+        other: "{0} megapascals"
+      short:
+        one: "{0} MPa"
+      narrow:
+        display_name: MPa
+        one: "{0}MPa"
+        other: "{0}MPa"
+    kilometer-per-hour:
+      long:
+        display_name: kilometers per hour
+        one: "{0} kilometer per hour"
+        other: "{0} kilometers per hour"
+      short:
+        display_name: km/hour
+        one: "{0} km/h"
+      narrow:
+        display_name: km/hr
+        one: "{0}km/h"
+        other: "{0}km/h"
+    meter-per-second:
+      long:
+        display_name: meters per second
+        one: "{0} meter per second"
+        other: "{0} meters per second"
+      short:
+        display_name: meters/sec
+        one: "{0} m/s"
+      narrow:
+        display_name: m/s
+        one: "{0}m/s"
+        other: "{0}m/s"
+    mile-per-hour:
+      long:
+        display_name: miles per hour
+        one: "{0} mile per hour"
+        other: "{0} miles per hour"
+      short:
+        display_name: miles/hour
+        one: "{0} mph"
+        other: "{0} mph"
+      narrow:
+        display_name: mi/hr
+        one: "{0}mph"
+        other: "{0}mph"
+    knot:
+      long:
+        display_name: knots
+        one: "{0} knot"
+        other: "{0} knots"
+      short:
+        one: "{0} kn"
+      narrow:
+        display_name: kn
+        one: "{0}kn"
+        other: "{0}kn"
+    beaufort:
+      long:
+        display_name: Beaufort
+        one: Beaufort {0}
+        other: Beaufort {0}
+      short:
+        one: B {0}
+      narrow:
+        display_name: Bft
+        one: B{0}
+        other: B{0}
+    generic:
+      long:
+        display_name: degrees temperature
+        one: "{0} degree temperature"
+        other: "{0} degrees temperature"
+      short:
+        display_name: deg. temp.
+        one: "{0}°"
+      narrow:
+        display_name: "°"
+        one: "{0}°"
+        other: "{0}°"
+    celsius:
+      long:
+        display_name: degrees Celsius
+        one: "{0} degree Celsius"
+        other: "{0} degrees Celsius"
+      short:
+        display_name: deg. C
+        one: "{0}°C"
+      narrow:
+        display_name: "°C"
+        one: "{0}°C"
+        other: "{0}°C"
+    fahrenheit:
+      long:
+        display_name: degrees Fahrenheit
+        one: "{0} degree Fahrenheit"
+        other: "{0} degrees Fahrenheit"
+      short:
+        display_name: deg. F
+        one: "{0}°F"
+      narrow:
+        display_name: "°F"
+        one: "{0}°"
+        other: "{0}°"
+    kelvin:
+      long:
+        display_name: kelvins
+        one: "{0} kelvin"
+        other: "{0} kelvins"
+      short:
+        one: "{0} K"
+      narrow:
+        display_name: K
+        one: "{0}K"
+        other: "{0}K"
+    pound-force-foot:
+      long:
+        display_name: pound-force-feet
+        one: "{0} pound-force-foot"
+        other: "{0} pound-force-feet"
+      short:
+        one: "{0} lbf⋅ft"
+      narrow:
+        display_name: lbf⋅ft
+        one: "{0}lbf⋅ft"
+        other: "{0}lbf⋅ft"
+    newton-meter:
+      long:
+        display_name: newton-meters
+        one: "{0} newton-meter"
+        other: "{0} newton-meters"
+      short:
+        one: "{0} N⋅m"
+      narrow:
+        display_name: N⋅m
+        one: "{0}N⋅m"
+        other: "{0}N⋅m"
+    cubic-kilometer:
+      long:
+        display_name: cubic kilometers
+        one: "{0} cubic kilometer"
+        other: "{0} cubic kilometers"
+      short:
+        one: "{0} km³"
+      narrow:
+        display_name: km³
+        one: "{0}km³"
+        other: "{0}km³"
+    cubic-meter:
+      long:
+        display_name: cubic meters
+        one: "{0} cubic meter"
+        other: "{0} cubic meters"
+        per_unit_pattern: "{0} per cubic meter"
+      short:
+        one: "{0} m³"
+      narrow:
+        display_name: m³
+        one: "{0}m³"
+        other: "{0}m³"
+        per_unit_pattern: "{0}/m³"
+    cubic-centimeter:
+      long:
+        display_name: cubic centimeters
+        one: "{0} cubic centimeter"
+        other: "{0} cubic centimeters"
+        per_unit_pattern: "{0} per cubic centimeter"
+      short:
+        one: "{0} cm³"
+      narrow:
+        display_name: cm³
+        one: "{0}cm³"
+        other: "{0}cm³"
+        per_unit_pattern: "{0}/cm³"
+    cubic-mile:
+      long:
+        display_name: cubic miles
+        one: "{0} cubic mile"
+        other: "{0} cubic miles"
+      short:
+        one: "{0} mi³"
+      narrow:
+        display_name: mi³
+        one: "{0}mi³"
+        other: "{0}mi³"
+    cubic-yard:
+      long:
+        display_name: cubic yards
+        one: "{0} cubic yard"
+        other: "{0} cubic yards"
+      short:
+        display_name: yards³
+        one: "{0} yd³"
+      narrow:
+        display_name: yd³
+        one: "{0}yd³"
+        other: "{0}yd³"
+    cubic-foot:
+      long:
+        display_name: cubic feet
+        one: "{0} cubic foot"
+        other: "{0} cubic feet"
+      short:
+        display_name: feet³
+        one: "{0} ft³"
+      narrow:
+        display_name: ft³
+        one: "{0}ft³"
+        other: "{0}ft³"
+    cubic-inch:
+      long:
+        display_name: cubic inches
+        one: "{0} cubic inch"
+        other: "{0} cubic inches"
+      short:
+        display_name: inches³
+        one: "{0} in³"
+      narrow:
+        display_name: in³
+        one: "{0}in³"
+        other: "{0}in³"
+    megaliter:
+      long:
+        display_name: megaliters
+        one: "{0} megaliter"
+        other: "{0} megaliters"
+      short:
+        one: "{0} ML"
+      narrow:
+        display_name: ML
+        one: "{0}ML"
+        other: "{0}ML"
+    hectoliter:
+      long:
+        display_name: hectoliters
+        one: "{0} hectoliter"
+        other: "{0} hectoliters"
+      short:
+        one: "{0} hL"
+      narrow:
+        display_name: hL
+        one: "{0}hL"
+        other: "{0}hL"
+    liter:
+      long:
+        display_name: liters
+        one: "{0} liter"
+        other: "{0} liters"
+        per_unit_pattern: "{0} per liter"
+      short:
+        display_name: liters
+        one: "{0} L"
+        other: "{0} L"
+        per_unit_pattern: "{0}/L"
+      narrow:
+        display_name: liter
+        one: "{0}L"
+        other: "{0}L"
+        per_unit_pattern: "{0}/L"
+    deciliter:
+      long:
+        display_name: deciliters
+        one: "{0} deciliter"
+        other: "{0} deciliters"
+      short:
+        one: "{0} dL"
+      narrow:
+        display_name: dL
+        one: "{0}dL"
+        other: "{0}dL"
+    centiliter:
+      long:
+        display_name: centiliters
+        one: "{0} centiliter"
+        other: "{0} centiliters"
+      short:
+        one: "{0} cL"
+      narrow:
+        display_name: cL
+        one: "{0}cL"
+        other: "{0}cL"
+    milliliter:
+      long:
+        display_name: milliliters
+        one: "{0} milliliter"
+        other: "{0} milliliters"
+      short:
+        one: "{0} mL"
+      narrow:
+        display_name: mL
+        one: "{0}mL"
+        other: "{0}mL"
+    pint-metric:
+      long:
+        display_name: metric pints
+        one: "{0} metric pint"
+        other: "{0} metric pints"
+      short:
+        one: "{0} mpt"
+      narrow:
+        display_name: pt
+        one: "{0}mpt"
+        other: "{0}mpt"
+    cup-metric:
+      long:
+        display_name: metric cups
+        one: "{0} metric cup"
+        other: "{0} metric cups"
+      short:
+        one: "{0} mc"
+      narrow:
+        display_name: mcup
+        one: "{0}mc"
+        other: "{0}mc"
+    acre-foot:
+      long:
+        display_name: acre-feet
+        one: "{0} acre-foot"
+        other: "{0} acre-feet"
+      short:
+        display_name: acre ft
+        one: "{0} ac ft"
+      narrow:
+        display_name: acre ft
+        one: "{0}ac ft"
+        other: "{0}ac ft"
+    bushel:
+      long:
+        display_name: bushels
+        one: "{0} bushel"
+        other: "{0} bushels"
+      short:
+        display_name: bushels
+        one: "{0} bu"
+      narrow:
+        display_name: bushel
+        one: "{0}bu"
+        other: "{0}bu"
+    gallon:
+      long:
+        display_name: gallons
+        one: "{0} gallon"
+        other: "{0} gallons"
+        per_unit_pattern: "{0} per gallon"
+      short:
+        display_name: gal
+        one: "{0} gal"
+        other: "{0} gal"
+      narrow:
+        display_name: gal
+        one: "{0}gal"
+        other: "{0}gal"
+        per_unit_pattern: "{0}/gal"
+    gallon-imperial:
+      long:
+        display_name: Imp. gallons
+        one: "{0} Imp. gallon"
+        other: "{0} Imp. gallons"
+        per_unit_pattern: "{0} per Imp. gallon"
+      short:
+        one: "{0} gal Imp."
+        per_unit_pattern: "{0}/galImp"
+      narrow:
+        display_name: Imp gal
+        one: "{0}galIm"
+        other: "{0}galIm"
+        per_unit_pattern: "{0}/galIm"
+    quart:
+      long:
+        display_name: quarts
+        one: "{0} quart"
+        other: "{0} quarts"
+      short:
+        display_name: qts
+        one: "{0} qt"
+      narrow:
+        display_name: qt
+        one: "{0}qt"
+        other: "{0}qt"
+    pint:
+      long:
+        display_name: pints
+        one: "{0} pint"
+        other: "{0} pints"
+      short:
+        display_name: pints
+        one: "{0} pt"
+      narrow:
+        display_name: pt
+        one: "{0}pt"
+        other: "{0}pt"
+    cup:
+      long:
+        display_name: cups
+        one: "{0} cup"
+        other: "{0} cups"
+      short:
+        display_name: cups
+        one: "{0} c"
+      narrow:
+        display_name: cup
+        one: "{0}c"
+        other: "{0}c"
+    fluid-ounce:
+      long:
+        display_name: fluid ounces
+        one: "{0} fluid ounce"
+        other: "{0} fluid ounces"
+      short:
+        display_name: fl oz
+        one: "{0} fl oz"
+        other: "{0} fl oz"
+      narrow:
+        display_name: fl oz
+        one: "{0}fl oz"
+        other: "{0}fl oz"
+    fluid-ounce-imperial:
+      long:
+        display_name: Imp. fluid ounces
+        one: "{0} Imp. fluid ounce"
+        other: "{0} Imp. fluid ounces"
+      short:
+        one: "{0} fl oz Imp."
+      narrow:
+        display_name: Imp fl oz
+        one: "{0}fl oz Im"
+        other: "{0}fl oz Im"
+    tablespoon:
+      long:
+        display_name: tablespoons
+        one: "{0} tablespoon"
+        other: "{0} tablespoons"
+      short:
+        one: "{0} tbsp"
+      narrow:
+        display_name: tbsp
+        one: "{0}tbsp"
+        other: "{0}tbsp"
+    teaspoon:
+      long:
+        display_name: teaspoons
+        one: "{0} teaspoon"
+        other: "{0} teaspoons"
+      short:
+        one: "{0} tsp"
+      narrow:
+        display_name: tsp
+        one: "{0}tsp"
+        other: "{0}tsp"
+    barrel:
+      long:
+        display_name: barrels
+        one: "{0} barrel"
+        other: "{0} barrels"
+      short:
+        display_name: barrel
+        one: "{0} bbl"
+      narrow:
+        display_name: bbl
+        one: "{0}bbl"
+        other: "{0}bbl"
+    dessert-spoon:
+      long:
+        display_name: dessert spoons
+        one: "{0} dessert spoon"
+        other: "{0} dessert spoons"
+      short:
+        display_name: dessert spoons
+        one: "{0} dsp"
+        other: "{0} dsp"
+      narrow:
+        display_name: dsp
+        one: "{0}dsp"
+        other: "{0}dsp"
+    dessert-spoon-imperial:
+      long:
+        display_name: Imp. dessert spoons
+        one: "{0} Imp. dessert spoon"
+        other: "{0} Imp. dessert spoons"
+      short:
+        display_name: Imp. dessert spoons
+        one: "{0} dsp-Imp."
+        other: "{0} dsp-Imp."
+      narrow:
+        display_name: dsp Imp
+        one: "{0}dsp-Imp"
+        other: "{0}dsp-Imp"
+    drop:
+      long:
+        display_name: drops
+        one: "{0} drop"
+        other: "{0} drops"
+      short:
+        display_name: drops
+        one: "{0} dr"
+        other: "{0} drdrops"
+      narrow:
+        display_name: dr
+        one: "{0}dr"
+        other: "{0}dr"
+    dram:
+      long:
+        display_name: drams
+        one: "{0} dram"
+        other: "{0} drams"
+      short:
+        display_name: drams
+        one: "{0} dram"
+        other: "{0} drams"
+      narrow:
+        display_name: fl.dr.
+        one: "{0}fl.dr."
+        other: "{0}fl.dr."
+    jigger:
+      long:
+        display_name: jiggers
+        one: "{0} jigger"
+        other: "{0} jiggers"
+      short:
+        display_name: jiggers
+        one: "{0} jigger"
+        other: "{0} jiggers"
+      narrow:
+        display_name: jigger
+        one: "{0}jigger"
+        other: "{0}jigger"
+    pinch:
+      long:
+        display_name: pinches
+        one: "{0} pinch"
+        other: "{0} pinches"
+      short:
+        display_name: pinches
+        one: "{0} pn"
+        other: "{0} pn"
+      narrow:
+        display_name: pn
+        one: "{0}pn"
+        other: "{0}pn"
+    quart-imperial:
+      long:
+        display_name: Imp. quarts
+        one: "{0} Imp. quart"
+        other: "{0} Imp. quarts"
+      short:
+        display_name: Imp. quarts
+        one: "{0} qt-Imp."
+        other: "{0} qt-Imp."
+      narrow:
+        display_name: qt Imp
+        one: "{0}qt-Imp."
+        other: "{0}qt-Imp."
+    gasoline-energy-density:
+      long:
+        display_name: of gasoline equivalent
+        one: "{0} of gasoline equivalent"
+        other: "{0} of gasoline equivalent"
+      category: pressure
+      short:
+        display_name: gas-equiv
+        one: "{0} gas-equiv"
+        other: "{0} gas-equiv"
+      narrow:
+        display_name: gas-equiv
+        one: "{0}gas-equiv"
+        other: "{0}gas-equiv"
+    light-speed:
+      long:
+        display_name: light
+        one: "{0} light"
+        other: "{0} light"
+      short:
+        one: "{0} light"
+      narrow:
+        display_name: light
+        one: "{0}light"
+        other: "{0}light"
+    portion-per-1e9:
+      long:
+        display_name: parts per billion
+        one: "{0} part per billion"
+        other: "{0} parts per billion"
+      short:
+        display_name: parts/billion
+        one: "{0} ppb"
+      narrow:
+        display_name: ppb
+        one: "{0}ppb"
+        other: "{0}ppb"
+    night:
+      long:
+        display_name: nights
+        one: "{0} night"
+        other: "{0} nights"
+        per_unit_pattern: "{0} per night"
+      short:
+        display_name: nights
+        one: "{0} night"
+        other: "{0} nights"
+      narrow:
+        display_name: nights
+        one: "{0}night"
+        other: "{0}nights"
+        per_unit_pattern: "{0}/night"

--- a/data/cldr/fr/number_formats.yml
+++ b/data/cldr/fr/number_formats.yml
@@ -1,6 +1,6 @@
 ---
 locale: fr
-generated_at: '2025-09-14T04:24:02Z'
+generated_at: '2025-09-14T05:42:41Z'
 cldr_version: '46'
 number_formats:
   symbols:
@@ -1364,3 +1364,2256 @@ number_formats:
       display_names:
         other: dollars zimbabwéens (2008)
         one: dollar zimbabwéen (2008)
+  units:
+    g-force:
+      long:
+        display_name: accélération de pesanteur terrestre
+        one: "{0} fois l’accélération de pesanteur terrestre"
+        other: "{0} fois l’accélération de pesanteur terrestre"
+        gender: feminine
+      short:
+        display_name: force g
+        one: "{0} force g"
+        other: "{0} force g"
+      narrow:
+        display_name: G
+    meter-per-square-second:
+      long:
+        display_name: mètres par seconde carrée
+        one: "{0} mètre par seconde carrée"
+        other: "{0} mètres par seconde carrée"
+        gender: masculine
+      short:
+        one: "{0} m/s²"
+        other: "{0} m/s²"
+      narrow:
+        one: "{0}m/s²"
+        other: "{0}m/s²"
+    revolution:
+      long:
+        display_name: tours
+        one: "{0} tour"
+        other: "{0} tours"
+        gender: masculine
+      short:
+        display_name: tr
+        one: "{0} tr"
+        other: "{0} tr"
+      narrow:
+        one: "{0}tr"
+        other: "{0}tr"
+    radian:
+      long:
+        display_name: radians
+        one: "{0} radian"
+        other: "{0} radians"
+        gender: masculine
+      short:
+        one: "{0} rad"
+        other: "{0} rad"
+      narrow:
+        one: "{0} rad"
+        other: "{0} rad"
+    degree:
+      long:
+        display_name: degrés
+        one: "{0} degré"
+        other: "{0} degrés"
+        gender: masculine
+      short:
+        display_name: "°"
+    arc-minute:
+      long:
+        display_name: minutes d’arc
+        one: "{0} minute d’arc"
+        other: "{0} minutes d’arc"
+        gender: feminine
+      short:
+        display_name: "′"
+    arc-second:
+      long:
+        display_name: secondes d’arc
+        one: "{0} seconde d’arc"
+        other: "{0} secondes d’arc"
+        gender: feminine
+      short:
+        display_name: "″"
+    square-kilometer:
+      long:
+        display_name: kilomètres carrés
+        one: "{0} kilomètre carré"
+        other: "{0} kilomètres carrés"
+        gender: masculine
+        per_unit_pattern: "{0} par kilomètre carré"
+      short:
+        one: "{0} km²"
+        other: "{0} km²"
+      narrow:
+        one: "{0}km²"
+        other: "{0}km²"
+    hectare:
+      long:
+        display_name: hectares
+        one: "{0} hectare"
+        other: "{0} hectares"
+        gender: masculine
+      short:
+        display_name: ha
+        one: "{0} ha"
+        other: "{0} ha"
+      narrow:
+        one: "{0}ha"
+        other: "{0}ha"
+    square-meter:
+      long:
+        display_name: mètres carrés
+        one: "{0} mètre carré"
+        other: "{0} mètres carrés"
+        gender: masculine
+        per_unit_pattern: "{0} par mètre carré"
+      short:
+        one: "{0} m²"
+        other: "{0} m²"
+      narrow:
+        one: "{0}m²"
+        other: "{0}m²"
+    square-centimeter:
+      long:
+        display_name: centimètres carrés
+        one: "{0} centimètre carré"
+        other: "{0} centimètres carrés"
+        gender: masculine
+        per_unit_pattern: "{0} par centimètre carré"
+      short:
+        one: "{0} cm²"
+        other: "{0} cm²"
+      narrow:
+        one: "{0}cm²"
+        other: "{0}cm²"
+    square-mile:
+      long:
+        display_name: milles carrés
+        one: "{0} mille carré"
+        other: "{0} milles carrés"
+        gender: masculine
+        per_unit_pattern: "{0} par mille carré"
+      short:
+        one: "{0} mi²"
+        other: "{0} mi²"
+      narrow:
+        one: "{0}mi²"
+        other: "{0}mi²"
+    acre:
+      long:
+        display_name: acres anglo-saxonnes
+        one: "{0} acre anglo-saxonne"
+        other: "{0} acres anglo-saxonnes"
+        gender: feminine
+      short:
+        display_name: ac
+        one: "{0} ac"
+        other: "{0} ac"
+      narrow:
+        one: "{0}ac"
+        other: "{0}ac"
+    square-yard:
+      long:
+        display_name: yards carrés
+        one: "{0} yard carré"
+        other: "{0} yards carrés"
+      short:
+        one: "{0} yd²"
+        other: "{0} yd²"
+      narrow:
+        one: "{0}yd²"
+        other: "{0}yd²"
+    square-foot:
+      long:
+        display_name: pieds carrés
+        one: "{0} pied carré"
+        other: "{0} pieds carrés"
+        gender: masculine
+      short:
+        display_name: pi²
+        one: "{0} pi²"
+        other: "{0} pi²"
+      narrow:
+        one: "{0}pi²"
+        other: "{0}pi²"
+    square-inch:
+      long:
+        display_name: pouces carrés
+        one: "{0} pouce carré"
+        other: "{0} pouces carrés"
+        per_unit_pattern: "{0} par pouce carré"
+      short:
+        display_name: po²
+        one: "{0} po²"
+        other: "{0} po²"
+        per_unit_pattern: "{0}/po²"
+      narrow:
+        one: "{0}po²"
+        other: "{0}po²"
+    dunam:
+      long:
+        display_name: dounams
+        one: "{0} dounam"
+        other: "{0} dounams"
+      short:
+        display_name: dounam
+        one: "{0} dounam"
+        other: "{0} dounam"
+      narrow:
+        one: "{0}dounam"
+        other: "{0}dounams"
+    karat:
+      long:
+        display_name: carats
+        one: "{0} carat"
+        other: "{0} carats"
+        gender: masculine
+      short:
+        display_name: ct
+        one: "{0} ct"
+        other: "{0} ct"
+      narrow:
+        one: "{0}ct"
+        other: "{0}ct"
+    milligram-ofglucose-per-deciliter:
+      long:
+        display_name: milligrammes par décilitre
+        one: "{0} milligramme par décilitre"
+        other: "{0} milligrammes par décilitre"
+        gender: masculine
+      short:
+        display_name: mg/dl
+        one: "{0} mg/dl"
+        other: "{0} mg/dl"
+      narrow:
+        one: "{0}mg/dl"
+        other: "{0}mg/dl"
+    millimole-per-liter:
+      long:
+        display_name: millimoles par litre
+        one: "{0} millimole par litre"
+        other: "{0} millimoles par litre"
+        gender: feminine
+      short:
+        display_name: mmol/l
+        one: "{0} mmol/l"
+        other: "{0} mmol/l"
+      narrow:
+        one: "{0}mmol/l"
+        other: "{0}mmol/l"
+    item:
+      long:
+        display_name: items
+        one: "{0} item"
+        other: "{0} items"
+        gender: masculine
+      short:
+        one: "{0} items"
+        other: "{0} items"
+      narrow:
+        one: "{0}item"
+        other: "{0}items"
+    permillion:
+      long:
+        display_name: parts par million
+        one: "{0} part par million"
+        other: "{0} parts par million"
+        gender: feminine
+      short:
+        one: "{0} ppm"
+        other: "{0} ppm"
+      narrow:
+        one: "{0}ppm"
+        other: "{0}ppm"
+    percent:
+      long:
+        display_name: pour cent
+        one: "{0} pour cent"
+        other: "{0} pour cent"
+        gender: masculine
+      short:
+        one: "{0} %"
+        other: "{0} %"
+    permille:
+      long:
+        display_name: pour mille
+        one: "{0} pour mille"
+        other: "{0} pour mille"
+        gender: masculine
+      short:
+        one: "{0} ‰"
+        other: "{0} ‰"
+      narrow:
+        one: "{0}‰"
+        other: "{0}‰"
+    permyriad:
+      long:
+        display_name: pour dix mille
+        one: "{0} pour dix mille"
+        other: "{0} pour dix mille"
+        gender: masculine
+      short:
+        one: "{0} ‱"
+        other: "{0} ‱"
+      narrow:
+        one: "{0}‱"
+        other: "{0}‱"
+    mole:
+      long:
+        display_name: moles
+        one: "{0} mole"
+        other: "{0} moles"
+        gender: feminine
+      short:
+        one: "{0} mol"
+        other: "{0} mol"
+      narrow:
+        one: "{0}mol"
+        other: "{0}mol"
+    liter-per-kilometer:
+      long:
+        display_name: litres au kilomètre
+        one: "{0} litre au kilomètre"
+        other: "{0} litres au kilomètre"
+        gender: masculine
+      short:
+        display_name: l/km
+        one: "{0} l/km"
+        other: "{0} l/km"
+      narrow:
+        one: "{0}l/km"
+        other: "{0}l/km"
+    liter-per-100-kilometer:
+      long:
+        display_name: litres aux 100 km
+        one: "{0} litre aux 100 km"
+        other: "{0} litres aux 100 km"
+        gender: masculine
+      short:
+        display_name: l/100 km
+        one: "{0} l/100 km"
+        other: "{0} l/100 km"
+      narrow:
+        display_name: l/100km
+        one: "{0}l/100km"
+        other: "{0}l/100km"
+    mile-per-gallon:
+      long:
+        display_name: miles par gallon
+        one: "{0} mile par gallon"
+        other: "{0} miles par gallon"
+        gender: masculine
+      short:
+        display_name: mi/gal
+        one: "{0} mi/gal"
+        other: "{0} mi/gal"
+      narrow:
+        one: "{0}mi/gal"
+        other: "{0}mi/gal"
+    mile-per-gallon-imperial:
+      long:
+        display_name: miles par gallon impérial
+        one: "{0} mile par gallon impérial"
+        other: "{0} miles par gallon impérial"
+        gender: masculine
+      short:
+        display_name: mi/gal imp.
+        one: "{0} mi/gal imp."
+        other: "{0} mi/gal imp."
+      narrow:
+        one: "{0}mi/gal imp."
+        other: "{0}mi/gal imp."
+    petabyte:
+      long:
+        display_name: pétaoctets
+        one: "{0} pétaoctet"
+        other: "{0} pétaoctets"
+        gender: masculine
+      short:
+        display_name: Po
+        one: "{0} Po"
+        other: "{0} Po"
+      narrow:
+        one: "{0}Po"
+        other: "{0}Po"
+    terabyte:
+      long:
+        display_name: téraoctets
+        one: "{0} téraoctet"
+        other: "{0} téraoctets"
+        gender: masculine
+      short:
+        display_name: To
+        one: "{0} To"
+        other: "{0} To"
+      narrow:
+        one: "{0}To"
+        other: "{0}To"
+    terabit:
+      long:
+        display_name: térabits
+        one: "{0} térabit"
+        other: "{0} térabits"
+        gender: masculine
+      short:
+        display_name: Tbit
+        one: "{0} Tbit"
+        other: "{0} Tbit"
+      narrow:
+        one: "{0}Tbit"
+        other: "{0}Tbit"
+    gigabyte:
+      long:
+        display_name: gigaoctets
+        one: "{0} gigaoctet"
+        other: "{0} gigaoctets"
+        gender: masculine
+      short:
+        display_name: Go
+        one: "{0} Go"
+        other: "{0} Go"
+      narrow:
+        one: "{0}Go"
+        other: "{0}Go"
+    gigabit:
+      long:
+        display_name: gigabits
+        one: "{0} gigabit"
+        other: "{0} gigabits"
+        gender: masculine
+      short:
+        display_name: Gbit
+        one: "{0} Gbit"
+        other: "{0} Gbit"
+      narrow:
+        one: "{0}Gbit"
+        other: "{0}Gbit"
+    megabyte:
+      long:
+        display_name: mégaoctets
+        one: "{0} mégaoctet"
+        other: "{0} mégaoctets"
+        gender: masculine
+      short:
+        display_name: Mo
+        one: "{0} Mo"
+        other: "{0} Mo"
+      narrow:
+        one: "{0}Mo"
+        other: "{0}Mo"
+    megabit:
+      long:
+        display_name: mégabits
+        one: "{0} mégabit"
+        other: "{0} mégabits"
+        gender: masculine
+      short:
+        display_name: Mbit
+        one: "{0} Mbit"
+        other: "{0} Mbit"
+      narrow:
+        one: "{0}Mbit"
+        other: "{0}Mbit"
+    kilobyte:
+      long:
+        display_name: kilooctets
+        one: "{0} kilooctet"
+        other: "{0} kilooctets"
+        gender: masculine
+      short:
+        display_name: ko
+        one: "{0} ko"
+        other: "{0} ko"
+      narrow:
+        one: "{0}ko"
+        other: "{0}ko"
+    kilobit:
+      long:
+        display_name: kilobits
+        one: "{0} kilobit"
+        other: "{0} kilobits"
+        gender: masculine
+      short:
+        display_name: kbit
+        one: "{0} kbit"
+        other: "{0} kbit"
+      narrow:
+        one: "{0}kbit"
+        other: "{0}kbit"
+    byte:
+      long:
+        display_name: octets
+        one: "{0} octet"
+        other: "{0} octets"
+        gender: masculine
+      short:
+        display_name: octet
+        one: "{0} o"
+        other: "{0} o"
+      narrow:
+        display_name: o
+        one: "{0}o"
+        other: "{0}o"
+    bit:
+      long:
+        display_name: bits
+        one: "{0} bit"
+        other: "{0} bits"
+        gender: masculine
+      short:
+        one: "{0} bit"
+        other: "{0} bit"
+      narrow:
+        one: "{0}bit"
+        other: "{0}bit"
+    century:
+      long:
+        display_name: siècles
+        one: "{0} siècle"
+        other: "{0} siècles"
+        gender: masculine
+      short:
+        display_name: s.
+        one: "{0} s."
+        other: "{0} s."
+      narrow:
+        one: "{0}s."
+        other: "{0}s."
+    decade:
+      long:
+        one: "{0} décennie"
+        other: "{0} décennies"
+        gender: feminine
+      short:
+        display_name: décennies
+        one: "{0} déc."
+        other: "{0} déc."
+      narrow:
+        display_name: déc.
+        one: "{0}déc."
+        other: "{0}déc."
+    year:
+      long:
+        one: "{0} an"
+        other: "{0} ans"
+        gender: masculine
+        per_unit_pattern: "{0} par an"
+      short:
+        display_name: ans
+        one: "{0} an"
+        other: "{0} ans"
+        per_unit_pattern: "{0}/an"
+      narrow:
+        display_name: a
+        one: "{0}a"
+        other: "{0}a"
+        per_unit_pattern: "{0}/a"
+    quarter:
+      long:
+        display_name: trimestres
+        one: "{0} trimestre"
+        other: "{0} trimestres"
+        gender: masculine
+        per_unit_pattern: "{0}/trimestre"
+      short:
+        display_name: trim.
+        one: "{0} trim."
+        other: "{0} trim."
+        per_unit_pattern: "{0}/trim."
+      narrow:
+        display_name: T
+        one: "{0} T"
+        other: "{0} T"
+        per_unit_pattern: "{0}/T"
+    month:
+      long:
+        display_name: mois
+        one: "{0} mois"
+        other: "{0} mois"
+        gender: masculine
+        per_unit_pattern: "{0} par mois"
+      short:
+        display_name: m.
+        one: "{0} m."
+        other: "{0} m."
+        per_unit_pattern: "{0}/m."
+      narrow:
+        one: "{0}m."
+        other: "{0}m."
+    week:
+      long:
+        display_name: semaines
+        one: "{0} semaine"
+        other: "{0} semaines"
+        gender: feminine
+        per_unit_pattern: "{0} par semaine"
+      short:
+        display_name: sem.
+        one: "{0} sem."
+        other: "{0} sem."
+        per_unit_pattern: "{0}/sem."
+      narrow:
+        one: "{0}sem."
+        other: "{0}sem."
+    day:
+      long:
+        display_name: jours
+        one: "{0} jour"
+        other: "{0} jours"
+        gender: masculine
+        per_unit_pattern: "{0} par jour"
+      short:
+        display_name: j
+        one: "{0} j"
+        other: "{0} j"
+        per_unit_pattern: "{0}/j"
+      narrow:
+        one: "{0}j"
+        other: "{0}j"
+    day-person:
+      long:
+        gender: masculine
+    hour:
+      long:
+        display_name: heures
+        one: "{0} heure"
+        other: "{0} heures"
+        gender: feminine
+        per_unit_pattern: "{0} par heure"
+      short:
+        display_name: h
+        one: "{0} h"
+        other: "{0} h"
+      narrow:
+        one: "{0}h"
+        other: "{0}h"
+    minute:
+      long:
+        display_name: minutes
+        one: "{0} minute"
+        other: "{0} minutes"
+        gender: feminine
+        per_unit_pattern: "{0} par minute"
+      short:
+        one: "{0} min"
+        other: "{0} min"
+      narrow:
+        one: "{0}min"
+        other: "{0}min"
+    second:
+      long:
+        display_name: secondes
+        one: "{0} seconde"
+        other: "{0} secondes"
+        gender: feminine
+        per_unit_pattern: "{0} par seconde"
+      short:
+        display_name: s
+        one: "{0} s"
+        other: "{0} s"
+      narrow:
+        one: "{0}s"
+        other: "{0}s"
+    millisecond:
+      long:
+        display_name: millisecondes
+        one: "{0} milliseconde"
+        other: "{0} millisecondes"
+        gender: feminine
+      short:
+        one: "{0} ms"
+        other: "{0} ms"
+      narrow:
+        one: "{0}ms"
+        other: "{0}ms"
+    microsecond:
+      long:
+        display_name: microsecondes
+        one: "{0} microseconde"
+        other: "{0} microsecondes"
+        gender: feminine
+      short:
+        one: "{0} μs"
+        other: "{0} μs"
+      narrow:
+        one: "{0}μs"
+        other: "{0}μs"
+    nanosecond:
+      long:
+        display_name: nanosecondes
+        one: "{0} nanoseconde"
+        other: "{0} nanosecondes"
+        gender: feminine
+      short:
+        one: "{0} ns"
+        other: "{0} ns"
+      narrow:
+        one: "{0}ns"
+        other: "{0}ns"
+    ampere:
+      long:
+        display_name: ampères
+        one: "{0} ampère"
+        other: "{0} ampères"
+        gender: masculine
+      short:
+        display_name: A
+        one: "{0} A"
+        other: "{0} A"
+      narrow:
+        one: "{0}A"
+        other: "{0}A"
+    milliampere:
+      long:
+        display_name: milliampères
+        one: "{0} milliampère"
+        other: "{0} milliampères"
+        gender: masculine
+      short:
+        one: "{0} mA"
+        other: "{0} mA"
+      narrow:
+        one: "{0}mA"
+        other: "{0}mA"
+    ohm:
+      long:
+        display_name: ohms
+        one: "{0} ohm"
+        other: "{0} ohms"
+        gender: masculine
+      short:
+        display_name: Ω
+        one: "{0} Ω"
+        other: "{0} Ω"
+      narrow:
+        one: "{0}Ω"
+        other: "{0}Ω"
+    volt:
+      long:
+        display_name: volts
+        one: "{0} volt"
+        other: "{0} volts"
+        gender: masculine
+      short:
+        display_name: V
+        one: "{0} V"
+        other: "{0} V"
+      narrow:
+        one: "{0}V"
+        other: "{0}V"
+    kilocalorie:
+      long:
+        display_name: kilocalories
+        one: "{0} kilocalorie"
+        other: "{0} kilocalories"
+        gender: feminine
+      short:
+        one: "{0} kcal"
+        other: "{0} kcal"
+      narrow:
+        one: "{0}kcal"
+        other: "{0}kcal"
+    calorie:
+      long:
+        display_name: calories
+        one: "{0} calorie"
+        other: "{0} calories"
+        gender: feminine
+      short:
+        one: "{0} cal"
+        other: "{0} cal"
+      narrow:
+        one: "{0}cal"
+        other: "{0}cal"
+    foodcalorie:
+      long:
+        display_name: kilocalories
+        one: "{0} kilocalorie"
+        other: "{0} kilocalories"
+        gender: feminine
+      short:
+        one: "{0} kcal"
+        other: "{0} kcal"
+      narrow:
+        one: "{0}kcal"
+        other: "{0}kcal"
+    kilojoule:
+      long:
+        display_name: kilojoules
+        one: "{0} kilojoule"
+        other: "{0} kilojoules"
+        gender: masculine
+      short:
+        one: "{0} kJ"
+        other: "{0} kJ"
+      narrow:
+        one: "{0}kJ"
+        other: "{0}kJ"
+    joule:
+      long:
+        display_name: joules
+        one: "{0} joule"
+        other: "{0} joules"
+        gender: masculine
+      short:
+        display_name: J
+        one: "{0} J"
+        other: "{0} J"
+      narrow:
+        one: "{0}J"
+        other: "{0}J"
+    kilowatt-hour:
+      long:
+        display_name: kilowatt-heures
+        one: "{0} kilowatt-heure"
+        other: "{0} kilowatt-heures"
+        gender: masculine
+      short:
+        one: "{0} kWh"
+        other: "{0} kWh"
+      narrow:
+        one: "{0}kWh"
+        other: "{0}kWh"
+    electronvolt:
+      long:
+        display_name: électronvolts
+        one: "{0} électronvolt"
+        other: "{0} électronvolts"
+      short:
+        one: "{0} eV"
+        other: "{0} eV"
+      narrow:
+        one: "{0}eV"
+        other: "{0}eV"
+    british-thermal-unit:
+      long:
+        display_name: British Thermal Units
+        one: "{0} British Thermal Unit"
+        other: "{0} British Thermal Units"
+      short:
+        display_name: BTU
+        one: "{0} Btu"
+        other: "{0} Btu"
+      narrow:
+        one: "{0}Btu"
+        other: "{0}Btu"
+    therm-us:
+      long:
+        display_name: therms US
+      short:
+        display_name: therm US
+        one: "{0} therm US"
+        other: "{0} therms US"
+      narrow:
+        display_name: thm US
+        one: "{0}thm US"
+        other: "{0}thm US"
+    pound-force:
+      long:
+        display_name: livres-force
+        one: "{0} livre-force"
+        other: "{0} livres-force"
+      short:
+        one: "{0} lbf"
+        other: "{0} lbf"
+      narrow:
+        one: "{0}lbf"
+        other: "{0}lbf"
+    newton:
+      long:
+        display_name: newtons
+        one: "{0} newton"
+        other: "{0} newtons"
+        gender: masculine
+      short:
+        one: "{0} N"
+        other: "{0} N"
+      narrow:
+        one: "{0}N"
+        other: "{0}N"
+    kilowatt-hour-per-100-kilometer:
+      long:
+        display_name: kilowatt-heures pour 100 kilomètres
+        one: "{0} kilowatt-heure pour 100 kilomètres"
+        other: "{0} kilowatt-heures pour 100 kilomètres"
+        gender: masculine
+      short:
+        display_name: kWh/100 km
+        one: "{0} kWh/100 km"
+        other: "{0} kWh/100 km"
+      narrow:
+        one: "{0}kWh/100km"
+        other: "{0}kWh/100km"
+    gigahertz:
+      long:
+        display_name: gigahertz
+        one: "{0} gigahertz"
+        other: "{0} gigahertz"
+        gender: masculine
+      short:
+        one: "{0} GHz"
+        other: "{0} GHz"
+      narrow:
+        one: "{0}GHz"
+        other: "{0}GHz"
+    megahertz:
+      long:
+        display_name: mégahertz
+        one: "{0} mégahertz"
+        other: "{0} mégahertz"
+        gender: masculine
+      short:
+        one: "{0} MHz"
+        other: "{0} MHz"
+      narrow:
+        one: "{0}MHz"
+        other: "{0}MHz"
+    kilohertz:
+      long:
+        display_name: kilohertz
+        one: "{0} kilohertz"
+        other: "{0} kilohertz"
+        gender: masculine
+      short:
+        one: "{0} kHz"
+        other: "{0} kHz"
+      narrow:
+        one: "{0}kHz"
+        other: "{0}kHz"
+    hertz:
+      long:
+        display_name: hertz
+        one: "{0} hertz"
+        other: "{0} hertz"
+        gender: masculine
+      short:
+        one: "{0} Hz"
+        other: "{0} Hz"
+      narrow:
+        one: "{0}Hz"
+        other: "{0}Hz"
+    em:
+      long:
+        display_name: cadratin
+        one: "{0} cadratin"
+        other: "{0} cadratins"
+        gender: masculine
+      short:
+        one: "{0} em"
+        other: "{0} em"
+      narrow:
+        one: "{0}em"
+        other: "{0}em"
+    pixel:
+      long:
+        display_name: pixels
+        one: "{0} pixel"
+        other: "{0} pixels"
+        gender: masculine
+      short:
+        one: "{0} px"
+      narrow:
+        one: "{0}px"
+        other: "{0}px"
+    megapixel:
+      long:
+        display_name: mégapixels
+        one: "{0} mégapixel"
+        other: "{0} mégapixels"
+        gender: masculine
+      short:
+        display_name: Mpx
+        one: "{0} Mpx"
+        other: "{0} Mpx"
+      narrow:
+        one: "{0}Mpx"
+        other: "{0}Mpx"
+    pixel-per-centimeter:
+      long:
+        display_name: pixels par centimètre
+        one: "{0} pixel par centimètre"
+        other: "{0} pixels par centimètre"
+        gender: masculine
+      short:
+        display_name: px/cm
+        one: "{0} px/cm"
+        other: "{0} px/cm"
+      narrow:
+        one: "{0}px/cm"
+        other: "{0}px/cm"
+    pixel-per-inch:
+      long:
+        display_name: pixels par pouce
+        one: "{0} pixel par pouce"
+        other: "{0} pixels par pouce"
+      short:
+        display_name: px/po
+        one: "{0} px/po"
+        other: "{0} px/po"
+      narrow:
+        one: "{0}px/po"
+        other: "{0}px/po"
+    dot-per-centimeter:
+      long:
+        display_name: points par centimètre
+        one: "{0} point par centimètre"
+        other: "{0} points par centimètre"
+      short:
+        display_name: pt/cm
+        one: "{0} pt/cm"
+        other: "{0} pt/cm"
+      narrow:
+        one: "{0}pt/cm"
+        other: "{0}pt/cm"
+    dot-per-inch:
+      long:
+        display_name: points par pouce
+        one: "{0} point par pouce"
+        other: "{0} points par pouce"
+      short:
+        display_name: pt/po
+        one: "{0} pt/po"
+        other: "{0} pt/po"
+      narrow:
+        one: "{0}pt/po"
+        other: "{0}pt/po"
+    dot:
+      long:
+        display_name: points
+        one: "{0} point"
+        other: "{0} points"
+      short:
+        display_name: pt
+        one: "{0} pt"
+        other: "{0} pt"
+      narrow:
+        one: "{0}pt"
+        other: "{0}pt"
+    earth-radius:
+      long:
+        display_name: rayon terrestre
+        one: "{0} rayon terrestre"
+        other: "{0} rayons terrestres"
+    kilometer:
+      long:
+        display_name: kilomètres
+        one: "{0} kilomètre"
+        other: "{0} kilomètres"
+        gender: masculine
+        per_unit_pattern: "{0} par kilomètre"
+      short:
+        one: "{0} km"
+        other: "{0} km"
+      narrow:
+        one: "{0}km"
+        other: "{0}km"
+    meter:
+      long:
+        display_name: mètres
+        one: "{0} mètre"
+        other: "{0} mètres"
+        gender: masculine
+        per_unit_pattern: "{0} par mètre"
+      short:
+        display_name: m
+        one: "{0} m"
+        other: "{0} m"
+      narrow:
+        one: "{0}m"
+        other: "{0}m"
+    decimeter:
+      long:
+        display_name: décimètres
+        one: "{0} décimètre"
+        other: "{0} décimètres"
+        gender: masculine
+      short:
+        one: "{0} dm"
+        other: "{0} dm"
+    centimeter:
+      long:
+        display_name: centimètres
+        one: "{0} centimètre"
+        other: "{0} centimètres"
+        gender: masculine
+        per_unit_pattern: "{0} par centimètre"
+      short:
+        one: "{0} cm"
+        other: "{0} cm"
+      narrow:
+        one: "{0}cm"
+        other: "{0}cm"
+    millimeter:
+      long:
+        display_name: millimètres
+        one: "{0} millimètre"
+        other: "{0} millimètres"
+        gender: masculine
+      short:
+        one: "{0} mm"
+        other: "{0} mm"
+      narrow:
+        one: "{0}mm"
+        other: "{0}mm"
+    micrometer:
+      long:
+        display_name: micromètres
+        one: "{0} micromètre"
+        other: "{0} micromètres"
+        gender: masculine
+      short:
+        one: "{0} μm"
+        other: "{0} μm"
+    nanometer:
+      long:
+        display_name: nanomètres
+        one: "{0} nanomètre"
+        other: "{0} nanomètres"
+        gender: masculine
+      short:
+        one: "{0} nm"
+        other: "{0} nm"
+    picometer:
+      long:
+        display_name: picomètres
+        one: "{0} picomètre"
+        other: "{0} picomètres"
+        gender: masculine
+      short:
+        one: "{0} pm"
+        other: "{0} pm"
+      narrow:
+        one: "{0}pm"
+        other: "{0}pm"
+    mile:
+      long:
+        display_name: miles
+        one: "{0} mile"
+        other: "{0} miles"
+        gender: masculine
+      short:
+        one: "{0} mi"
+        other: "{0} mi"
+      narrow:
+        one: "{0}mi"
+        other: "{0}mi"
+    yard:
+      long:
+        display_name: yards
+        one: "{0} yard"
+        other: "{0} yards"
+        gender: masculine
+      short:
+        one: "{0} yd"
+        other: "{0} yd"
+      narrow:
+        one: "{0}yd"
+        other: "{0}yd"
+    foot:
+      long:
+        display_name: pieds
+        one: "{0} pied"
+        other: "{0} pieds"
+        gender: masculine
+        per_unit_pattern: "{0} par pied"
+      short:
+        display_name: pi
+        one: "{0} pi"
+        other: "{0} pi"
+        per_unit_pattern: "{0}/pi"
+      narrow:
+        one: "{0}′"
+        other: "{0}′"
+    inch:
+      long:
+        display_name: pouces
+        one: "{0} pouce"
+        other: "{0} pouces"
+        gender: masculine
+        per_unit_pattern: "{0} par pouce"
+      short:
+        display_name: po
+        one: "{0} po"
+        other: "{0} po"
+        per_unit_pattern: "{0}/po"
+      narrow:
+        one: "{0}″"
+        other: "{0}″"
+    parsec:
+      long:
+        display_name: parsecs
+        one: "{0} parsec"
+        other: "{0} parsecs"
+        gender: masculine
+      short:
+        one: "{0} pc"
+        other: "{0} pc"
+    light-year:
+      long:
+        display_name: années-lumière
+        one: "{0} année-lumière"
+        other: "{0} années-lumière"
+      short:
+        display_name: al
+        one: "{0} al"
+        other: "{0} al"
+    astronomical-unit:
+      long:
+        display_name: unités astronomiques
+        one: "{0} unité astronomique"
+        other: "{0} unités astronomiques"
+      short:
+        display_name: ua
+        one: "{0} ua"
+        other: "{0} ua"
+      narrow:
+        one: "{0}ua"
+        other: "{0}ua"
+    furlong:
+      long:
+        display_name: furlongs
+        one: "{0} furlong"
+        other: "{0} furlongs"
+    fathom:
+      long:
+        display_name: brasses
+        one: "{0} brasse"
+        other: "{0} brasses"
+      short:
+        one: "{0} fm"
+        other: "{0} fm"
+    nautical-mile:
+      long:
+        display_name: milles marins
+        one: "{0} mille marin"
+        other: "{0} milles marins"
+      short:
+        one: "{0} nmi"
+        other: "{0} nmi"
+    mile-scandinavian:
+      long:
+        display_name: milles scandinaves
+        one: "{0} mille scandinave"
+        other: "{0} milles scandinaves"
+        gender: masculine
+      short:
+        one: "{0} smi"
+        other: "{0} smi"
+    point:
+      long:
+        one: "{0} point typographique"
+        other: "{0} points typographiques"
+        gender: masculine
+      short:
+        display_name: pt typog.
+        one: "{0} pt typog."
+        other: "{0} pts typog."
+    solar-radius:
+      long:
+        display_name: rayons solaires
+        one: "{0} rayon solaire"
+        other: "{0} rayons solaires"
+        gender: masculine
+      short:
+        one: "{0} R☉"
+        other: "{0} R☉"
+      narrow:
+        one: "{0}R☉"
+        other: "{0}R☉"
+    lux:
+      long:
+        display_name: lux
+        one: "{0} lux"
+        other: "{0} lux"
+        gender: masculine
+      short:
+        one: "{0} lx"
+        other: "{0} lx"
+      narrow:
+        one: "{0}lx"
+        other: "{0}lx"
+    candela:
+      long:
+        display_name: candela
+        one: "{0} candela"
+        other: "{0} candelas"
+        gender: feminine
+      narrow:
+        one: "{0}cd"
+        other: "{0}cd"
+    lumen:
+      long:
+        display_name: lumen
+        one: "{0} lumen"
+        other: "{0} lumens"
+        gender: masculine
+      narrow:
+        one: "{0}lm"
+        other: "{0}lm"
+    solar-luminosity:
+      long:
+        display_name: luminosités solaires
+        one: "{0} luminosité solaire"
+        other: "{0} luminosités solaires"
+        gender: feminine
+      short:
+        one: "{0} L☉"
+        other: "{0} L☉"
+      narrow:
+        one: "{0}L☉"
+        other: "{0}L☉"
+    tonne:
+      long:
+        display_name: tonnes
+        one: "{0} tonne"
+        other: "{0} tonnes"
+        gender: feminine
+      short:
+        one: "{0} t"
+        other: "{0} t"
+      narrow:
+        one: "{0}t"
+        other: "{0}t"
+    kilogram:
+      long:
+        display_name: kilogrammes
+        one: "{0} kilogramme"
+        other: "{0} kilogrammes"
+        gender: masculine
+        per_unit_pattern: "{0} par kilogramme"
+      short:
+        one: "{0} kg"
+        other: "{0} kg"
+      narrow:
+        one: "{0}kg"
+        other: "{0}kg"
+    gram:
+      long:
+        display_name: grammes
+        one: "{0} gramme"
+        other: "{0} grammes"
+        gender: masculine
+        per_unit_pattern: "{0} par gramme"
+      short:
+        display_name: g
+        one: "{0} g"
+        other: "{0} g"
+      narrow:
+        one: "{0}g"
+        other: "{0}g"
+    milligram:
+      long:
+        display_name: milligrammes
+        one: "{0} milligramme"
+        other: "{0} milligrammes"
+        gender: masculine
+      short:
+        one: "{0} mg"
+        other: "{0} mg"
+      narrow:
+        one: "{0}mg"
+        other: "{0}mg"
+    microgram:
+      long:
+        display_name: microgrammes
+        one: "{0} microgramme"
+        other: "{0} microgrammes"
+        gender: masculine
+      short:
+        one: "{0} μg"
+        other: "{0} μg"
+      narrow:
+        one: "{0}μg"
+        other: "{0}μg"
+    ton:
+      long:
+        display_name: tonnes courtes
+        one: "{0} tonne courte"
+        other: "{0} tonnes courtes"
+      short:
+        display_name: sh tn
+        one: "{0} sh tn"
+        other: "{0} sh tn"
+      narrow:
+        one: "{0} sh tn"
+        other: "{0} sh tn"
+    stone:
+      long:
+        display_name: stones
+        one: "{0} stone"
+        other: "{0} stones"
+    pound:
+      long:
+        display_name: livres
+        one: "{0} livre"
+        other: "{0} livres"
+        gender: feminine
+        per_unit_pattern: "{0} par livre"
+      short:
+        one: "{0} lb"
+        other: "{0} lb"
+      narrow:
+        one: "{0}lb"
+        other: "{0}lb"
+    ounce:
+      long:
+        display_name: onces
+        one: "{0} once"
+        other: "{0} onces"
+        gender: feminine
+        per_unit_pattern: "{0} par once"
+      short:
+        one: "{0} oz"
+        other: "{0} oz"
+      narrow:
+        one: "{0}oz"
+        other: "{0}oz"
+    ounce-troy:
+      long:
+        display_name: onces troy
+        one: "{0} once troy"
+        other: "{0} onces troy"
+      short:
+        one: "{0} oz t"
+        other: "{0} oz t"
+      narrow:
+        display_name: oz t
+        one: "{0}oz t"
+        other: "{0}oz t"
+    carat:
+      long:
+        display_name: carats
+        one: "{0} carat"
+        other: "{0} carats"
+        gender: masculine
+      short:
+        display_name: ct
+        one: "{0} ct"
+        other: "{0} ct"
+      narrow:
+        one: "{0}ct"
+        other: "{0}ct"
+    dalton:
+      long:
+        display_name: daltons
+        one: "{0} dalton"
+        other: "{0} daltons"
+        gender: masculine
+      short:
+        one: "{0} Da"
+        other: "{0} Da"
+      narrow:
+        one: "{0}Da"
+        other: "{0}Da"
+    earth-mass:
+      long:
+        display_name: masses terrestres
+        one: "{0} masse terrestre"
+        other: "{0} masses terrestres"
+        gender: feminine
+      short:
+        one: "{0} M⊕"
+        other: "{0} M⊕"
+      narrow:
+        one: "{0}M⊕"
+        other: "{0}M⊕"
+    solar-mass:
+      long:
+        display_name: masses solaires
+        one: "{0} masse solaire"
+        other: "{0} masses solaires"
+        gender: feminine
+      short:
+        one: "{0} M☉"
+        other: "{0} M☉"
+      narrow:
+        one: "{0}M☉"
+        other: "{0}M☉"
+    grain:
+      long:
+        display_name: grains
+        one: "{0} grain"
+        other: "{0} grains"
+        gender: masculine
+      short:
+        one: "{0} grains"
+        other: "{0} grains"
+      narrow:
+        one: "{0} grain"
+        other: "{0} grains"
+    gigawatt:
+      long:
+        display_name: gigawatts
+        one: "{0} gigawatt"
+        other: "{0} gigawatts"
+        gender: masculine
+      short:
+        one: "{0} GW"
+        other: "{0} GW"
+      narrow:
+        one: "{0}GW"
+        other: "{0}GW"
+    megawatt:
+      long:
+        display_name: mégawatts
+        one: "{0} mégawatt"
+        other: "{0} mégawatts"
+        gender: masculine
+      short:
+        one: "{0} MW"
+        other: "{0} MW"
+      narrow:
+        one: "{0}MW"
+        other: "{0}MW"
+    kilowatt:
+      long:
+        display_name: kilowatts
+        one: "{0} kilowatt"
+        other: "{0} kilowatts"
+        gender: masculine
+      short:
+        one: "{0} kW"
+        other: "{0} kW"
+      narrow:
+        one: "{0}kW"
+        other: "{0}kW"
+    watt:
+      long:
+        display_name: watts
+        one: "{0} watt"
+        other: "{0} watts"
+        gender: masculine
+      short:
+        display_name: W
+        one: "{0} W"
+        other: "{0} W"
+      narrow:
+        one: "{0}W"
+        other: "{0}W"
+    milliwatt:
+      long:
+        display_name: milliwatts
+        one: "{0} milliwatt"
+        other: "{0} milliwatts"
+        gender: masculine
+      short:
+        one: "{0} mW"
+        other: "{0} mW"
+      narrow:
+        one: "{0}mW"
+        other: "{0}mW"
+    horsepower:
+      long:
+        display_name: chevaux-vapeur
+        one: "{0} cheval-vapeur"
+        other: "{0} chevaux-vapeur"
+      short:
+        display_name: ch
+        one: "{0} ch"
+        other: "{0} ch"
+      narrow:
+        one: "{0}ch"
+        other: "{0}ch"
+    millimeter-ofhg:
+      long:
+        display_name: millimètres de mercure
+        one: "{0} millimètre de mercure"
+        other: "{0} millimètres de mercure"
+        gender: masculine
+      short:
+        display_name: mmHg
+        one: "{0} mmHg"
+        other: "{0} mmHg"
+      narrow:
+        one: "{0} mmHg"
+        other: "{0} mmHg"
+    pound-force-per-square-inch:
+      long:
+        display_name: livres-force par pouce carré
+        one: "{0} livre-force par pouce carré"
+        other: "{0} livres-force par pouce carré"
+      short:
+        display_name: lb/po²
+        one: "{0} lb/po²"
+        other: "{0} lb/po²"
+      narrow:
+        one: "{0} lb/po²"
+        other: "{0} lb/po²"
+    inch-ofhg:
+      long:
+        display_name: pouces de mercure
+        one: "{0} pouce de mercure"
+        other: "{0} pouces de mercure"
+      short:
+        one: "{0} inHg"
+        other: "{0} inHg"
+    bar:
+      long:
+        display_name: bars
+        gender: masculine
+      short:
+        one: "{0} bar"
+        other: "{0} bars"
+      narrow:
+        one: "{0}bar"
+        other: "{0}bar"
+    millibar:
+      long:
+        display_name: millibars
+        one: "{0} millibar"
+        other: "{0} millibars"
+        gender: masculine
+      short:
+        one: "{0} mbar"
+        other: "{0} mbar"
+      narrow:
+        one: "{0}mbar"
+        other: "{0}mbar"
+    atmosphere:
+      long:
+        display_name: atmosphères
+        one: "{0} atmosphère"
+        other: "{0} atmosphères"
+        gender: feminine
+      short:
+        one: "{0} atm"
+        other: "{0} atm"
+      narrow:
+        one: "{0}atm"
+        other: "{0}atm"
+    pascal:
+      long:
+        display_name: pascals
+        one: "{0} pascal"
+        other: "{0} pascals"
+        gender: masculine
+      short:
+        one: "{0} Pa"
+        other: "{0} Pa"
+      narrow:
+        one: "{0}Pa"
+        other: "{0}Pa"
+    hectopascal:
+      long:
+        display_name: hectopascals
+        one: "{0} hectopascal"
+        other: "{0} hectopascals"
+        gender: masculine
+      short:
+        one: "{0} hPa"
+        other: "{0} hPa"
+      narrow:
+        one: "{0}hPa"
+        other: "{0}hPa"
+    kilopascal:
+      long:
+        display_name: kilopascals
+        one: "{0} kilopascal"
+        other: "{0} kilopascals"
+        gender: masculine
+      short:
+        one: "{0} kPa"
+        other: "{0} kPa"
+      narrow:
+        one: "{0}kPa"
+        other: "{0}kPa"
+    megapascal:
+      long:
+        display_name: mégapascals
+        one: "{0} mégapascal"
+        other: "{0} mégapascals"
+        gender: masculine
+      short:
+        one: "{0} MPa"
+        other: "{0} MPa"
+      narrow:
+        one: "{0}MPa"
+        other: "{0}MPa"
+    kilometer-per-hour:
+      long:
+        display_name: kilomètres par heure
+        one: "{0} kilomètre par heure"
+        other: "{0} kilomètres par heure"
+        gender: masculine
+      short:
+        one: "{0} km/h"
+        other: "{0} km/h"
+      narrow:
+        one: "{0}km/h"
+        other: "{0}km/h"
+    meter-per-second:
+      long:
+        display_name: mètres par seconde
+        one: "{0} mètre par seconde"
+        other: "{0} mètres par seconde"
+        gender: masculine
+      short:
+        one: "{0} m/s"
+        other: "{0} m/s"
+      narrow:
+        one: "{0} m/s"
+        other: "{0}m/s"
+    mile-per-hour:
+      long:
+        display_name: miles par heure
+        one: "{0} mile par heure"
+        other: "{0} miles par heure"
+        gender: masculine
+      short:
+        one: "{0} mi/h"
+        other: "{0} mi/h"
+    knot:
+      long:
+        display_name: nœuds
+        one: "{0} nœud"
+        other: "{0} nœuds"
+      short:
+        display_name: nd
+        one: "{0} nd"
+        other: "{0} nd"
+      narrow:
+        one: "{0} nd"
+        other: "{0} nd"
+    beaufort:
+      long:
+        display_name: Beaufort
+        one: "{0} degré Beaufort"
+        other: "{0} degrés Beaufort"
+      short:
+        one: "{0} Bft"
+        other: "{0} Bft"
+      narrow:
+        one: "{0}Bft"
+        other: "{0}Bft"
+    generic:
+      long:
+        display_name: degrés
+        one: "{0} degré"
+        other: "{0} degrés"
+        gender: masculine
+    celsius:
+      long:
+        display_name: degrés Celsius
+        one: "{0} degré Celsius"
+        other: "{0} degrés Celsius"
+        gender: masculine
+      short:
+        one: "{0} °C"
+        other: "{0} °C"
+      narrow:
+        one: "{0}°C"
+        other: "{0}°C"
+    fahrenheit:
+      long:
+        display_name: degrés Fahrenheit
+        one: "{0} degré Fahrenheit"
+        other: "{0} degrés Fahrenheit"
+        gender: masculine
+      short:
+        one: "{0} °F"
+        other: "{0} °F"
+      narrow:
+        one: "{0}°F"
+        other: "{0}°F"
+    kelvin:
+      long:
+        display_name: kelvins
+        one: "{0} kelvin"
+        other: "{0} kelvins"
+        gender: masculine
+      short:
+        one: "{0} K"
+        other: "{0} K"
+      narrow:
+        one: "{0}K"
+        other: "{0}K"
+    pound-force-foot:
+      long:
+        display_name: livres-force-pieds
+        one: "{0} livre-force-pied"
+        other: "{0} livres-force-pieds"
+      short:
+        one: "{0} lbf⋅ft"
+        other: "{0} lbf⋅ft"
+      narrow:
+        one: "{0}lbf⋅ft"
+        other: "{0}lbf⋅ft"
+    newton-meter:
+      long:
+        display_name: newtons-mètres
+        one: "{0} newton-mètre"
+        other: "{0} newtons-mètres"
+        gender: masculine
+      short:
+        one: "{0} N⋅m"
+        other: "{0} N⋅m"
+      narrow:
+        one: "{0}N⋅m"
+        other: "{0}N⋅m"
+    cubic-kilometer:
+      long:
+        display_name: kilomètres cubes
+        one: "{0} kilomètre cube"
+        other: "{0} kilomètres cubes"
+        gender: masculine
+      short:
+        one: "{0} km³"
+        other: "{0} km³"
+      narrow:
+        one: "{0}km³"
+        other: "{0}km³"
+    cubic-meter:
+      long:
+        display_name: mètres cubes
+        one: "{0} mètre cube"
+        other: "{0} mètres cubes"
+        gender: masculine
+        per_unit_pattern: "{0} par mètre cube"
+      short:
+        one: "{0} m³"
+        other: "{0} m³"
+      narrow:
+        one: "{0}m³"
+        other: "{0}m³"
+    cubic-centimeter:
+      long:
+        display_name: centimètres cubes
+        one: "{0} centimètre cube"
+        other: "{0} centimètres cubes"
+        gender: masculine
+        per_unit_pattern: "{0} par centimètre cube"
+      short:
+        one: "{0} cm³"
+        other: "{0} cm³"
+      narrow:
+        one: "{0}cm³"
+        other: "{0}cm³"
+    cubic-mile:
+      long:
+        display_name: milles cubes
+        one: "{0} mille cube"
+        other: "{0} milles cubes"
+        gender: masculine
+      short:
+        one: "{0} mi³"
+        other: "{0} mi³"
+      narrow:
+        one: "{0}mi³"
+        other: "{0}mi³"
+    cubic-yard:
+      long:
+        display_name: yards cubes
+        one: "{0} yard cube"
+        other: "{0} yards cubes"
+      short:
+        one: "{0} yd³"
+        other: "{0} yd³"
+      narrow:
+        one: "{0}yd³"
+        other: "{0}yd³"
+    cubic-foot:
+      long:
+        display_name: pieds cubes
+        one: "{0} pied cube"
+        other: "{0} pieds cubes"
+        gender: masculine
+      short:
+        display_name: pi³
+        one: "{0} pi³"
+        other: "{0} pi³"
+      narrow:
+        one: "{0}pi³"
+        other: "{0}pi³"
+    cubic-inch:
+      long:
+        display_name: pouces cubes
+        one: "{0} pouce cube"
+        other: "{0} pouces cubes"
+      short:
+        display_name: po³
+        one: "{0} po³"
+        other: "{0} po³"
+      narrow:
+        one: "{0}po³"
+        other: "{0}po³"
+    megaliter:
+      long:
+        display_name: mégalitres
+        one: "{0} mégalitre"
+        other: "{0} mégalitres"
+        gender: masculine
+      short:
+        display_name: Ml
+        one: "{0} Ml"
+        other: "{0} Ml"
+      narrow:
+        one: "{0}Ml"
+        other: "{0}Ml"
+    hectoliter:
+      long:
+        display_name: hectolitres
+        one: "{0} hectolitre"
+        other: "{0} hectolitres"
+        gender: masculine
+      short:
+        display_name: hl
+        one: "{0} hl"
+        other: "{0} hl"
+      narrow:
+        one: "{0}hl"
+        other: "{0}hl"
+    liter:
+      long:
+        display_name: litres
+        one: "{0} litre"
+        other: "{0} litres"
+        gender: masculine
+        per_unit_pattern: "{0} par litre"
+      short:
+        display_name: l
+        one: "{0} l"
+        other: "{0} l"
+      narrow:
+        one: "{0}l"
+        other: "{0}l"
+    deciliter:
+      long:
+        display_name: décilitres
+        one: "{0} décilitre"
+        other: "{0} décilitres"
+        gender: masculine
+      short:
+        display_name: dl
+        one: "{0} dl"
+        other: "{0} dl"
+      narrow:
+        one: "{0}dl"
+        other: "{0}dl"
+    centiliter:
+      long:
+        display_name: centilitres
+        one: "{0} centilitre"
+        other: "{0} centilitres"
+        gender: masculine
+      short:
+        display_name: cl
+        one: "{0} cl"
+        other: "{0} cl"
+      narrow:
+        one: "{0}cl"
+        other: "{0}cl"
+    milliliter:
+      long:
+        display_name: millilitres
+        one: "{0} millilitre"
+        other: "{0} millilitres"
+        gender: masculine
+      short:
+        display_name: ml
+        one: "{0} ml"
+        other: "{0} ml"
+      narrow:
+        one: "{0}ml"
+        other: "{0}ml"
+    pint-metric:
+      long:
+        display_name: pintes métriques
+        one: "{0} pinte métrique"
+        other: "{0} pintes métriques"
+        gender: feminine
+      narrow:
+        one: "{0}mpt"
+        other: "{0}mpt"
+    cup-metric:
+      long:
+        display_name: tasses métriques
+        one: "{0} tasse métrique"
+        other: "{0} tasses métriques"
+        gender: feminine
+      short:
+        display_name: tm
+        one: "{0} tm"
+        other: "{0} tm"
+      narrow:
+        one: "{0}tm"
+        other: "{0}tm"
+    acre-foot:
+      long:
+        display_name: acres-pieds
+        one: "{0} acre-pied"
+        other: "{0} acres-pieds"
+      short:
+        display_name: ac pi
+        one: "{0} ac pi"
+        other: "{0} ac pi"
+      narrow:
+        display_name: acpi
+        one: "{0}acpi"
+        other: "{0}acpi"
+    bushel:
+      long:
+        display_name: boisseaux
+        one: "{0} boisseau"
+        other: "{0} boisseaux"
+      short:
+        one: "{0} bu"
+        other: "{0} bu"
+      narrow:
+        one: "{0}bu"
+        other: "{0}bu"
+    gallon:
+      long:
+        display_name: gallons
+        one: "{0} gallon"
+        other: "{0} gallons"
+        gender: masculine
+        per_unit_pattern: "{0} par gallon"
+      short:
+        display_name: gal
+        one: "{0} gal"
+        other: "{0} gal"
+        per_unit_pattern: "{0}/gal"
+      narrow:
+        one: "{0}gal"
+        other: "{0}gal"
+    gallon-imperial:
+      long:
+        display_name: gallons impériaux
+        one: "{0} gallon impérial"
+        other: "{0} gallons impériaux"
+        gender: masculine
+        per_unit_pattern: "{0} par gallon impérial"
+      short:
+        display_name: gal imp.
+        one: "{0} gal imp."
+        other: "{0} gal imp."
+        per_unit_pattern: "{0} gal imp."
+      narrow:
+        one: "{0}gal imp."
+        other: "{0}gal imp."
+        per_unit_pattern: "{0}/gal imp."
+    quart:
+      long:
+        display_name: quarts
+        one: "{0} quart"
+        other: "{0} quarts"
+        gender: masculine
+      narrow:
+        one: "{0}qt"
+        other: "{0}qt"
+    pint:
+      long:
+        display_name: pintes
+        one: "{0} pinte"
+        other: "{0} pintes"
+        gender: feminine
+      short:
+        display_name: pte
+        one: "{0} pte"
+        other: "{0} pte"
+      narrow:
+        one: "{0}pte"
+        other: "{0}pte"
+    cup:
+      long:
+        gender: feminine
+      short:
+        display_name: tasses
+        one: "{0} tasse"
+        other: "{0} tasses"
+      narrow:
+        display_name: ta
+        one: "{0}ta"
+        other: "{0}ta"
+    fluid-ounce:
+      long:
+        display_name: onces liquides
+        one: "{0} once liquide"
+        other: "{0} onces liquides"
+        gender: feminine
+      short:
+        display_name: fl oz
+        one: "{0} fl oz"
+        other: "{0} fl oz"
+      narrow:
+        one: "{0}fl oz"
+        other: "{0}fl oz"
+    fluid-ounce-imperial:
+      long:
+        display_name: onces liquides impériales
+        one: "{0} once liquide impériale"
+        other: "{0} onces liquides impériales"
+        gender: feminine
+      short:
+        display_name: fl oz imp.
+        one: "{0} fl oz imp."
+        other: "{0} fl oz imp."
+      narrow:
+        one: "{0}fl oz imp"
+        other: "{0}fl oz imp"
+    tablespoon:
+      long:
+        display_name: cuillères à soupe
+        one: "{0} cuillère à soupe"
+        other: "{0} cuillères à soupe"
+        gender: feminine
+      short:
+        display_name: c. à s.
+        one: "{0} c. à s."
+        other: "{0} c. à s."
+      narrow:
+        display_name: CàS
+        one: "{0}CàS"
+        other: "{0}CàS"
+    teaspoon:
+      long:
+        display_name: cuillères à café
+        one: "{0} cuillère à café"
+        other: "{0} cuillères à café"
+        gender: feminine
+      short:
+        display_name: c. à c.
+        one: "{0} c. à c."
+        other: "{0} c. à c."
+      narrow:
+        display_name: CàC
+        one: "{0}CàC"
+        other: "{0}CàC"
+    barrel:
+      long:
+        display_name: barils
+        one: "{0} baril"
+        other: "{0} barils"
+      short:
+        one: "{0} bbl"
+        other: "{0} bbl"
+      narrow:
+        one: "{0}bbl"
+        other: "{0}bbl"
+    dessert-spoon:
+      long:
+        display_name: cuillères à dessert
+        one: "{0} cuillère à dessert"
+        other: "{0} cuillères à dessert"
+        gender: feminine
+      short:
+        display_name: c. à d.
+        one: "{0} c. à d."
+        other: "{0} c. à d."
+      narrow:
+        display_name: CàD
+        one: "{0}CàD"
+        other: "{0}CàD"
+    dessert-spoon-imperial:
+      long:
+        display_name: cuillères à dessert impériales
+        one: "{0} cuillère à dessert impériale"
+        other: "{0} cuillères à dessert impériales"
+        gender: feminine
+      short:
+        display_name: c. à d. imp.
+        one: "{0} c. à d. imp."
+        other: "{0} c. à d. imp."
+      narrow:
+        display_name: CàD imp.
+        one: "{0}CàD imp."
+        other: "{0}CàD imp."
+    drop:
+      long:
+        display_name: gouttes
+        one: "{0} goutte"
+        other: "{0} gouttes"
+        gender: feminine
+      short:
+        display_name: gte
+        one: "{0} gte"
+        other: "{0} gte"
+      narrow:
+        one: "{0}gte"
+        other: "{0}gte"
+    dram:
+      long:
+        display_name: drachmes
+        one: "{0} drachme"
+        other: "{0} drachmes"
+        gender: feminine
+      short:
+        display_name: drachme fluide
+        one: "{0} fl dr"
+        other: "{0} fl dr"
+      narrow:
+        display_name: fl dr
+        one: "{0}fl dr"
+        other: "{0}fl dr"
+    jigger:
+      long:
+        display_name: jiggers
+        gender: masculine
+      short:
+        one: "{0} jigger"
+        other: "{0} jiggers"
+    pinch:
+      long:
+        display_name: pincées
+        gender: feminine
+      short:
+        display_name: pincée
+        one: "{0} pincée"
+        other: "{0} pincées"
+    quart-imperial:
+      long:
+        display_name: quarts impériaux
+        one: "{0} quart impérial"
+        other: "{0} quarts impériaux"
+        gender: masculine
+      short:
+        display_name: qt imp.
+        one: "{0} qt imp."
+        other: "{0} qt imp."
+      narrow:
+        one: "{0}qt imp."
+        other: "{0}qt imp."
+    light-speed:
+      long:
+        display_name: lumière
+        one: "{0} lumière"
+        other: "{0} lumière"
+        gender: feminine
+      short:
+        display_name: lumière
+        one: "{0} lumière"
+        other: "{0} lumière"
+      narrow:
+        display_name: lumière
+        one: "{0} lumière"
+        other: "{0} lumière"
+    portion-per-1e9:
+      long:
+        display_name: parts par milliard
+        one: "{0} part par milliard"
+        other: "{0} parts par milliard"
+        gender: feminine
+      narrow:
+        one: "{0}ppb"
+        other: "{0}ppb"
+    night:
+      long:
+        display_name: nuits
+        one: "{0} nuit"
+        other: "{0} nuits"
+        gender: feminine
+        per_unit_pattern: "{0} par nuit"
+      short:
+        display_name: nuits
+        one: "{0} nuit"
+        other: "{0} nuits"
+        per_unit_pattern: "{0}/nuit"
+      narrow:
+        display_name: nuits
+        one: "{0}nuit"
+        other: "{0}nuits"
+        per_unit_pattern: "{0}/nuit"

--- a/data/cldr/ja/number_formats.yml
+++ b/data/cldr/ja/number_formats.yml
@@ -1,6 +1,6 @@
 ---
 locale: ja
-generated_at: '2025-09-14T02:07:14Z'
+generated_at: '2025-09-14T05:42:36Z'
 cldr_version: '46'
 number_formats:
   decimal_formats:
@@ -1268,3 +1268,1483 @@ number_formats:
       display_names:
         other: シンバブエ ドル（2008）
         one: シンバブエ ドル（2008）
+  units:
+    meter-per-square-second:
+      long:
+        display_name: メートル毎秒毎秒
+        other: "{0} メートル毎秒毎秒"
+      narrow:
+        other: "{0}m/s²"
+    revolution:
+      long:
+        other: "{0} 回転"
+      short:
+        display_name: 回転
+      narrow:
+        display_name: rev
+        other: "{0}rev"
+    radian:
+      long:
+        other: "{0} ラジアン"
+      short:
+        display_name: ラジアン
+      narrow:
+        display_name: rad
+        other: "{0}rad"
+    square-kilometer:
+      long:
+        display_name: 平方キロメートル
+        other: "{0} 平方キロメートル"
+        per_unit_pattern: "{0}/平方キロメートル"
+      narrow:
+        other: "{0}km²"
+    hectare:
+      long:
+        other: "{0} ヘクタール"
+      short:
+        display_name: ヘクタール
+      narrow:
+        other: "{0}ha"
+    square-meter:
+      long:
+        display_name: 平方メートル
+        other: "{0} 平方メートル"
+        per_unit_pattern: "{0}/平方メートル"
+      narrow:
+        other: "{0}m²"
+    square-centimeter:
+      long:
+        display_name: 平方センチメートル
+        other: "{0} 平方センチメートル"
+        per_unit_pattern: "{0}/平方センチメートル"
+      narrow:
+        other: "{0}cm²"
+    square-mile:
+      long:
+        other: "{0} 平方マイル"
+        per_unit_pattern: "{0}/平方マイル"
+      short:
+        display_name: 平方マイル
+      narrow:
+        display_name: mi²
+        other: "{0}mi²"
+    acre:
+      long:
+        other: "{0} エーカー"
+      short:
+        display_name: エーカー
+      narrow:
+        other: "{0}ac"
+    square-yard:
+      long:
+        other: "{0} 平方ヤード"
+      short:
+        display_name: 平方ヤード
+      narrow:
+        display_name: yd²
+        other: "{0}yd²"
+    square-foot:
+      long:
+        other: "{0} 平方フィート"
+      short:
+        display_name: 平方フィート
+      narrow:
+        display_name: ft²
+        other: "{0}ft²"
+    square-inch:
+      long:
+        other: "{0} 平方インチ"
+        per_unit_pattern: "{0}/平方インチ"
+      short:
+        display_name: 平方インチ
+      narrow:
+        display_name: in²
+        other: "{0}in²"
+    dunam:
+      long:
+        other: "{0} ドゥナム"
+      short:
+        display_name: ドゥナム
+        other: "{0}ドゥナム"
+    milligram-ofglucose-per-deciliter:
+      long:
+        other: "{0} ミリグラム毎デシリットル"
+      short:
+        display_name: ミリグラム毎デシリットル
+      narrow:
+        display_name: mg/dL
+        other: "{0}mg/dL"
+    millimole-per-liter:
+      long:
+        other: "{0} ミリモル毎リットル"
+      short:
+        display_name: ミリモル毎リットル
+      narrow:
+        display_name: mmol/L
+        other: "{0}mmol/L"
+    percent:
+      long:
+        other: "{0} パーセント"
+      short:
+        display_name: パーセント
+      narrow:
+        display_name: "%"
+    permille:
+      long:
+        other: "{0} パーミル"
+      short:
+        display_name: パーミル
+      narrow:
+        display_name: "‰"
+    permyriad:
+      long:
+        other: "{0} パーミリアド"
+      short:
+        display_name: パーミリアド
+      narrow:
+        display_name: "‱"
+    mole:
+      long:
+        other: "{0} モル"
+      short:
+        display_name: モル
+      narrow:
+        display_name: mol
+        other: "{0}mol"
+    liter-per-kilometer:
+      long:
+        display_name: リットル毎キロメートル
+        other: "{0} リットル毎キロメートル"
+      narrow:
+        other: "{0}L/km"
+    liter-per-100-kilometer:
+      long:
+        display_name: リットル毎100キロメートル
+        other: "{0} リットル毎100キロメートル"
+      narrow:
+        other: "{0}L/100km"
+    mile-per-gallon:
+      long:
+        display_name: マイル毎ガロン
+        other: "{0} マイル毎ガロン"
+      short:
+        display_name: マイル/ガロン
+        other: "{0} mpg"
+      narrow:
+        display_name: mpg
+        other: "{0}mpg"
+    mile-per-gallon-imperial:
+      long:
+        other: "{0} マイル毎英ガロン"
+      short:
+        display_name: マイル毎英ガロン
+      narrow:
+        display_name: マイル/英ガロン
+        other: "{0}mpg Imp."
+    petabyte:
+      long:
+        other: "{0} ペタバイト"
+      short:
+        display_name: ペタバイト
+      narrow:
+        display_name: PB
+        other: "{0}PB"
+    terabyte:
+      long:
+        other: "{0} テラバイト"
+      short:
+        display_name: テラバイト
+      narrow:
+        display_name: TB
+        other: "{0}TB"
+    terabit:
+      long:
+        other: "{0} テラビット"
+      short:
+        display_name: テラビット
+      narrow:
+        display_name: Tb
+        other: "{0}Tb"
+    gigabyte:
+      long:
+        display_name: ギガバイト
+        other: "{0} ギガバイト"
+      narrow:
+        other: "{0}GB"
+    gigabit:
+      long:
+        other: "{0} ギガビット"
+      short:
+        display_name: ギガビット
+      narrow:
+        display_name: Gb
+        other: "{0}Gb"
+    megabyte:
+      long:
+        display_name: メガバイト
+        other: "{0} メガバイト"
+      narrow:
+        other: "{0}MB"
+    megabit:
+      long:
+        other: "{0} メガビット"
+      short:
+        display_name: メガビット
+      narrow:
+        display_name: Mb
+        other: "{0}Mb"
+    kilobyte:
+      long:
+        display_name: キロバイト
+        other: "{0} キロバイト"
+      short:
+        display_name: KB
+        other: "{0} KB"
+      narrow:
+        other: "{0}KB"
+    kilobit:
+      long:
+        other: "{0} キロビット"
+      short:
+        display_name: キロビット
+      narrow:
+        display_name: kb
+        other: "{0}kb"
+    byte:
+      long:
+        other: "{0} バイト"
+      short:
+        display_name: バイト
+      narrow:
+        display_name: B
+        other: "{0}B"
+    bit:
+      long:
+        other: "{0} ビット"
+      short:
+        display_name: ビット
+      narrow:
+        other: "{0}b"
+    quarter:
+      long:
+        other: "{0} 四半期"
+      short:
+        display_name: 四半期
+        other: "{0}四半期"
+        per_unit_pattern: "{0}/四半期"
+      narrow:
+        other: "{0}Q"
+        per_unit_pattern: "{0}/Q"
+    millisecond:
+      long:
+        other: "{0} ミリ秒"
+      short:
+        display_name: ミリ秒
+      narrow:
+        display_name: ms
+        other: "{0}ms"
+    microsecond:
+      long:
+        other: "{0} マイクロ秒"
+      short:
+        display_name: マイクロ秒
+      narrow:
+        display_name: μs
+        other: "{0}μs"
+    nanosecond:
+      long:
+        other: "{0} ナノ秒"
+      short:
+        display_name: ナノ秒
+      narrow:
+        display_name: ns
+        other: "{0}ns"
+    ampere:
+      long:
+        other: "{0} アンペア"
+      short:
+        display_name: アンペア
+      narrow:
+        other: "{0}A"
+    milliampere:
+      long:
+        other: "{0} ミリアンペア"
+      short:
+        display_name: ミリアンペア
+      narrow:
+        other: "{0}mA"
+    ohm:
+      long:
+        other: "{0} オーム"
+      short:
+        display_name: オーム
+      narrow:
+        other: "{0}Ω"
+    volt:
+      long:
+        other: "{0} ボルト"
+      short:
+        display_name: ボルト
+      narrow:
+        other: "{0}V"
+    kilocalorie:
+      long:
+        display_name: キロカロリー
+        other: "{0} キロカロリー"
+      narrow:
+        other: "{0}kcal"
+    calorie:
+      long:
+        display_name: カロリー
+        other: "{0} カロリー"
+      narrow:
+        other: "{0}calth"
+    foodcalorie:
+      long:
+        display_name: カロリー
+        other: "{0} カロリー"
+      short:
+        display_name: cal
+        other: "{0} cal"
+      narrow:
+        other: "{0}cal"
+    kilojoule:
+      long:
+        other: "{0} キロジュール"
+      short:
+        display_name: キロジュール
+      narrow:
+        other: "{0}kJ"
+    joule:
+      long:
+        other: "{0} ジュール"
+      short:
+        display_name: ジュール
+      narrow:
+        other: "{0}J"
+    kilowatt-hour:
+      long:
+        other: "{0} キロワット時"
+      short:
+        display_name: キロワット時
+      narrow:
+        display_name: kWh
+        other: "{0}kWh"
+    electronvolt:
+      long:
+        other: "{0} 電子ボルト"
+      short:
+        display_name: 電子ボルト
+      narrow:
+        display_name: eV
+    british-thermal-unit:
+      long:
+        other: "{0} 英熱量"
+      short:
+        display_name: 英熱量
+        other: "{0} BTU"
+      narrow:
+        other: "{0}BTU"
+    pound-force:
+      long:
+        other: "{0} 重量ポンド"
+      short:
+        display_name: 重量ポンド
+      narrow:
+        display_name: lbf
+        other: "{0}lbf"
+    newton:
+      long:
+        other: "{0} ニュートン"
+      short:
+        display_name: ニュートン
+      narrow:
+        display_name: "N"
+        other: "{0}N"
+    kilowatt-hour-per-100-kilometer:
+      long:
+        display_name: キロワット時毎100キロメートル
+        other: "{0} キロワット時毎100キロメートル"
+      narrow:
+        other: "{0}kWh/100km"
+    gigahertz:
+      long:
+        display_name: ギガヘルツ
+        other: "{0} ギガヘルツ"
+      narrow:
+        other: "{0}GHz"
+    megahertz:
+      long:
+        display_name: メガヘルツ
+        other: "{0} メガヘルツ"
+      narrow:
+        other: "{0}MHz"
+    kilohertz:
+      long:
+        display_name: キロヘルツ
+        other: "{0} キロヘルツ"
+      narrow:
+        other: "{0}kHz"
+    hertz:
+      long:
+        display_name: ヘルツ
+        other: "{0} ヘルツ"
+      narrow:
+        other: "{0}Hz"
+    em:
+      long:
+        display_name: フォントサイズ em
+      narrow:
+        other: "{0}em"
+    pixel:
+      long:
+        other: "{0} ピクセル"
+      short:
+        display_name: ピクセル
+      narrow:
+        display_name: px
+        other: "{0}px"
+    megapixel:
+      long:
+        other: "{0} メガピクセル"
+      short:
+        display_name: メガピクセル
+      narrow:
+        display_name: MP
+        other: "{0}MP"
+    pixel-per-centimeter:
+      long:
+        display_name: ピクセル/cm
+        other: "{0} ピクセル/cm"
+      narrow:
+        other: "{0}ppcm"
+    pixel-per-inch:
+      long:
+        display_name: ピクセル/インチ
+        other: "{0} ピクセル/インチ"
+      narrow:
+        other: "{0}ppi"
+    dot-per-centimeter:
+      long:
+        display_name: ドット/cm
+        other: "{0} ドット/cm"
+      short:
+        display_name: dpcm
+        other: "{0} dpcm"
+      narrow:
+        other: "{0}dpcm"
+    dot-per-inch:
+      long:
+        display_name: ドット/インチ
+        other: "{0} ドット/インチ"
+      short:
+        display_name: dpi
+        other: "{0} dpi"
+      narrow:
+        other: "{0}dpi"
+    earth-radius:
+      long:
+        display_name: 地球半径
+        other: "{0} 地球半径"
+      narrow:
+        other: "{0}R⊕"
+    kilometer:
+      long:
+        display_name: キロメートル
+        other: "{0} キロメートル"
+        per_unit_pattern: "{0}/キロメートル"
+      narrow:
+        other: "{0}km"
+    meter:
+      long:
+        display_name: メートル
+        other: "{0} メートル"
+        per_unit_pattern: "{0}/メートル"
+      short:
+        display_name: m
+      narrow:
+        other: "{0}m"
+    decimeter:
+      long:
+        other: "{0} デシメートル"
+      short:
+        display_name: デシメートル
+      narrow:
+        other: "{0}dm"
+    centimeter:
+      long:
+        display_name: センチメートル
+        other: "{0} センチメートル"
+        per_unit_pattern: "{0}/センチメートル"
+      narrow:
+        other: "{0}cm"
+    millimeter:
+      long:
+        display_name: ミリメートル
+        other: "{0} ミリメートル"
+      narrow:
+        other: "{0}mm"
+    micrometer:
+      long:
+        other: "{0} マイクロメートル"
+      short:
+        display_name: マイクロメートル
+      narrow:
+        other: "{0}μm"
+    nanometer:
+      long:
+        other: "{0} ナノメートル"
+      short:
+        display_name: ナノメートル
+      narrow:
+        other: "{0}nm"
+    picometer:
+      long:
+        other: "{0} ピコメートル"
+      short:
+        display_name: ピコメートル
+      narrow:
+        other: "{0}pm"
+    mile:
+      long:
+        other: "{0} マイル"
+      short:
+        display_name: マイル
+      narrow:
+        other: "{0}mi"
+    yard:
+      long:
+        other: "{0} ヤード"
+      short:
+        display_name: ヤード
+      narrow:
+        other: "{0}yd"
+    foot:
+      long:
+        other: "{0} フィート"
+        per_unit_pattern: "{0}/フィート"
+      short:
+        display_name: フィート
+      narrow:
+        other: "{0}′"
+    inch:
+      long:
+        other: "{0} インチ"
+        per_unit_pattern: "{0}/インチ"
+      short:
+        display_name: インチ
+      narrow:
+        other: "{0}″"
+    parsec:
+      long:
+        other: "{0} パーセク"
+      short:
+        display_name: パーセク
+      narrow:
+        other: "{0}pc"
+    astronomical-unit:
+      long:
+        other: "{0} 天文単位"
+      short:
+        display_name: 天文単位
+      narrow:
+        other: "{0}au"
+    furlong:
+      long:
+        other: "{0} ハロン"
+      short:
+        display_name: ハロン
+      narrow:
+        other: "{0}fur"
+    fathom:
+      long:
+        other: "{0} ファゾム"
+      short:
+        display_name: ファゾム
+      narrow:
+        other: "{0}fth"
+    mile-scandinavian:
+      long:
+        other: "{0} スカンジナビアマイル"
+      short:
+        display_name: スカンジナビアマイル
+      narrow:
+        other: "{0}smi"
+    point:
+      long:
+        other: "{0} ポイント"
+      short:
+        display_name: ポイント
+      narrow:
+        display_name: pt
+        other: "{0}pt"
+    solar-radius:
+      long:
+        other: "{0} 太陽半径"
+      short:
+        display_name: 太陽半径
+      narrow:
+        display_name: R☉
+        other: "{0}R☉"
+    lux:
+      long:
+        other: "{0} ルクス"
+      short:
+        display_name: ルクス
+      narrow:
+        other: "{0}lx"
+    candela:
+      long:
+        display_name: カンデラ
+        other: "{0} カンデラ"
+      narrow:
+        other: "{0}cd"
+    lumen:
+      long:
+        display_name: ルーメン
+        other: "{0} ルーメン"
+      narrow:
+        other: "{0}lm"
+    solar-luminosity:
+      long:
+        other: "{0} 太陽光度"
+      short:
+        display_name: 太陽光度
+      narrow:
+        display_name: L☉
+        other: "{0}L☉"
+    tonne:
+      long:
+        display_name: トン
+        other: "{0} トン"
+      narrow:
+        other: "{0}t"
+    kilogram:
+      long:
+        display_name: キログラム
+        other: "{0} キログラム"
+        per_unit_pattern: "{0}/キログラム"
+      narrow:
+        other: "{0}kg"
+    gram:
+      long:
+        other: "{0} グラム"
+        per_unit_pattern: "{0}/グラム"
+      short:
+        display_name: グラム
+      narrow:
+        display_name: g
+        other: "{0}g"
+    milligram:
+      long:
+        display_name: ミリグラム
+        other: "{0} ミリグラム"
+      narrow:
+        other: "{0}mg"
+    microgram:
+      long:
+        other: "{0} マイクログラム"
+      short:
+        display_name: マイクログラム
+      narrow:
+        display_name: μg
+        other: "{0}μg"
+    ton:
+      long:
+        other: "{0} 米トン"
+      short:
+        display_name: 米トン
+        other: "{0} s/t"
+      narrow:
+        other: "{0}s/t"
+    stone:
+      long:
+        other: "{0} ストーン"
+      short:
+        display_name: ストーン
+      narrow:
+        other: "{0}st"
+    pound:
+      long:
+        other: "{0} ポンド"
+        per_unit_pattern: "{0}/ポンド"
+      short:
+        display_name: ポンド
+      narrow:
+        other: "{0}lb"
+    ounce:
+      long:
+        other: "{0} オンス"
+        per_unit_pattern: "{0}/オンス"
+      short:
+        display_name: オンス
+      narrow:
+        other: "{0}oz"
+    ounce-troy:
+      long:
+        other: "{0} トロイオンス"
+      short:
+        display_name: トロイオンス
+      narrow:
+        display_name: oz t
+        other: "{0}oz t"
+    carat:
+      long:
+        other: "{0} カラット"
+      short:
+        display_name: カラット
+        other: "{0} ct"
+      narrow:
+        other: "{0}ct"
+    dalton:
+      long:
+        other: "{0} ダルトン"
+      short:
+        display_name: ダルトン
+      narrow:
+        display_name: Da
+        other: "{0}Da"
+    earth-mass:
+      long:
+        other: "{0} 地球質量"
+      short:
+        display_name: 地球質量
+      narrow:
+        display_name: M⊕
+        other: "{0}M⊕"
+    solar-mass:
+      long:
+        other: "{0} 太陽質量"
+      short:
+        display_name: 太陽質量
+      narrow:
+        display_name: M☉
+        other: "{0}M☉"
+    gigawatt:
+      long:
+        other: "{0} ギガワット"
+      short:
+        display_name: ギガワット
+      narrow:
+        other: "{0}GW"
+    megawatt:
+      long:
+        other: "{0} メガワット"
+      short:
+        display_name: メガワット
+      narrow:
+        other: "{0}MW"
+    kilowatt:
+      long:
+        other: "{0} キロワット"
+      short:
+        display_name: キロワット
+      narrow:
+        display_name: kW
+        other: "{0}kW"
+    watt:
+      long:
+        other: "{0} ワット"
+      short:
+        display_name: ワット
+      narrow:
+        other: "{0}W"
+    milliwatt:
+      long:
+        other: "{0} ミリワット"
+      short:
+        display_name: ミリワット
+      narrow:
+        display_name: mW
+        other: "{0}mW"
+    millimeter-ofhg:
+      long:
+        other: "{0} 水銀柱ミリメートル"
+      short:
+        display_name: 水銀柱ミリメートル
+      narrow:
+        other: "{0}mmHg"
+    pound-force-per-square-inch:
+      long:
+        other: "{0} 重量ポンド毎平方インチ"
+      short:
+        display_name: 重量ポンド毎平方インチ
+      narrow:
+        other: "{0}psi"
+    inch-ofhg:
+      long:
+        other: "{0} 水銀柱インチ"
+      short:
+        display_name: 水銀柱インチ
+      narrow:
+        other: '{0}" Hg'
+    bar:
+      long:
+        other: "{0} バール"
+      short:
+        display_name: バール
+      narrow:
+        other: "{0}bar"
+    millibar:
+      long:
+        other: "{0} ミリバール"
+      short:
+        display_name: ミリバール
+        other: "{0} mb"
+      narrow:
+        other: "{0}mb"
+    atmosphere:
+      long:
+        other: "{0} 気圧"
+      short:
+        display_name: 気圧
+      narrow:
+        other: "{0}atm"
+    pascal:
+      long:
+        other: "{0} パスカル"
+      short:
+        display_name: パスカル
+      narrow:
+        display_name: Pa
+        other: "{0}Pa"
+    hectopascal:
+      long:
+        display_name: ヘクトパスカル
+        other: "{0} ヘクトパスカル"
+      narrow:
+        other: "{0}hPa"
+    kilopascal:
+      long:
+        display_name: キロパスカル
+        other: "{0} キロパスカル"
+      narrow:
+        other: "{0}kPa"
+    megapascal:
+      long:
+        display_name: メガパスカル
+        other: "{0} メガパスカル"
+      narrow:
+        other: "{0}MPa"
+    kilometer-per-hour:
+      long:
+        display_name: キロメートル毎時
+        other: 時速 {0} キロメートル
+      narrow:
+        other: "{0}km/h"
+    meter-per-second:
+      long:
+        display_name: メートル毎秒
+        other: 秒速 {0} メートル
+      narrow:
+        other: "{0}m/s"
+    mile-per-hour:
+      long:
+        other: 時速 {0} マイル
+      short:
+        display_name: マイル毎時
+        other: "{0} mph"
+      narrow:
+        other: "{0}mi/h"
+    knot:
+      long:
+        other: "{0} ノット"
+      short:
+        display_name: ノット
+      narrow:
+        other: "{0}kn"
+    beaufort:
+      long:
+        display_name: ビューフォート風力階級
+        other: ビューフォート風力階級 {0}
+      short:
+        display_name: 風力階級
+      narrow:
+        other: B{0}
+    generic:
+      long:
+        display_name: 度
+        other: "{0}度"
+    celsius:
+      long:
+        display_name: 摂氏
+        other: 摂氏 {0} 度
+    fahrenheit:
+      long:
+        display_name: 華氏
+        other: 華氏 {0} 度
+    kelvin:
+      long:
+        display_name: ケルビン
+        other: "{0} ケルビン"
+      narrow:
+        other: "{0}K"
+    pound-force-foot:
+      long:
+        other: "{0} ポンドフィート"
+      short:
+        display_name: ポンドフィート
+      narrow:
+        display_name: lbf⋅ft
+        other: "{0}lbf⋅ft"
+    newton-meter:
+      long:
+        other: "{0} ニュートンメートル"
+      short:
+        display_name: ニュートンメートル
+      narrow:
+        display_name: N⋅m
+        other: "{0}N⋅m"
+    cubic-kilometer:
+      long:
+        display_name: 立方キロメートル
+        other: "{0} 立方キロメートル"
+      narrow:
+        other: "{0}km³"
+    cubic-meter:
+      long:
+        display_name: 立方メートル
+        other: "{0} 立方メートル"
+        per_unit_pattern: "{0}/立方メートル"
+      narrow:
+        other: "{0}m³"
+    cubic-centimeter:
+      long:
+        display_name: 立方センチメートル
+        other: "{0} 立方センチメートル"
+        per_unit_pattern: "{0}/立方センチメートル"
+      narrow:
+        other: "{0}cm³"
+    cubic-mile:
+      long:
+        other: "{0} 立方マイル"
+      short:
+        display_name: 立方マイル
+      narrow:
+        display_name: mi³
+        other: "{0}mi³"
+    cubic-yard:
+      long:
+        other: "{0} 立方ヤード"
+      short:
+        display_name: 立方ヤード
+      narrow:
+        display_name: yd³
+        other: "{0}yd³"
+    cubic-foot:
+      long:
+        other: "{0} 立方フィート"
+      short:
+        display_name: 立方フィート
+      narrow:
+        display_name: ft³
+        other: "{0}ft³"
+    cubic-inch:
+      long:
+        other: "{0} 立方インチ"
+      short:
+        display_name: 立方インチ
+      narrow:
+        display_name: in³
+        other: "{0}in³"
+    megaliter:
+      long:
+        other: "{0} メガリットル"
+      short:
+        display_name: メガリットル
+      narrow:
+        display_name: ML
+        other: "{0}ML"
+    hectoliter:
+      long:
+        other: "{0} ヘクトリットル"
+      short:
+        display_name: ヘクトリットル
+      narrow:
+        display_name: hL
+        other: "{0}hL"
+    liter:
+      long:
+        other: "{0} リットル"
+        per_unit_pattern: "{0}/リットル"
+      short:
+        display_name: リットル
+        other: "{0} L"
+        per_unit_pattern: "{0}/L"
+      narrow:
+        display_name: L
+        other: "{0}L"
+    deciliter:
+      long:
+        other: "{0} デシリットル"
+      short:
+        display_name: デシリットル
+      narrow:
+        display_name: dL
+        other: "{0}dL"
+    centiliter:
+      long:
+        other: "{0} センチリットル"
+      short:
+        display_name: センチリットル
+      narrow:
+        display_name: cL
+        other: "{0}cL"
+    milliliter:
+      long:
+        other: "{0} ミリリットル"
+      short:
+        display_name: ミリリットル
+        other: "{0} ml"
+      narrow:
+        display_name: mL
+        other: "{0}ml"
+    pint-metric:
+      long:
+        other: "{0} メトリックパイント"
+      short:
+        display_name: メトリックパイント
+      narrow:
+        other: "{0}mpt"
+    cup-metric:
+      long:
+        other: "{0} メトリックカップ"
+      short:
+        display_name: メトリックカップ
+      narrow:
+        other: "{0}mc"
+    acre-foot:
+      long:
+        other: "{0} エーカーフィート"
+      short:
+        display_name: エーカーフィート
+      narrow:
+        display_name: ac ft
+        other: "{0}ac ft"
+    bushel:
+      long:
+        other: "{0} ブッシェル"
+      short:
+        display_name: ブッシェル
+      narrow:
+        other: "{0}bu"
+    gallon:
+      long:
+        other: "{0} ガロン"
+        per_unit_pattern: "{0}/ガロン"
+      short:
+        display_name: ガロン
+        other: "{0} gal"
+        per_unit_pattern: "{0}/gal"
+      narrow:
+        display_name: gal
+        other: "{0}gal"
+    gallon-imperial:
+      long:
+        other: "{0} 英ガロン"
+        per_unit_pattern: "{0}/英ガロン"
+      short:
+        display_name: 英ガロン
+      narrow:
+        display_name: Imp gal
+        other: "{0}gal Imp."
+    quart:
+      long:
+        other: "{0} クォート"
+      short:
+        display_name: クォート
+      narrow:
+        display_name: qt
+        other: "{0}qt"
+    pint:
+      long:
+        other: "{0} パイント"
+      short:
+        display_name: パイント
+      narrow:
+        display_name: pt
+        other: "{0}pt"
+    fluid-ounce:
+      long:
+        other: "{0} 液量オンス"
+      short:
+        display_name: 液量オンス
+        other: "{0} fl oz"
+      narrow:
+        display_name: fl oz
+        other: "{0}fl oz"
+    fluid-ounce-imperial:
+      long:
+        other: "{0} 英液量オンス"
+      short:
+        display_name: 英液量オンス
+        other: "{0} fl oz Imp"
+      narrow:
+        display_name: Imp fl oz
+        other: "{0}Imp fl oz"
+    tablespoon:
+      long:
+        other: "{0} テーブルスプーン"
+      short:
+        display_name: テーブルスプーン
+      narrow:
+        display_name: tbsp
+        other: "{0}tbsp"
+    teaspoon:
+      long:
+        other: "{0} ティースプーン"
+      short:
+        display_name: ティースプーン
+      narrow:
+        display_name: tsp
+        other: "{0}tsp"
+    barrel:
+      long:
+        other: "{0} バレル"
+      short:
+        display_name: バレル
+      narrow:
+        display_name: bbl
+        other: "{0}bbl"
+    dram:
+      long:
+        display_name: ドラム
+        other: "{0} ドラム"
+      short:
+        display_name: 液量ドラム
+        other: "{0} 液量ドラム"
+      narrow:
+        other: "{0}fl dr"
+    quart-imperial:
+      long:
+        other: "{0} 英クォート"
+      short:
+        display_name: 英クォート
+      narrow:
+        display_name: qt Imp
+        other: "{0}qt-Imp."
+    light-speed:
+      long:
+        display_name: 光
+        other: "{0} 光"
+      short:
+        display_name: 光
+        other: "{0} 光"
+      narrow:
+        display_name: 光
+        other: "{0}光"
+    night:
+      long:
+        display_name: 泊
+        other: "{0} 泊"
+        per_unit_pattern: "{0}/泊"
+      short:
+        display_name: 泊
+        other: "{0} 泊"
+        per_unit_pattern: "{0}/泊"
+      narrow:
+        display_name: 泊
+        other: "{0}泊"
+        per_unit_pattern: "{0}/泊"
+    g-force:
+      short:
+        display_name: 重力加速度
+      narrow:
+        other: "{0}G"
+    degree:
+      short:
+        display_name: 度
+        other: "{0} 度"
+      narrow:
+        other: "{0}°"
+    arc-minute:
+      short:
+        display_name: 分
+        other: "{0} 分"
+      narrow:
+        other: "{0}′"
+    arc-second:
+      short:
+        display_name: 秒
+        other: "{0} 秒"
+      narrow:
+        other: "{0}″"
+    karat:
+      short:
+        display_name: 金
+        other: "{0} 金"
+      narrow:
+        other: "{0}K"
+    item:
+      short:
+        display_name: 項目
+        other: "{0} 項目"
+      narrow:
+        other: "{0}項目"
+    century:
+      short:
+        display_name: 世紀
+        other: "{0} 世紀"
+      narrow:
+        other: "{0}世紀"
+    decade:
+      short:
+        display_name: 十年
+        other: "{0} 十年"
+      narrow:
+        other: "{0}十年"
+    year:
+      short:
+        display_name: 年
+        other: "{0} 年"
+        per_unit_pattern: "{0}/年"
+      narrow:
+        other: "{0}y"
+    month:
+      short:
+        display_name: か月
+        other: "{0} か月"
+        per_unit_pattern: "{0}/月"
+      narrow:
+        other: "{0}m"
+    week:
+      short:
+        display_name: 週間
+        other: "{0} 週間"
+        per_unit_pattern: "{0}/週"
+      narrow:
+        other: "{0}w"
+    day:
+      short:
+        display_name: 日
+        other: "{0} 日"
+        per_unit_pattern: "{0}/日"
+      narrow:
+        other: "{0}d"
+    hour:
+      short:
+        display_name: 時間
+        other: "{0} 時間"
+        per_unit_pattern: "{0}/時間"
+      narrow:
+        other: "{0}h"
+    minute:
+      short:
+        display_name: 分
+        other: "{0} 分"
+        per_unit_pattern: "{0}/分"
+      narrow:
+        other: "{0}m"
+    second:
+      short:
+        display_name: 秒
+        other: "{0} 秒"
+        per_unit_pattern: "{0}/秒"
+      narrow:
+        other: "{0}s"
+    therm-us:
+      short:
+        display_name: 米サーム
+        other: "{0} 米サーム"
+      narrow:
+        other: "{0}米サーム"
+    dot:
+      short:
+        display_name: ドット
+        other: "{0} ドット"
+      narrow:
+        other: "{0}ドット"
+    light-year:
+      short:
+        display_name: 光年
+        other: "{0} 光年"
+      narrow:
+        other: "{0}光年"
+    nautical-mile:
+      short:
+        display_name: 海里
+        other: "{0} 海里"
+      narrow:
+        other: "{0}海里"
+    grain:
+      short:
+        display_name: グレーン
+        other: "{0} グレーン"
+      narrow:
+        other: "{0}グレーン"
+    horsepower:
+      short:
+        display_name: 馬力
+        other: "{0} 馬力"
+      narrow:
+        other: "{0}hp"
+    cup:
+      short:
+        display_name: カップ - 米国
+        other: "{0} カップ - 米国"
+      narrow:
+        display_name: カップ
+        other: "{0}カップ"
+    dessert-spoon:
+      short:
+        display_name: 中さじ
+        other: 中さじ {0}
+      narrow:
+        other: 中さじ{0}
+    dessert-spoon-imperial:
+      short:
+        display_name: 英デザートスプーン
+        other: "{0} 英デザートスプーン"
+      narrow:
+        other: "{0}英デザートスプーン"
+    drop:
+      short:
+        display_name: 滴
+        other: "{0} 滴"
+      narrow:
+        other: "{0}滴"
+    jigger:
+      short:
+        display_name: ジガー
+        other: "{0} ジガー"
+      narrow:
+        other: "{0}ジガー"
+    pinch:
+      short:
+        display_name: つまみ
+        other: "{0} つまみ"
+      narrow:
+        other: "{0}つまみ"
+    rin:
+      short:
+        display_name: 厘
+        other: "{0} 厘"
+      category: length
+      narrow:
+        other: "{0}厘"
+    sun:
+      short:
+        display_name: 寸
+        other: "{0} 寸"
+      category: length
+      narrow:
+        other: "{0}寸"
+    shaku-length:
+      short:
+        display_name: 尺
+        other: "{0} 尺"
+      category: length
+      narrow:
+        other: "{0}尺"
+    shaku-cloth:
+      short:
+        display_name: 鯨尺
+        other: "{0} 鯨尺"
+      category: length
+      narrow:
+        other: "{0}鯨尺"
+    ken:
+      short:
+        display_name: 間
+        other: "{0} 間"
+      category: length
+      narrow:
+        other: "{0}間"
+    jo-jp:
+      short:
+        display_name: 丈
+        other: "{0} 丈"
+      category: length
+      narrow:
+        other: "{0}丈"
+    ri-jp:
+      short:
+        display_name: 里
+        other: "{0} 里"
+      category: length
+      narrow:
+        other: "{0}里"
+    bu-jp:
+      short:
+        display_name: 歩
+        other: "{0} 歩"
+      category: area
+      narrow:
+        other: "{0}歩"
+    se-jp:
+      short:
+        display_name: 畝
+        other: "{0} 畝"
+      category: area
+      narrow:
+        other: "{0}畝"
+    cho:
+      short:
+        display_name: 町
+        other: "{0} 町"
+      category: area
+      narrow:
+        other: "{0}町"
+    kosaji:
+      short:
+        display_name: 小さじ
+        other: 小さじ {0}
+      category: volume
+      narrow:
+        other: 小さじ{0}
+    osaji:
+      short:
+        display_name: 大さじ
+        other: 大さじ {0}
+      category: volume
+      narrow:
+        other: 大さじ{0}
+    cup-jp:
+      short:
+        display_name: カップ
+        other: "{0} カップ"
+      category: volume
+      narrow:
+        other: "{0}カップ"
+    shaku:
+      short:
+        display_name: 勺
+        other: "{0} 勺"
+      category: volume
+      narrow:
+        other: "{0}勺"
+    sai:
+      short:
+        display_name: 才
+        other: "{0} 才"
+      category: volume
+      narrow:
+        other: "{0}才"
+    to-jp:
+      short:
+        display_name: 斗
+        other: "{0} 斗"
+      category: volume
+      narrow:
+        other: "{0}斗"
+    koku:
+      short:
+        display_name: 石
+        other: "{0} 石"
+      category: volume
+      narrow:
+        other: "{0}石"
+    fun:
+      short:
+        display_name: 分 - 質量
+        other: "{0} 分 - 質量"
+      category: mass
+      narrow:
+        display_name: 分
+        other: "{0}分"
+    permillion:
+      narrow:
+        other: "{0}ppm"
+    portion-per-1e9:
+      narrow:
+        other: "{0}ppb"

--- a/data/cldr/root/number_formats.yml
+++ b/data/cldr/root/number_formats.yml
@@ -1,6 +1,6 @@
 ---
 locale: root
-generated_at: '2025-09-13T17:40:09Z'
+generated_at: '2025-09-14T05:58:42Z'
 cldr_version: '46'
 number_formats:
   symbols:
@@ -21,6 +21,32 @@ number_formats:
     standard: "¤ #,##0.00"
   scientific_formats:
     standard: "#E0"
+  compact_formats:
+    short:
+      '1000':
+        other: 0K
+      '10000':
+        other: 00K
+      '100000':
+        other: 000K
+      '1000000':
+        other: 0M
+      '10000000':
+        other: 00M
+      '100000000':
+        other: 000M
+      '1000000000':
+        other: 0G
+      '10000000000':
+        other: 00G
+      '100000000000':
+        other: 000G
+      '1000000000000':
+        other: 0T
+      '10000000000000':
+        other: 00T
+      '100000000000000':
+        other: 000T
   currencies:
     AFN:
       symbol: "؋"
@@ -234,6 +260,974 @@ number_formats:
       symbol: R
     ZMW:
       symbol: ZK
+  units:
+    g-force:
+      short:
+        display_name: g-force
+        other: "{0} G"
+      category: acceleration
+    meter-per-square-second:
+      short:
+        display_name: m/s²
+        other: "{0} m/s²"
+      category: acceleration
+    revolution:
+      short:
+        display_name: rev
+        other: "{0} rev"
+      category: angle
+    radian:
+      short:
+        display_name: rad
+        other: "{0} rad"
+      category: angle
+    degree:
+      short:
+        display_name: deg
+        other: "{0}°"
+      category: angle
+    arc-minute:
+      short:
+        display_name: arcmin
+        other: "{0}′"
+      category: angle
+    arc-second:
+      short:
+        display_name: arcsec
+        other: "{0}″"
+      category: angle
+    square-kilometer:
+      short:
+        display_name: km²
+        other: "{0} km²"
+        per_unit_pattern: "{0}/km²"
+      category: area
+    hectare:
+      short:
+        display_name: hectare
+        other: "{0} ha"
+      category: area
+    square-meter:
+      short:
+        display_name: m²
+        other: "{0} m²"
+        per_unit_pattern: "{0}/m²"
+      category: area
+    square-centimeter:
+      short:
+        display_name: cm²
+        other: "{0} cm²"
+        per_unit_pattern: "{0}/cm²"
+      category: area
+    square-mile:
+      short:
+        display_name: mi²
+        other: "{0} mi²"
+        per_unit_pattern: "{0}/mi²"
+      category: area
+    acre:
+      short:
+        display_name: acre
+        other: "{0} ac"
+      category: area
+    square-yard:
+      short:
+        display_name: yd²
+        other: "{0} yd²"
+      category: area
+    square-foot:
+      short:
+        display_name: ft²
+        other: "{0} ft²"
+      category: area
+    square-inch:
+      short:
+        display_name: in²
+        other: "{0} in²"
+        per_unit_pattern: "{0}/in²"
+      category: area
+    dunam:
+      short:
+        display_name: dunam
+        other: "{0} dunam"
+      category: area
+    karat:
+      short:
+        display_name: kt
+        other: "{0} kt"
+      category: concentr
+    milligram-ofglucose-per-deciliter:
+      short:
+        display_name: mg/dL
+        other: "{0} mg/dL"
+      category: concentr
+    millimole-per-liter:
+      short:
+        display_name: mmol/L
+        other: "{0} mmol/L"
+      category: concentr
+    item:
+      short:
+        display_name: item
+        other: "{0} item"
+      category: concentr
+    permillion:
+      short:
+        display_name: ppm
+        other: "{0} ppm"
+      category: concentr
+    percent:
+      short:
+        display_name: "%"
+        other: "{0}%"
+      category: concentr
+    permille:
+      short:
+        display_name: "‰"
+        other: "{0}‰"
+      category: concentr
+    permyriad:
+      short:
+        display_name: "‱"
+        other: "{0}‱"
+      category: concentr
+    mole:
+      short:
+        display_name: mol
+        other: "{0} mol"
+      category: concentr
+    liter-per-kilometer:
+      short:
+        display_name: L/km
+        other: "{0} L/km"
+      category: consumption
+    liter-per-100-kilometer:
+      short:
+        display_name: L/100km
+        other: "{0} L/100km"
+      category: consumption
+    mile-per-gallon:
+      short:
+        display_name: mpg US
+        other: "{0} mpg US"
+      category: consumption
+    mile-per-gallon-imperial:
+      short:
+        display_name: mpg Imp.
+        other: "{0} mpg Imp."
+      category: consumption
+    petabyte:
+      short:
+        display_name: PB
+        other: "{0} PB"
+      category: digital
+    terabyte:
+      short:
+        display_name: TB
+        other: "{0} TB"
+      category: digital
+    terabit:
+      short:
+        display_name: Tb
+        other: "{0} Tb"
+      category: digital
+    gigabyte:
+      short:
+        display_name: GB
+        other: "{0} GB"
+      category: digital
+    gigabit:
+      short:
+        display_name: Gb
+        other: "{0} Gb"
+      category: digital
+    megabyte:
+      short:
+        display_name: MB
+        other: "{0} MB"
+      category: digital
+    megabit:
+      short:
+        display_name: Mb
+        other: "{0} Mb"
+      category: digital
+    kilobyte:
+      short:
+        display_name: kB
+        other: "{0} kB"
+      category: digital
+    kilobit:
+      short:
+        display_name: kb
+        other: "{0} kb"
+      category: digital
+    byte:
+      short:
+        display_name: byte
+        other: "{0} byte"
+      category: digital
+    bit:
+      short:
+        display_name: bit
+        other: "{0} bit"
+      category: digital
+    century:
+      short:
+        display_name: c
+        other: "{0} c"
+      category: duration
+    decade:
+      short:
+        display_name: dec
+        other: "{0} dec"
+      category: duration
+    year:
+      short:
+        display_name: yr
+        other: "{0} y"
+        per_unit_pattern: "{0}/y"
+      category: duration
+    year-person:
+      short: {}
+      category: duration
+    quarter:
+      short:
+        display_name: qtr
+        other: "{0} q"
+        per_unit_pattern: "{0}/q"
+      category: duration
+    month:
+      short:
+        display_name: mon
+        other: "{0} m"
+        per_unit_pattern: "{0}/m"
+      category: duration
+    month-person:
+      short: {}
+      category: duration
+    week:
+      short:
+        display_name: wk
+        other: "{0} w"
+        per_unit_pattern: "{0}/w"
+      category: duration
+    week-person:
+      short: {}
+      category: duration
+    day:
+      short:
+        display_name: day
+        other: "{0} d"
+        per_unit_pattern: "{0}/d"
+      category: duration
+    day-person:
+      short: {}
+      category: duration
+    hour:
+      short:
+        display_name: hr
+        other: "{0} h"
+        per_unit_pattern: "{0}/h"
+      category: duration
+    minute:
+      short:
+        display_name: min
+        other: "{0} min"
+        per_unit_pattern: "{0}/min"
+      category: duration
+    second:
+      short:
+        display_name: sec
+        other: "{0} s"
+        per_unit_pattern: "{0}/s"
+      category: duration
+    millisecond:
+      short:
+        display_name: ms
+        other: "{0} ms"
+      category: duration
+    microsecond:
+      short:
+        display_name: μs
+        other: "{0} μs"
+      category: duration
+    nanosecond:
+      short:
+        display_name: ns
+        other: "{0} ns"
+      category: duration
+    ampere:
+      short:
+        display_name: amp
+        other: "{0} A"
+      category: electric
+    milliampere:
+      short:
+        display_name: mA
+        other: "{0} mA"
+      category: electric
+    ohm:
+      short:
+        display_name: ohm
+        other: "{0} Ω"
+      category: electric
+    volt:
+      short:
+        display_name: volt
+        other: "{0} V"
+      category: electric
+    kilocalorie:
+      short:
+        display_name: kcal
+        other: "{0} kcal"
+      category: energy
+    calorie:
+      short:
+        display_name: cal
+        other: "{0} cal"
+      category: energy
+    foodcalorie:
+      short: {}
+      category: energy
+    kilojoule:
+      short:
+        display_name: kJ
+        other: "{0} kJ"
+      category: energy
+    joule:
+      short:
+        display_name: joule
+        other: "{0} J"
+      category: energy
+    kilowatt-hour:
+      short:
+        display_name: kWh
+        other: "{0} kWh"
+      category: energy
+    electronvolt:
+      short:
+        display_name: eV
+        other: "{0} eV"
+      category: energy
+    british-thermal-unit:
+      short:
+        display_name: Btu
+        other: "{0} Btu"
+      category: energy
+    therm-us:
+      short:
+        display_name: US therm
+        other: "{0} US therm"
+      category: energy
+    pound-force:
+      short:
+        display_name: lbf
+        other: "{0} lbf"
+      category: force
+    newton:
+      short:
+        display_name: "N"
+        other: "{0} N"
+      category: force
+    kilowatt-hour-per-100-kilometer:
+      short:
+        display_name: kWh/100km
+        other: "{0} kWh/100km"
+      category: force
+    gigahertz:
+      short:
+        display_name: GHz
+        other: "{0} GHz"
+      category: frequency
+    megahertz:
+      short:
+        display_name: MHz
+        other: "{0} MHz"
+      category: frequency
+    kilohertz:
+      short:
+        display_name: kHz
+        other: "{0} kHz"
+      category: frequency
+    hertz:
+      short:
+        display_name: Hz
+        other: "{0} Hz"
+      category: frequency
+    em:
+      short:
+        display_name: em
+        other: "{0} em"
+      category: graphics
+    pixel:
+      short:
+        display_name: px
+        other: "{0} px"
+      category: graphics
+    megapixel:
+      short:
+        display_name: MP
+        other: "{0} MP"
+      category: graphics
+    pixel-per-centimeter:
+      short:
+        display_name: ppcm
+        other: "{0} ppcm"
+      category: graphics
+    pixel-per-inch:
+      short:
+        display_name: ppi
+        other: "{0} ppi"
+      category: graphics
+    dot-per-centimeter:
+      short: {}
+      category: graphics
+    dot-per-inch:
+      short: {}
+      category: graphics
+    dot:
+      short: {}
+      category: graphics
+    earth-radius:
+      short:
+        display_name: R⊕
+        other: "{0} R⊕"
+      category: length
+    kilometer:
+      short:
+        display_name: km
+        other: "{0} km"
+        per_unit_pattern: "{0}/km"
+      category: length
+    meter:
+      short:
+        display_name: meter
+        other: "{0} m"
+        per_unit_pattern: "{0}/m"
+      category: length
+    decimeter:
+      short:
+        display_name: dm
+        other: "{0} dm"
+      category: length
+    centimeter:
+      short:
+        display_name: cm
+        other: "{0} cm"
+        per_unit_pattern: "{0}/cm"
+      category: length
+    millimeter:
+      short:
+        display_name: mm
+        other: "{0} mm"
+      category: length
+    micrometer:
+      short:
+        display_name: μm
+        other: "{0} μm"
+      category: length
+    nanometer:
+      short:
+        display_name: nm
+        other: "{0} nm"
+      category: length
+    picometer:
+      short:
+        display_name: pm
+        other: "{0} pm"
+      category: length
+    mile:
+      short:
+        display_name: mi
+        other: "{0} mi"
+      category: length
+    yard:
+      short:
+        display_name: yd
+        other: "{0} yd"
+      category: length
+    foot:
+      short:
+        display_name: ft
+        other: "{0} ft"
+        per_unit_pattern: "{0}/ft"
+      category: length
+    inch:
+      short:
+        display_name: in
+        other: "{0} in"
+        per_unit_pattern: "{0}/in"
+      category: length
+    parsec:
+      short:
+        display_name: pc
+        other: "{0} pc"
+      category: length
+    light-year:
+      short:
+        display_name: ly
+        other: "{0} ly"
+      category: length
+    astronomical-unit:
+      short:
+        display_name: au
+        other: "{0} au"
+      category: length
+    furlong:
+      short:
+        display_name: fur
+        other: "{0} fur"
+      category: length
+    fathom:
+      short:
+        display_name: fm
+        other: "{0} fth"
+      category: length
+    nautical-mile:
+      short:
+        display_name: nmi
+        other: "{0} nmi"
+      category: length
+    mile-scandinavian:
+      short:
+        display_name: smi
+        other: "{0} smi"
+      category: length
+    point:
+      short:
+        display_name: pt
+        other: "{0} pt"
+      category: length
+    solar-radius:
+      short:
+        display_name: R☉
+        other: "{0} R☉"
+      category: length
+    lux:
+      short:
+        display_name: lx
+        other: "{0} lx"
+      category: light
+    candela:
+      short:
+        display_name: cd
+        other: "{0} cd"
+      category: light
+    lumen:
+      short:
+        display_name: lm
+        other: "{0} lm"
+      category: light
+    solar-luminosity:
+      short:
+        display_name: L☉
+        other: "{0} L☉"
+      category: light
+    tonne:
+      short:
+        display_name: t
+        other: "{0} t"
+      category: mass
+    kilogram:
+      short:
+        display_name: kg
+        other: "{0} kg"
+        per_unit_pattern: "{0}/kg"
+      category: mass
+    gram:
+      short:
+        display_name: gram
+        other: "{0} g"
+        per_unit_pattern: "{0}/g"
+      category: mass
+    milligram:
+      short:
+        display_name: mg
+        other: "{0} mg"
+      category: mass
+    microgram:
+      short:
+        display_name: μg
+        other: "{0} μg"
+      category: mass
+    ton:
+      short:
+        display_name: tn
+        other: "{0} tn"
+      category: mass
+    stone:
+      short:
+        display_name: st
+        other: "{0} st"
+      category: mass
+    pound:
+      short:
+        display_name: lb
+        other: "{0} lb"
+        per_unit_pattern: "{0}/lb"
+      category: mass
+    ounce:
+      short:
+        display_name: oz
+        other: "{0} oz"
+        per_unit_pattern: "{0}/oz"
+      category: mass
+    ounce-troy:
+      short:
+        display_name: oz t
+        other: "{0} oz t"
+      category: mass
+    carat:
+      short:
+        display_name: CD
+        other: "{0} CD"
+      category: mass
+    dalton:
+      short:
+        display_name: Da
+        other: "{0} Da"
+      category: mass
+    earth-mass:
+      short:
+        display_name: M⊕
+        other: "{0} M⊕"
+      category: mass
+    solar-mass:
+      short:
+        display_name: M☉
+        other: "{0} M☉"
+      category: mass
+    grain:
+      short:
+        display_name: grain
+        other: "{0} grain"
+      category: mass
+    gigawatt:
+      short:
+        display_name: GW
+        other: "{0} GW"
+      category: power
+    megawatt:
+      short:
+        display_name: MW
+        other: "{0} MW"
+      category: power
+    kilowatt:
+      short:
+        display_name: kW
+        other: "{0} kW"
+      category: power
+    watt:
+      short:
+        display_name: watt
+        other: "{0} W"
+      category: power
+    milliwatt:
+      short:
+        display_name: mW
+        other: "{0} mW"
+      category: power
+    horsepower:
+      short:
+        display_name: hp
+        other: "{0} hp"
+      category: power
+    millimeter-ofhg:
+      short:
+        display_name: mm Hg
+        other: "{0} mm Hg"
+      category: pressure
+    pound-force-per-square-inch:
+      short:
+        display_name: psi
+        other: "{0} psi"
+      category: pressure
+    inch-ofhg:
+      short:
+        display_name: inHg
+        other: "{0} inHg"
+      category: pressure
+    bar:
+      short:
+        display_name: bar
+        other: "{0} bar"
+      category: pressure
+    millibar:
+      short:
+        display_name: mbar
+        other: "{0} mbar"
+      category: pressure
+    atmosphere:
+      short:
+        display_name: atm
+        other: "{0} atm"
+      category: pressure
+    pascal:
+      short:
+        display_name: Pa
+        other: "{0} Pa"
+      category: pressure
+    hectopascal:
+      short:
+        display_name: hPa
+        other: "{0} hPa"
+      category: pressure
+    kilopascal:
+      short:
+        display_name: kPa
+        other: "{0} kPa"
+      category: pressure
+    megapascal:
+      short:
+        display_name: MPa
+        other: "{0} MPa"
+      category: pressure
+    kilometer-per-hour:
+      short:
+        display_name: km/h
+        other: "{0} km/h"
+      category: speed
+    meter-per-second:
+      short:
+        display_name: m/s
+        other: "{0} m/s"
+      category: speed
+    mile-per-hour:
+      short:
+        display_name: mi/h
+        other: "{0} mi/h"
+      category: speed
+    knot:
+      short:
+        display_name: kn
+        other: "{0} kn"
+      category: speed
+    beaufort:
+      short:
+        display_name: Bft
+        other: B {0}
+      category: speed
+    generic:
+      short:
+        display_name: "°"
+        other: "{0}°"
+      category: temperature
+    celsius:
+      short:
+        display_name: "°C"
+        other: "{0}°C"
+      category: temperature
+    fahrenheit:
+      short:
+        display_name: "°F"
+        other: "{0}°F"
+      category: temperature
+    kelvin:
+      short:
+        display_name: K
+        other: "{0} K"
+      category: temperature
+    pound-force-foot:
+      short:
+        display_name: lbf⋅ft
+        other: "{0} lbf⋅ft"
+      category: torque
+    newton-meter:
+      short:
+        display_name: N⋅m
+        other: "{0} N⋅m"
+      category: torque
+    cubic-kilometer:
+      short:
+        display_name: km³
+        other: "{0} km³"
+      category: volume
+    cubic-meter:
+      short:
+        display_name: m³
+        other: "{0} m³"
+        per_unit_pattern: "{0}/m³"
+      category: volume
+    cubic-centimeter:
+      short:
+        display_name: cm³
+        other: "{0} cm³"
+        per_unit_pattern: "{0}/cm³"
+      category: volume
+    cubic-mile:
+      short:
+        display_name: mi³
+        other: "{0} mi³"
+      category: volume
+    cubic-yard:
+      short:
+        display_name: yd³
+        other: "{0} yd³"
+      category: volume
+    cubic-foot:
+      short:
+        display_name: ft³
+        other: "{0} ft³"
+      category: volume
+    cubic-inch:
+      short:
+        display_name: in³
+        other: "{0} in³"
+      category: volume
+    megaliter:
+      short:
+        display_name: ML
+        other: "{0} ML"
+      category: volume
+    hectoliter:
+      short:
+        display_name: hL
+        other: "{0} hL"
+      category: volume
+    liter:
+      short:
+        display_name: liter
+        other: "{0} l"
+        per_unit_pattern: "{0}/l"
+      category: volume
+    deciliter:
+      short:
+        display_name: dL
+        other: "{0} dL"
+      category: volume
+    centiliter:
+      short:
+        display_name: cL
+        other: "{0} cL"
+      category: volume
+    milliliter:
+      short:
+        display_name: mL
+        other: "{0} mL"
+      category: volume
+    pint-metric:
+      short:
+        display_name: mpt
+        other: "{0} mpt"
+      category: volume
+    cup-metric:
+      short:
+        display_name: mcup
+        other: "{0} mc"
+      category: volume
+    acre-foot:
+      short:
+        display_name: ac ft
+        other: "{0} ac ft"
+      category: volume
+    bushel:
+      short:
+        display_name: bu
+        other: "{0} bu"
+      category: volume
+    gallon:
+      short:
+        display_name: US gal
+        other: "{0} gal US"
+        per_unit_pattern: "{0}/gal US"
+      category: volume
+    gallon-imperial:
+      short:
+        display_name: Imp. gal
+        other: "{0} gal Imp."
+        per_unit_pattern: "{0}/gal Imp."
+      category: volume
+    quart:
+      short:
+        display_name: qt
+        other: "{0} qt"
+      category: volume
+    pint:
+      short:
+        display_name: pt
+        other: "{0} pt"
+      category: volume
+    cup:
+      short:
+        display_name: cup
+        other: "{0} c"
+      category: volume
+    fluid-ounce:
+      short:
+        display_name: US fl oz
+        other: "{0} fl oz US"
+      category: volume
+    fluid-ounce-imperial:
+      short:
+        display_name: Imp. fl oz
+        other: "{0} fl oz Imp."
+      category: volume
+    tablespoon:
+      short:
+        display_name: tbsp
+        other: "{0} tbsp"
+      category: volume
+    teaspoon:
+      short:
+        display_name: tsp
+        other: "{0} tsp"
+      category: volume
+    barrel:
+      short:
+        display_name: bbl
+        other: "{0} bbl"
+      category: volume
+    dessert-spoon:
+      short:
+        display_name: dstspn
+        other: "{0} dstspn"
+      category: volume
+    dessert-spoon-imperial:
+      short:
+        display_name: dstspn Imp
+        other: "{0} dstspn Imp"
+      category: volume
+    drop:
+      short:
+        display_name: drop
+        other: "{0} drop"
+      category: volume
+    dram:
+      short:
+        display_name: dram fluid
+        other: "{0} dram fl"
+      category: volume
+    jigger:
+      short:
+        display_name: jigger
+        other: "{0} jigger"
+      category: volume
+    pinch:
+      short:
+        display_name: pinch
+        other: "{0} pinch"
+      category: volume
+    quart-imperial:
+      short:
+        display_name: qt Imp
+        other: "{0} qt Imp."
+      category: volume
+    light-speed:
+      short:
+        display_name: light
+        other: "{0} light"
+      category: speed
+    portion-per-1e9:
+      short:
+        display_name: ppb
+        other: "{0} ppb"
+      category: concentr
+    night:
+      short:
+        display_name: night
+        other: "{0} night"
+        per_unit_pattern: "{0}/night"
+      category: duration
 currency_fractions:
   ADP:
     digits: 0

--- a/lib/foxtail/cldr/extractor/number_formats.rb
+++ b/lib/foxtail/cldr/extractor/number_formats.rb
@@ -16,7 +16,8 @@ module Foxtail
               "currency_formats" => extract_currency_formats(xml_doc, formats),
               "scientific_formats" => {"standard" => formats["scientific"]},
               "compact_formats" => extract_compact_formats(xml_doc),
-              "currencies" => merge_locale_and_root_currencies(xml_doc)
+              "currencies" => merge_locale_and_root_currencies(xml_doc),
+              "units" => extract_units(xml_doc)
             }
           }
 
@@ -276,6 +277,62 @@ module Foxtail
           end
 
           currencies
+        end
+
+        # Extract unit formatting data from CLDR XML
+        private def extract_units(xml_doc)
+          units = {}
+
+          # Extract from units/unitLength sections (long and short forms)
+          %w[long short narrow].each do |unit_width|
+            xpath = "//units/unitLength[@type='#{unit_width}']/unit"
+            xml_doc.elements.each(xpath) do |unit_element|
+              unit_type = unit_element.attributes["type"]
+              next unless unit_type
+
+              # Parse unit type (e.g., "length-kilometer" -> category: "length", unit: "kilometer")
+              parts = unit_type.split("-", 2)
+              next unless parts.length == 2
+
+              category = parts[0]
+              unit_name = parts[1]
+
+              units[unit_name] ||= {}
+              units[unit_name][unit_width] ||= {}
+
+              # Extract display name
+              display_name_element = unit_element.elements["displayName"]
+              if display_name_element
+                units[unit_name][unit_width]["display_name"] = display_name_element.text
+              end
+
+              # Extract unit patterns for different plural forms
+              unit_element.elements.each("unitPattern") do |pattern_element|
+                count = pattern_element.attributes["count"] || "other"
+                case_attr = pattern_element.attributes["case"]
+
+                pattern_key = case_attr ? "#{count}_#{case_attr}" : count
+                units[unit_name][unit_width][pattern_key] = pattern_element.text
+              end
+
+              # Extract gender information (for German, etc.)
+              gender_element = unit_element.elements["gender"]
+              if gender_element
+                units[unit_name][unit_width]["gender"] = gender_element.text
+              end
+
+              # Extract per-unit pattern
+              per_unit_element = unit_element.elements["perUnitPattern"]
+              if per_unit_element
+                units[unit_name][unit_width]["per_unit_pattern"] = per_unit_element.text
+              end
+
+              # Store category information
+              units[unit_name]["category"] = category
+            end
+          end
+
+          units
         end
       end
     end

--- a/lib/foxtail/cldr/formatter/number.rb
+++ b/lib/foxtail/cldr/formatter/number.rb
@@ -122,6 +122,7 @@ module Foxtail
 
             pattern
           else
+            # Use decimal pattern for unit, decimal, and default cases
             number_formats.decimal_pattern
           end
         end
@@ -340,6 +341,22 @@ module Foxtail
                       else
                         format_non_digit_token(token, number_formats, decimal_value, options)
                       end
+          end
+
+          # Apply unit pattern for unit style
+          style = options[:style] || "decimal"
+          if style == "unit"
+            unit = options[:unit] || "meter"
+            unit_display = options[:unitDisplay] || "short"
+            unit_pattern = number_formats.unit_pattern(unit, unit_display)
+
+            if unit_pattern
+              # Replace {0} placeholder with the formatted number
+              result = unit_pattern.gsub("{0}", result)
+            else
+              # Fallback: append unit name if no pattern found
+              result += " #{unit}"
+            end
           end
 
           result
@@ -608,6 +625,15 @@ module Foxtail
               return "#{symbol}0"
             when "percent"
               return "0%"
+            when "unit"
+              unit = options[:unit] || "meter"
+              unit_display = options[:unitDisplay] || "short"
+              unit_pattern = number_formats.unit_pattern(unit, unit_display)
+
+              return unit_pattern.gsub("{0}", "0") if unit_pattern
+
+              return "0 #{unit}"
+
             else
               return "0"
             end
@@ -824,6 +850,8 @@ module Foxtail
             percent_pattern = number_formats.percent_pattern
             combine_patterns_using_tokens(base_pattern, percent_pattern)
           else
+            # For units, decimal, and default cases, use base pattern as-is
+            # Unit symbol will be added in format_with_pattern for unit style
             base_pattern
           end
         end
@@ -872,6 +900,16 @@ module Foxtail
           when "percent"
             percent_pattern = number_formats.percent_pattern
             apply_style_pattern_to_compact_result(formatted_number, percent_pattern, "%", number_formats)
+          when "unit"
+            unit = options[:unit] || "meter"
+            unit_display = options[:unitDisplay] || "short"
+            unit_pattern = number_formats.unit_pattern(unit, unit_display)
+
+            if unit_pattern
+              unit_pattern.gsub("{0}", formatted_number)
+            else
+              "#{formatted_number} #{unit}"
+            end
           else
             formatted_number
           end


### PR DESCRIPTION
## Summary
Implements full CLDR unit pattern support with proper inheritance, achieving **94% overall compatibility** with Node.js Intl.NumberFormat (**97.3% for unit style**).

## Changes
### Major Improvements
- Extract complete unit data from CLDR XML (long/short/narrow forms)
- Implement unit pattern substitution with `{0}` placeholders
- Add proper CLDR inheritance for missing patterns (e.g., Japanese short inherits from root)
- Support multiple units beyond kilometer (meter, gram, liter, celsius, kilometer-per-hour)
- Extract unit data for root locale to enable proper inheritance

### Technical Details
- `NumberFormats#unit_pattern` method with fallback logic (short → narrow → long)
- Proper pattern validation (must contain `{0}` placeholder)
- Unit display name and per-unit pattern extraction
- Comprehensive test coverage across multiple locales and units

## Compatibility Results
| Category | Before | After | Change |
|----------|--------|-------|--------|
| Overall | 83.5% | 94.0% | +10.5% |
| Unit style | 55.4% | 97.3% | +41.9% |
| Decimal | 97.3% | 97.3% | - |
| Currency | 93.8% | 93.8% | - |

## Test Plan
- [x] Run `rake compatibility:node_intl` to verify compatibility
- [x] Run `rake spec` to ensure all tests pass
- [x] Run `rake rubocop` to ensure code quality

## Next Steps
Remaining issues for future PRs:
- Decimal separator differences in compact notation (de-DE, fr-FR)
- Negative currency symbol positioning
- Percent compact notation grouping
- Support for compound units with `{0} {1}` patterns

🤖 Generated with [Claude Code](https://claude.ai/code)