### PR TITLE
:recycle: Replace CLDR PluralRules with ICU4X::PluralRules

### DIFF
--- a/lib/foxtail/bundle/resolver.rb
+++ b/lib/foxtail/bundle/resolver.rb
@@ -330,8 +330,10 @@ module Foxtail
 
         # Try each locale in the bundle's chain for plural rules
         @bundle.locales.each do |locale|
-          plural_rules = Foxtail::CLDR::Repository::PluralRules.new(locale)
-          plural_category = plural_rules.select(numeric_value)
+          locale_str = locale.respond_to?(:to_rfc) ? locale.to_rfc : locale.to_s
+          icu_locale = ICU4X::Locale.parse(locale_str)
+          plural_rules = ICU4X::PluralRules.new(icu_locale)
+          plural_category = plural_rules.select(numeric_value).to_s
           return key_str.to_s == plural_category
         rescue
           # If plural rule evaluation fails for this locale, try next

--- a/spec/foxtail/bundle/resolver_spec.rb
+++ b/spec/foxtail/bundle/resolver_spec.rb
@@ -348,8 +348,8 @@ RSpec.describe Foxtail::Bundle::Resolver do
 
     it "falls back to default when plural rules fail" do
       # Test with unsupported locale that might fail plural rule evaluation
-      plural_rules_double = instance_double(Foxtail::CLDR::Repository::PluralRules)
-      allow(Foxtail::CLDR::Repository::PluralRules).to receive(:new).and_return(plural_rules_double)
+      plural_rules_double = instance_double(ICU4X::PluralRules)
+      allow(ICU4X::PluralRules).to receive(:new).and_return(plural_rules_double)
       allow(plural_rules_double).to receive(:select).and_raise("Error")
 
       expr = {


### PR DESCRIPTION
## Summary

Replace `Foxtail::CLDR::Repository::PluralRules` with `ICU4X::PluralRules` in the bundle resolver for FTL plural category matching.

## Changes

- Use `ICU4X::PluralRules` for plural category matching (one, other, few, many, etc.)
- Convert locale to ICU4X format using `to_rfc`
- Update test mock to use `ICU4X::PluralRules`

## Notes

This removes the last CLDR dependency from bundle resolution, enabling CLDR module removal in #90.

Closes #89
