### PR TITLE
Centralize CLDR version management with SOURCE_VERSION constant

### DIFF
--- a/lib/foxtail/cldr.rb
+++ b/lib/foxtail/cldr.rb
@@ -6,6 +6,10 @@ module Foxtail
   # CLDR (Common Locale Data Repository) integration
   # Provides ICU-compliant plural rules and datetime formatting data
   module CLDR
+    # CLDR source data version used by this gem
+    SOURCE_VERSION = "46"
+    public_constant :SOURCE_VERSION
+
     # Logger instance for CLDR-related operations
     def self.logger
       @logger ||= Dry.Logger(:cldr)

--- a/lib/foxtail/cldr/extractor/base.rb
+++ b/lib/foxtail/cldr/extractor/base.rb
@@ -190,7 +190,7 @@ module Foxtail
           yaml_data = {
             "locale" => locale_id,
             "generated_at" => Time.now.utc.iso8601,
-            "cldr_version" => ENV.fetch("CLDR_VERSION", "46")
+            "cldr_version" => Foxtail::CLDR::SOURCE_VERSION
           }
 
           # Merge in the data, preserving its structure

--- a/lib/foxtail/cldr/extractor/locale_aliases.rb
+++ b/lib/foxtail/cldr/extractor/locale_aliases.rb
@@ -129,7 +129,7 @@ module Foxtail
 
           yaml_data = {
             "generated_at" => Time.now.utc.iso8601,
-            "cldr_version" => ENV.fetch("CLDR_VERSION", "46"),
+            "cldr_version" => Foxtail::CLDR::SOURCE_VERSION,
             "locale_aliases" => aliases
           }
 

--- a/lib/foxtail/cldr/extractor/metazone_mapping.rb
+++ b/lib/foxtail/cldr/extractor/metazone_mapping.rb
@@ -18,7 +18,7 @@ module Foxtail
 
           yaml_data = {
             "generated_at" => Time.now.utc.iso8601,
-            "cldr_version" => ENV.fetch("CLDR_VERSION", "46")
+            "cldr_version" => Foxtail::CLDR::SOURCE_VERSION
           }.merge(mapping_data)
 
           # Skip writing if only generated_at differs

--- a/lib/foxtail/cldr/extractor/parent_locales.rb
+++ b/lib/foxtail/cldr/extractor/parent_locales.rb
@@ -15,7 +15,7 @@ module Foxtail
 
           parent_locales_data = {
             "generated_at" => Time.now.utc.iso8601,
-            "cldr_version" => ENV.fetch("CLDR_VERSION", "46"),
+            "cldr_version" => Foxtail::CLDR::SOURCE_VERSION,
             "parent_locales" => extract_parent_locales_data
           }
 

--- a/lib/tasks/cldr.rake
+++ b/lib/tasks/cldr.rake
@@ -13,8 +13,7 @@ task :set_debug_logging do
 end
 
 # CLDR version configuration
-CLDR_VERSION = "46"
-CLDR_CORE_URL = "https://unicode.org/Public/cldr/#{CLDR_VERSION}/core.zip".freeze
+CLDR_CORE_URL = "https://unicode.org/Public/cldr/#{Foxtail::CLDR::SOURCE_VERSION}/core.zip".freeze
 
 # Define paths
 TMP_DIR = Foxtail::ROOT + "tmp"

--- a/spec/foxtail/cldr/extractor/base_spec.rb
+++ b/spec/foxtail/cldr/extractor/base_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Foxtail::CLDR::Extractor::Base do
         content = YAML.load_file(file_path)
         expect(content["locale"]).to eq("en")
         expect(content["generated_at"]).not_to be_nil
-        expect(content["cldr_version"]).to eq("46")
+        expect(content["cldr_version"]).to eq(Foxtail::CLDR::SOURCE_VERSION)
         expect(content["test_key"]).to eq("test_value")
       end
     end
