### PR TITLE
:recycle: refactor: Make Resolver accept Locale objects and clarify string parameters

### DIFF
--- a/lib/foxtail/cldr/extractor/base.rb
+++ b/lib/foxtail/cldr/extractor/base.rb
@@ -125,8 +125,8 @@ module Foxtail
           raise ArgumentError, "CLDR source directory not found: #{locales_dir}"
         end
 
-        private def parent_locales
-          @parent_locales ||= @inheritance.load_parent_locales(@output_dir)
+        private def parent_locale_ids
+          @parent_locale_ids ||= @inheritance.load_parent_locale_ids(@output_dir)
         end
 
         private def load_raw_locale_data(locale_id)
@@ -146,8 +146,8 @@ module Foxtail
           return nil if locale_id == "root"
 
           # Check explicit parent mappings first
-          if parent_locales[locale_id]
-            parent_locales[locale_id]
+          if parent_locale_ids[locale_id]
+            parent_locale_ids[locale_id]
           else
             # Use algorithmic parent resolution
             chain = @inheritance.resolve_inheritance_chain(locale_id)

--- a/lib/foxtail/cldr/repository/date_time_formats.rb
+++ b/lib/foxtail/cldr/repository/date_time_formats.rb
@@ -20,7 +20,7 @@ module Foxtail
       class DateTimeFormats < Base
         def initialize(locale)
           super
-          @resolver = Resolver.new(@locale.to_simple.to_s)
+          @resolver = Resolver.new(@locale)
 
           # Check data availability during construction
           return if data?

--- a/lib/foxtail/cldr/repository/number_formats.rb
+++ b/lib/foxtail/cldr/repository/number_formats.rb
@@ -21,7 +21,7 @@ module Foxtail
       class NumberFormats < Base
         def initialize(locale)
           super
-          @resolver = Resolver.new(@locale.to_simple.to_s)
+          @resolver = Resolver.new(@locale)
 
           # Check data availability during construction
           return if data?

--- a/lib/foxtail/cldr/repository/plural_rules.rb
+++ b/lib/foxtail/cldr/repository/plural_rules.rb
@@ -21,7 +21,7 @@ module Foxtail
       class PluralRules < Base
         def initialize(locale)
           super
-          @resolver = Resolver.new(@locale.to_simple.to_s)
+          @resolver = Resolver.new(@locale)
         end
 
         # Select appropriate plural category for the given number

--- a/spec/foxtail/cldr/repository/inheritance_spec.rb
+++ b/spec/foxtail/cldr/repository/inheritance_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Foxtail::CLDR::Repository::Inheritance do
     end
   end
 
-  describe "#load_parent_locales" do
+  describe "#load_parent_locale_ids" do
     let(:temp_dir) { Dir.mktmpdir }
     let(:parent_locales_file) { File.join(temp_dir, "parent_locales.yml") }
 
@@ -56,7 +56,7 @@ RSpec.describe Foxtail::CLDR::Repository::Inheritance do
 
       File.write(parent_locales_file, yaml_content.to_yaml)
 
-      parents = inheritance.load_parent_locales(temp_dir)
+      parents = inheritance.load_parent_locale_ids(temp_dir)
 
       expect(parents).to eq({
         "en_AU" => "en_001",
@@ -69,7 +69,7 @@ RSpec.describe Foxtail::CLDR::Repository::Inheritance do
 
     it "raises ArgumentError when parent locales file does not exist" do
       expect {
-        inheritance.load_parent_locales(temp_dir)
+        inheritance.load_parent_locale_ids(temp_dir)
       }.to raise_error(ArgumentError, /Parent locales data not found/)
     end
 
@@ -77,7 +77,7 @@ RSpec.describe Foxtail::CLDR::Repository::Inheritance do
       File.write(parent_locales_file, "invalid: yaml: [")
 
       expect {
-        inheritance.load_parent_locales(temp_dir)
+        inheritance.load_parent_locale_ids(temp_dir)
       }.to raise_error(ArgumentError, /Could not load parent locales/)
     end
   end


### PR DESCRIPTION
## Summary

- Change Resolver constructor to accept Locale objects directly instead of strings
- String conversion only happens when needed (file paths, inheritance chains)  
- Use normalized locale string (`@locale_id`) for cache keys to improve memory efficiency
- Rename string parameters from 'locale' to 'locale_id' for clarity throughout codebase
- Rename 'parent_locales' to 'parent_locale_ids' for consistency

## Benefits

- **Type Safety**: Eliminates confusion between Locale objects and locale ID strings
- **Bug Prevention**: Prevents potential bugs from incorrect type assumptions  
- **Memory Efficiency**: Cache sharing for equivalent locales (e.g., `zh-Hans-CN` and `zh-CN` after normalization)
- **Code Clarity**: Clear distinction between objects and string IDs in variable names

## Changes

- **Repository classes**: Updated NumberFormats, DateTimeFormats, PluralRules to pass Locale objects to Resolver
- **Resolver class**: Now accepts Locale objects, converts to strings only when needed
- **Inheritance class**: Renamed methods and parameters for clarity (`load_parent_locale_ids`)
- **Extractor base**: Updated to use new naming conventions
- **Tests**: Updated to match new method names

## Test Results

- :white_check_mark: All 489 tests passing  
- :white_check_mark: RuboCop clean
- :white_check_mark: Coverage maintained at 83.53%

:robot: Generated with [Claude Code](https://claude.ai/code)