### PR TITLE
🚧 [DO NOT MERGE] Debug timezone formatting in GitHub Actions

### DIFF
--- a/.github/workflows/debug-timezone.yml
+++ b/.github/workflows/debug-timezone.yml
@@ -1,0 +1,61 @@
+name: Debug Timezone Issue
+
+# This workflow is for debugging timezone formatting issues
+# DO NOT MERGE - This is for investigation only
+
+on:
+  push:
+    branches:
+      - experiment/debug-timezone-issue
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'experiment/**'
+      - '.github/workflows/debug-timezone.yml'
+
+  # Allow manual triggering
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  debug-timezone:
+    runs-on: ubuntu-latest
+    name: Debug Timezone Environment
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: Debug timezone environment
+        run: |
+          echo "=== System Information ==="
+          date
+          timedatectl status || echo "timedatectl not available"
+          cat /etc/timezone || echo "No /etc/timezone"
+          ls -la /etc/localtime || echo "No /etc/localtime"
+          echo "TZ environment: $TZ"
+
+          echo ""
+          echo "=== Ruby Timezone Debug ==="
+          bundle exec ruby debug_timezone_environment.rb
+
+      - name: Run problematic Node.js compatibility test
+        run: |
+          echo "=== Running Node.js Compatibility Test ==="
+          bundle exec rake compatibility:node_intl || echo "Test completed (may have failures)"
+
+      - name: Upload debug results
+        uses: actions/upload-artifact@v4
+        with:
+          name: timezone-debug-results
+          path: |
+            compat/node_intl_compatibility_report.md
+          retention-days: 7

--- a/debug_timezone_environment.rb
+++ b/debug_timezone_environment.rb
@@ -1,0 +1,100 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "lib/foxtail"
+
+puts "=== GitHub Actions Environment Debug ==="
+puts "Ruby version: #{RUBY_VERSION}"
+puts "Platform: #{RUBY_PLATFORM}"
+puts "TZ environment variable: #{ENV['TZ'] || 'not set'}"
+puts "System timezone: #{Time.now.zone}"
+puts "UTC offset: #{Time.now.utc_offset / 3600} hours"
+puts "Current time: #{Time.now}"
+puts "Current UTC time: #{Time.now.utc}"
+puts
+
+# Test the specific problematic case
+formatter = Foxtail::CLDR::Formatter::DateTime.new
+locale_tag = Locale::Tag.parse("fr-FR")
+
+puts "=== Testing French Locale Timezone Formatting ==="
+
+test_cases = [
+  {
+    value: "2023-02-14T23:59:59Z",
+    options: { timeStyle: "long" },
+    description: "timeStyle: long (no timezone specified)"
+  },
+  {
+    value: "2023-02-14T23:59:59Z",
+    options: { timeStyle: "short" },
+    description: "timeStyle: short (no timezone specified)"
+  },
+  {
+    value: "2023-02-14T23:59:59Z",
+    options: { timeStyle: "long", timeZone: "UTC" },
+    description: "timeStyle: long, explicit UTC"
+  },
+  {
+    value: "2023-02-14T23:59:59Z",
+    options: { timeStyle: "long", timeZone: "Etc/UTC" },
+    description: "timeStyle: long, explicit Etc/UTC"
+  }
+]
+
+test_cases.each do |test_case|
+  puts "Testing: #{test_case[:description]}"
+  puts "Options: #{test_case[:options].inspect}"
+
+  begin
+    result = formatter.call(test_case[:value], locale: locale_tag, **test_case[:options])
+    puts "Result: '#{result}'"
+
+    # Analyze characters
+    hex_dump = result.unpack("U*").map {|code| "U+#{code.to_s(16).upcase.rjust(4, '0')}" }.join(" ")
+    puts "Hex: #{hex_dump}"
+
+    if result.include?("TU")
+      puts "🚨 FOUND PROBLEM: 'TU' detected!"
+    elsif result.include?("UTC")
+      puts "✓ UTC found (expected)"
+    else
+      puts "? No UTC/TU found"
+    end
+  rescue => e
+    puts "ERROR: #{e.message}"
+    puts "Backtrace: #{e.backtrace.first(3).join(', ')}"
+  end
+
+  puts "---"
+end
+
+puts
+puts "=== System Timezone Detection Debug ==="
+
+# Debug timezone detection
+begin
+  # Access internal timezone detection if possible
+  datetime_formatter = Foxtail::CLDR::Formatter::DateTime.new
+  context = datetime_formatter.instance_variable_get(:@context) rescue nil
+
+  if context
+    puts "Formatter context timezone info:"
+    puts "Context class: #{context.class}"
+    # Try to access system timezone method if available
+    if context.respond_to?(:system_timezone, true)
+      system_tz = context.send(:system_timezone) rescue "Failed to get system timezone"
+      puts "System timezone from context: #{system_tz}"
+    end
+  end
+rescue => e
+  puts "Could not access internal timezone info: #{e.message}"
+end
+
+puts
+puts "=== Environment Variables ==="
+ENV.each do |key, value|
+  if key.match?(/time|zone|utc/i) || key.match?(/tz/i)
+    puts "#{key}: #{value}"
+  end
+end

