### PR TITLE
Refactor format method to call with alias

### DIFF
--- a/lib/foxtail/cldr/formatter/date_time.rb
+++ b/lib/foxtail/cldr/formatter/date_time.rb
@@ -94,11 +94,6 @@ module Foxtail
           utc_time = @original_time&.getutc
           @time_with_zone = apply_timezone(utc_time, @options[:timeZone])
 
-          format
-        end
-
-        # Format the date/time value using CLDR data and options
-        def format
           return @original_value.to_s if @time_with_zone.nil?
 
           # Handle custom pattern first (highest priority)
@@ -113,6 +108,8 @@ module Foxtail
             format_with_fields
           end
         end
+
+        alias format call
 
         # Convert value to Time for consistent processing
         private def convert_to_time(value)

--- a/lib/foxtail/cldr/formatter/number.rb
+++ b/lib/foxtail/cldr/formatter/number.rb
@@ -97,11 +97,6 @@ module Foxtail
           @original_value = value
           @decimal_value = convert_to_decimal(value)
 
-          format
-        end
-
-        # Format the number value using CLDR data and options
-        def format
           # Handle special values (Infinity, -Infinity, NaN) early
           if special_value?(@original_value)
             return format_special_value(@original_value)
@@ -146,6 +141,8 @@ module Foxtail
           original_was_negative = transformed_value.negative? && !has_separator
           build_formatted_string(format_value, pattern_tokens, original_was_negative)
         end
+
+        alias format call
 
         # Check if currency repository is needed (any currency symbol ¤, ¤¤, ¤¤¤)
         private def use_currency?(options)


### PR DESCRIPTION
## Summary
- Inline format method into call method in both Number and DateTime formatters
- Make format an alias of call

## Test plan
- [x] All existing tests pass (598 examples, 0 failures)
- [x] RuboCop style checks pass

:robot: Generated with [Claude Code](https://claude.ai/code)