@@ -200,7 +200,7 @@ RSpec.describe Foxtail::CLDR::Extractor::Base do
         {
           "locale" => "en",
           "generated_at" => "2023-01-01T00:00:00Z",
-          "cldr_version" => "46",
+          "cldr_version" => Foxtail::CLDR::SOURCE_VERSION,
           "test_key" => "test_value"
         }
       end
@@ -214,7 +214,7 @@ RSpec.describe Foxtail::CLDR::Extractor::Base do
           {
             "locale" => "en",
             "generated_at" => "2023-12-31T23:59:59Z",
-            "cldr_version" => "46",
+            "cldr_version" => Foxtail::CLDR::SOURCE_VERSION,
             "test_key" => "test_value"
           }
         end
@@ -229,7 +229,7 @@ RSpec.describe Foxtail::CLDR::Extractor::Base do
           {
             "locale" => "en",
             "generated_at" => "2023-12-31T23:59:59Z",
-            "cldr_version" => "46",
+            "cldr_version" => Foxtail::CLDR::SOURCE_VERSION,
             "test_key" => "different_value"
           }
         end
@@ -244,7 +244,7 @@ RSpec.describe Foxtail::CLDR::Extractor::Base do
           {
             "locale" => "en",
             "generated_at" => "2023-12-31T23:59:59Z",
-            "cldr_version" => "46",
+            "cldr_version" => Foxtail::CLDR::SOURCE_VERSION,
             "test_key" => "test_value",
             "new_field" => "new_value"
           }

--- a/spec/foxtail/cldr/extractor/parent_locales_spec.rb
+++ b/spec/foxtail/cldr/extractor/parent_locales_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Foxtail::CLDR::Extractor::ParentLocales do
         initial_mtime # Ensure file exists with recorded mtime
 
         # Change CLDR version
-        allow(ENV).to receive(:fetch).with("CLDR_VERSION", "46").and_return("47")
+        stub_const("Foxtail::CLDR::SOURCE_VERSION", "47")
 
         extractor.extract_all
 

--- a/spec/foxtail/cldr/repository/resolver_spec.rb
+++ b/spec/foxtail/cldr/repository/resolver_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe Foxtail::CLDR::Repository::Resolver do
       yaml_content = {
         "locale" => locale,
         "generated_at" => Time.now.utc.iso8601,
-        "cldr_version" => "46",
+        "cldr_version" => Foxtail::CLDR::SOURCE_VERSION,
         data_type => content
       }
       file_path.write(yaml_content.to_yaml)


### PR DESCRIPTION
## Summary

- Add `Foxtail::CLDR::SOURCE_VERSION` constant for unified CLDR version management
- Replace scattered `ENV.fetch("CLDR_VERSION", "46")` calls with constant reference
- Update Rake tasks to use constant directly without unnecessary intermediate assignment
- Modernize tests to use constant instead of hardcoded "46" values and environment variable stubs

## Benefits

- **Single source of truth**: All CLDR version references now point to one constant
- **Easier maintenance**: Future version updates require only changing one line
- **Better consistency**: Eliminates risk of version mismatches across the codebase
- **Cleaner code**: Removes redundant environment variable handling

## Changes Made

### Core Implementation
- Defined `SOURCE_VERSION = "46"` in `lib/foxtail/cldr.rb` with `public_constant` declaration
- Updated all extractors to use the constant instead of `ENV.fetch`
- Simplified Rake task to reference constant directly

### Test Improvements
- Replaced hardcoded `"46"` expectations with `Foxtail::CLDR::SOURCE_VERSION`
- Changed environment variable stubbing to constant stubbing in tests
- Maintained all existing test functionality while improving maintainability

## Test Plan

- [x] All RSpec tests pass (571 examples, 0 failures)
- [x] RuboCop style checks pass
- [x] CLDR version constant is accessible and returns correct value
- [x] Rake tasks continue to work with new constant reference

:robot: Generated with [Claude Code](https://claude.ai/code)