--- a/debug_timezone_environment.rb
+++ b/debug_timezone_environment.rb
@@ -6,7 +6,7 @@ require_relative "lib/foxtail"
 puts "=== GitHub Actions Environment Debug ==="
 puts "Ruby version: #{RUBY_VERSION}"
 puts "Platform: #{RUBY_PLATFORM}"
-puts "TZ environment variable: #{ENV['TZ'] || 'not set'}"
+puts "TZ environment variable: #{ENV["TZ"] || "not set"}"
 puts "System timezone: #{Time.now.zone}"
 puts "UTC offset: #{Time.now.utc_offset / 3600} hours"
 puts "Current time: #{Time.now}"
@@ -22,22 +22,22 @@ puts "=== Testing French Locale Timezone Formatting ==="
 test_cases = [
   {
     value: "2023-02-14T23:59:59Z",
-    options: { timeStyle: "long" },
+    options: {timeStyle: "long"},
     description: "timeStyle: long (no timezone specified)"
   },
   {
     value: "2023-02-14T23:59:59Z",
-    options: { timeStyle: "short" },
+    options: {timeStyle: "short"},
     description: "timeStyle: short (no timezone specified)"
   },
   {
     value: "2023-02-14T23:59:59Z",
-    options: { timeStyle: "long", timeZone: "UTC" },
+    options: {timeStyle: "long", timeZone: "UTC"},
     description: "timeStyle: long, explicit UTC"
   },
   {
     value: "2023-02-14T23:59:59Z",
-    options: { timeStyle: "long", timeZone: "Etc/UTC" },
+    options: {timeStyle: "long", timeZone: "Etc/UTC"},
     description: "timeStyle: long, explicit Etc/UTC"
   }
 ]
@@ -51,7 +51,7 @@ test_cases.each do |test_case|
     puts "Result: '#{result}'"
 
     # Analyze characters
-    hex_dump = result.unpack("U*").map {|code| "U+#{code.to_s(16).upcase.rjust(4, '0')}" }.join(" ")
+    hex_dump = result.unpack("U*").map {|code| "U+#{code.to_s(16).upcase.rjust(4, "0")}" }.join(" ")
     puts "Hex: #{hex_dump}"
 
     if result.include?("TU")
@@ -63,7 +63,7 @@ test_cases.each do |test_case|
     end
   rescue => e
     puts "ERROR: #{e.message}"
-    puts "Backtrace: #{e.backtrace.first(3).join(', ')}"
+    puts "Backtrace: #{e.backtrace.first(3).join(", ")}"
   end
 
   puts "---"
@@ -76,14 +76,22 @@ puts "=== System Timezone Detection Debug ==="
 begin
   # Access internal timezone detection if possible
   datetime_formatter = Foxtail::CLDR::Formatter::DateTime.new
-  context = datetime_formatter.instance_variable_get(:@context) rescue nil
+  context = begin
+    datetime_formatter.instance_variable_get(:@context)
+  rescue
+    nil
+  end
 
   if context
     puts "Formatter context timezone info:"
     puts "Context class: #{context.class}"
     # Try to access system timezone method if available
     if context.respond_to?(:system_timezone, true)
-      system_tz = context.send(:system_timezone) rescue "Failed to get system timezone"
+      system_tz = begin
+        context.__send__(:system_timezone)
+      rescue
+        "Failed to get system timezone"
+      end
       puts "System timezone from context: #{system_tz}"
     end
   end


### PR DESCRIPTION
## ⚠️ DO NOT MERGE - Investigation Only

This PR is for debugging timezone formatting differences between local and GitHub Actions environments.

### 🎯 Purpose
Investigate why French locale outputs `TU` instead of `UTC` in CI environment:
- Local: `23:59:59 UTC` ✓
- GitHub Actions: `23:59:59 TU` ❌

### 🔍 What this does
- Adds comprehensive environment debugging script
- Captures system timezone, Ruby environment, and formatting results
- Runs Node.js compatibility tests to reproduce the issue

### 📊 Expected outcome
Identify the root cause of the `Etc/UTC` zone short form (`TU`) being used instead of the locale-specific `gmt_format` (`UTC`).

---

🤖 Generated with [Claude Code](https://claude.ai/code)