### PR TITLE
:recycle: Extract duplicate GMT offset formatting into helper method

### DIFF
--- a/lib/foxtail/cldr/formatter/date_time.rb
+++ b/lib/foxtail/cldr/formatter/date_time.rb
@@ -768,11 +768,7 @@ module Foxtail
                 elsif offset_seconds == 0
                   name = gmt_format.gsub("{0}", "")
                 else
-                  hours = offset_seconds.abs / 3600
-                  minutes = (offset_seconds.abs % 3600) / 60
-                  sign = offset_seconds >= 0 ? "+" : "-"
-                  offset_string = "#{sign}#{hours}"
-                  offset_string += ":#{"%02d" % minutes}" if minutes > 0
+                  offset_string = format_gmt_offset_string(offset_seconds)
                   name = gmt_format.gsub("{0}", offset_string)
                 end
               end
@@ -802,11 +798,7 @@ module Foxtail
                       name = gmt_format.gsub("{0}", "")
                     elsif gmt_format&.start_with?("UTC") && offset_seconds != 0
                       # For non-zero offsets, use the UTC format with offset
-                      hours = offset_seconds.abs / 3600
-                      minutes = (offset_seconds.abs % 3600) / 60
-                      sign = offset_seconds >= 0 ? "+" : "-"
-                      offset_string = "#{sign}#{hours}"
-                      offset_string += ":#{"%02d" % minutes}" if minutes > 0
+                      offset_string = format_gmt_offset_string(offset_seconds)
                       name = gmt_format.gsub("{0}", offset_string)
                     else
                       # Use metazone name for GMT-preferring locales
@@ -840,11 +832,7 @@ module Foxtail
                 base_format = @timezone_names.gmt_format
                 name = base_format.gsub("{0}", "")
               else
-                hours = offset_seconds.abs / 3600
-                minutes = (offset_seconds.abs % 3600) / 60
-                sign = offset_seconds >= 0 ? "+" : "-"
-                offset_string = "#{sign}#{hours}"
-                offset_string += ":#{"%02d" % minutes}" if minutes > 0
+                offset_string = format_gmt_offset_string(offset_seconds)
 
                 # Apply CLDR gmt_format pattern (e.g., "GMT{0}" or "UTC{0}")
                 gmt_pattern = @timezone_names.gmt_format
@@ -940,6 +928,18 @@ module Foxtail
             utc_time = @original_time.getutc
             period = timezone.period_for_utc(utc_time)
             period.offset.utc_total_offset
+          end
+
+          # Format offset seconds into GMT/UTC style string (e.g., "+9", "+9:30", "-5")
+          private def format_gmt_offset_string(offset_seconds)
+            return "" if offset_seconds == 0
+
+            hours = offset_seconds.abs / 3600
+            minutes = (offset_seconds.abs % 3600) / 60
+            sign = offset_seconds >= 0 ? "+" : "-"
+            offset_string = "#{sign}#{hours}"
+            offset_string += ":#{"%02d" % minutes}" if minutes > 0
+            offset_string
           end
 
           # Check if the current time is in daylight saving time for the given timezone


### PR DESCRIPTION
## Summary

Refactor timezone formatting code to eliminate duplication by extracting common GMT/UTC offset string formatting logic into a dedicated helper method.

## Changes

- **Add `format_gmt_offset_string` helper method**: Centralizes GMT/UTC style offset formatting logic
- **Remove code duplication**: Replaces 3 instances of identical offset calculation and formatting code
- **Improve maintainability**: Single source of truth for GMT offset string formatting
- **Preserve functionality**: No behavioral changes, all existing tests pass

## Before/After

**Before**: 3 separate implementations of this pattern:
```ruby
hours = offset_seconds.abs / 3600
minutes = (offset_seconds.abs % 3600) / 60
sign = offset_seconds >= 0 ? "+" : "-"
offset_string = "#{sign}#{hours}"
offset_string += ":#{"%02d" % minutes}" if minutes > 0
```

**After**: Single helper method:
```ruby
offset_string = format_gmt_offset_string(offset_seconds)
```

## Benefits

- **DRY principle**: Eliminates duplicate code
- **Consistency**: Single implementation ensures consistent formatting
- **Maintainability**: Changes to offset formatting logic only need to be made in one place
- **Readability**: More semantic method names improve code clarity

🤖 Generated with [Claude Code](https://claude.ai/code)
