### PR TITLE
:recycle: Migrate from locale gem to ICU4X::Locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ en_resource = Foxtail::Resource.from_string(<<~FTL)
   }.
 FTL
 
-en_bundle = Foxtail::Bundle.new(Locale::Tag.parse("en-US"))
+en_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("en-US"))
 en_bundle.add_resource(en_resource)
 en_bundle.format("hello", name: "Alice")
 # => "Hello, Alice!"
@@ -60,7 +60,7 @@ ja_resource = Foxtail::Resource.from_string(<<~FTL)
   emails = メールが{$count}件あります。
 FTL
 
-ja_bundle = Foxtail::Bundle.new(Locale::Tag.parse("ja"))
+ja_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("ja"))
 ja_bundle.add_resource(ja_resource)
 ja_bundle.format("hello", name: "太郎")
 # => "こんにちは、太郎さん！"
@@ -79,7 +79,7 @@ en_resource = Foxtail::Resource.from_string(<<~FTL)
   discount = Sale: {NUMBER($percent, style: "percent")} off!
 FTL
 
-en_bundle = Foxtail::Bundle.new(Locale::Tag.parse("en-US"))
+en_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("en-US"))
 en_bundle.add_resource(en_resource)
 en_bundle.format("price", amount: 1234.50)
 # => "The price is $1,234.50."
@@ -92,7 +92,7 @@ ja_resource = Foxtail::Resource.from_string(<<~FTL)
   discount = セール：{NUMBER($percent, style: "percent")}オフ！
 FTL
 
-ja_bundle = Foxtail::Bundle.new(Locale::Tag.parse("ja"))
+ja_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("ja"))
 ja_bundle.add_resource(ja_resource)
 ja_bundle.format("price", amount: 1234)
 # => "価格は￥1,234です。"
@@ -184,9 +184,8 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/sakuro
 
 This project stands on the shoulders of giants:
 
-- **ICU4X**: Number, date/time, and plural rules formatting via the [icu4x gem](https://github.com/nicholaides/icu4x-rb) ([MIT License](https://opensource.org/licenses/MIT))
+- **ICU4X**: Number, date/time, plural rules, and locale handling via the [icu4x gem](https://github.com/nicholaides/icu4x-rb) ([MIT License](https://opensource.org/licenses/MIT))
 - **Fluent Project**: Foxtail aims for compatibility with Mozilla's [Fluent localization system](https://projectfluent.org/), particularly [fluent.js](https://github.com/projectfluent/fluent.js) ([Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt))
-- **Ruby Locale**: Locale parsing and handling provided by the [Ruby GetText project](https://ruby-gettext.github.io/) ([Ruby License](https://www.ruby-lang.org/en/about/license.txt))
 
 ## License
 

--- a/docs/cldr-numbering-systems.md
+++ b/docs/cldr-numbering-systems.md
@@ -140,7 +140,7 @@ Unicode mathematical alphanumeric symbols:
 ### 3. API Design
 ```ruby
 # Example API for Foxtail
-bundle = Foxtail::Bundle.new(Locale::Tag.parse("ja"))
+bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("ja"))
 bundle.format("price", amount: 1234, numbering_system: "jpan")
 # => "一千二百三十四円"
 

--- a/docs/nodejs-numbering-systems.md
+++ b/docs/nodejs-numbering-systems.md
@@ -291,7 +291,7 @@ The Node.js patterns can inform Foxtail's Ruby API design:
 
 ```ruby
 # Foxtail equivalent concepts
-bundle = Foxtail::Bundle.new(Locale::Tag.parse("ar-SA"))
+bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("ar-SA"))
 bundle.format("price", amount: 1234.56, numbering_system: "arab")
 
 # With number format options

--- a/foxtail.gemspec
+++ b/foxtail.gemspec
@@ -38,6 +38,5 @@ Gem::Specification.new do |spec|
   # Dependencies
   spec.add_dependency "icu4x", "~> 0.6"
   spec.add_dependency "icu4x-data-recommended", "~> 0.6"
-  spec.add_dependency "locale", "~> 2.1"
   spec.add_dependency "zeitwerk", "~> 2.6"
 end

--- a/lib/foxtail/bundle.rb
+++ b/lib/foxtail/bundle.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "locale"
+require "icu4x"
 
 module Foxtail
   # Main runtime class for message formatting and localization.
@@ -10,7 +10,7 @@ module Foxtail
   # variable interpolation, and function calls.
   #
   # @example Basic usage
-  #   locale = Locale::Tag.parse("en-US")
+  #   locale = ICU4X::Locale.parse("en-US")
   #   bundle = Foxtail::Bundle.new(locale)
   #
   #   resource = Foxtail::Resource.from_string("hello = Hello, {$name}!")
@@ -36,28 +36,28 @@ module Foxtail
 
     # Create a new Bundle instance.
     #
-    # @param locales [Locale::Tag::Simple, Array<Locale::Tag::Simple>]
+    # @param locales [ICU4X::Locale, Array<ICU4X::Locale>]
     #   A single locale or array of locale instances for fallback chain
     # @param options [Hash] Configuration options
     # @option options [Hash] :functions Custom formatting functions (defaults to NUMBER and DATETIME)
     # @option options [Boolean] :use_isolating Whether to use Unicode isolating marks (default: true, not currently implemented)
     # @option options [Proc, nil] :transform Optional message transformation function (not currently implemented)
-    # @raise [ArgumentError] if locales are not Locale::Tag::Simple instances
+    # @raise [ArgumentError] if locales are not ICU4X::Locale instances
     #
     # @example Basic bundle creation
-    #   locale = Locale::Tag.parse("en-US")
+    #   locale = ICU4X::Locale.parse("en-US")
     #   bundle = Foxtail::Bundle.new(locale)
     #
     # @example Bundle with fallback locales
-    #   locales = [Locale::Tag.parse("en-US"), Locale::Tag.parse("en")]
+    #   locales = [ICU4X::Locale.parse("en-US"), ICU4X::Locale.parse("en")]
     #   bundle = Foxtail::Bundle.new(locales)
     def initialize(locales, **options)
-      # Accept only Locale instances for type safety
+      # Accept only ICU4X::Locale instances for type safety
       @locales = Array(locales).each_with_object([]) {|locale, acc|
-        unless locale.is_a?(Locale::Tag::Simple)
-          raise ArgumentError, "All locales must be Locale instances " \
-                               "(subclass of Locale::Tag::Simple), got: #{locale.class}"
+        unless locale.is_a?(ICU4X::Locale)
+          raise ArgumentError, "All locales must be ICU4X::Locale instances, got: #{locale.class}"
         end
+
         acc << locale
       }.freeze
 

--- a/lib/foxtail/bundle/resolver.rb
+++ b/lib/foxtail/bundle/resolver.rb
@@ -330,9 +330,7 @@ module Foxtail
 
         # Try each locale in the bundle's chain for plural rules
         @bundle.locales.each do |locale|
-          locale_str = locale.respond_to?(:to_rfc) ? locale.to_rfc : locale.to_s
-          icu_locale = ICU4X::Locale.parse(locale_str)
-          plural_rules = ICU4X::PluralRules.new(icu_locale)
+          plural_rules = ICU4X::PluralRules.new(locale)
           plural_category = plural_rules.select(numeric_value).to_s
           return key_str.to_s == plural_category
         rescue

--- a/lib/foxtail/function.rb
+++ b/lib/foxtail/function.rb
@@ -3,7 +3,6 @@
 require "date"
 require "icu4x"
 require "icu4x/data/recommended"
-require "locale"
 require "time"
 
 module Foxtail
@@ -30,36 +29,26 @@ module Foxtail
 
     # Format number using ICU4X
     # @param value [Numeric] Number to format
-    # @param locale [Locale::Tag::Simple] Locale for formatting
+    # @param locale [ICU4X::Locale] Locale for formatting
     # @param options [Hash] Formatting options
     # @return [String] Formatted number
     private_class_method def self.format_number(value, locale, options)
-      icu_locale = to_icu_locale(locale)
       icu_options = convert_number_options(options)
-      ICU4X::NumberFormat.new(icu_locale, **icu_options).format(value)
+      ICU4X::NumberFormat.new(locale, **icu_options).format(value)
     end
 
     # Format datetime using ICU4X
     # @param value [Time, DateTime, Date] DateTime to format
-    # @param locale [Locale::Tag::Simple] Locale for formatting
+    # @param locale [ICU4X::Locale] Locale for formatting
     # @param options [Hash] Formatting options
     # @return [String] Formatted datetime
     private_class_method def self.format_datetime(value, locale, options)
-      icu_locale = to_icu_locale(locale)
       icu_options = convert_datetime_options(options)
       # ICU4X requires at least one of date_style or time_style
       # Default to :medium for date if neither specified
       icu_options[:date_style] ||= :medium unless icu_options[:time_style]
       time_value = to_time(value)
-      ICU4X::DateTimeFormat.new(icu_locale, **icu_options).format(time_value)
-    end
-
-    # Convert Locale::Tag to ICU4X::Locale
-    # @param locale [Locale::Tag::Simple, String] Locale to convert
-    # @return [ICU4X::Locale] ICU4X locale object
-    private_class_method def self.to_icu_locale(locale)
-      locale_str = locale.respond_to?(:to_rfc) ? locale.to_rfc : locale.to_s
-      ICU4X::Locale.parse(locale_str)
+      ICU4X::DateTimeFormat.new(locale, **icu_options).format(time_value)
     end
 
     # Convert value to Time object

--- a/sig/foxtail.rbs
+++ b/sig/foxtail.rbs
@@ -5,34 +5,34 @@ module Foxtail
   end
 
   class Bundle
-    @locales: Array[Locale::Tag::Simple]
+    @locales: Array[ICU4X::Locale]
     @messages: Hash[String, Hash[String, untyped]]
     @terms: Hash[String, Hash[String, untyped]]
     @functions: Hash[String, Proc]
     @use_isolating: bool
     @transform: Proc?
 
-    attr_reader locales: Array[Locale::Tag::Simple]
+    attr_reader locales: Array[ICU4X::Locale]
     attr_reader messages: Hash[String, Hash[String, untyped]]
     attr_reader terms: Hash[String, Hash[String, untyped]]
     attr_reader functions: Hash[String, Proc]
     attr_reader use_isolating: bool
     attr_reader transform: Proc?
 
-    def initialize: (Locale::Tag::Simple | Array[Locale::Tag::Simple] locales, **untyped options) -> void
-    def locale: () -> Locale::Tag::Simple
-    def add_resource: (String | Resource resource, ?locale: Locale::Tag::Simple?) -> void
+    def initialize: (ICU4X::Locale | Array[ICU4X::Locale] locales, **untyped options) -> void
+    def locale: () -> String
+    def add_resource: (String | Resource resource, **untyped options) -> Array[String]
     def message?: (String | Symbol id) -> bool
     def message: (String | Symbol id) -> Hash[String, untyped]?
     def term?: (String | Symbol id) -> bool
     def term: (String | Symbol id) -> Hash[String, untyped]?
     def format: (String | Symbol id, ?Hash[String | Symbol, untyped] args) -> String
-    def format_pattern: (Hash[String, untyped] pattern, ?Hash[String | Symbol, untyped] args) -> String
+    def format_pattern: (Hash[String, untyped] pattern, ?Hash[String | Symbol, untyped] args, ?Array[String]? errors) -> String
 
     private
 
-    def add_message_entry: (untyped entry, Locale::Tag::Simple locale) -> void
-    def add_term_entry: (untyped entry, Locale::Tag::Simple locale) -> void
+    def add_message_entry: (untyped entry, bool allow_overrides) -> void
+    def add_term_entry: (untyped entry, bool allow_overrides) -> void
   end
 
   class Parser

--- a/spec/foxtail/bundle_spec.rb
+++ b/spec/foxtail/bundle_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe Foxtail::Bundle do
   describe "#initialize" do
     it "accepts a single locale" do
       bundle = Foxtail::Bundle.new(locale("en-US"))
-      expect(bundle.locales.map(&:to_s)).to eq(["en_US"])
+      expect(bundle.locales.map(&:to_s)).to eq(["en-US"])
     end
 
     it "accepts multiple locales" do
       bundle = Foxtail::Bundle.new([locale("en-US"), locale("en")])
-      expect(bundle.locales.map(&:to_s)).to eq(%w[en_US en])
+      expect(bundle.locales.map(&:to_s)).to eq(%w[en-US en])
     end
 
     it "sets default options" do

--- a/spec/support/locale_context.rb
+++ b/spec/support/locale_context.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require "locale"
+require "icu4x"
 
 # Shared context for locale helper method
 RSpec.shared_context "with locale" do
-  def locale(locale_string) = Locale::Tag.parse(locale_string)
+  def locale(locale_string) = ICU4X::Locale.parse(locale_string)
 end
 
 # Include locale helpers in all specs


### PR DESCRIPTION
## Summary
Migrate from the `locale` gem to using `ICU4X::Locale` directly for locale handling, eliminating an external dependency.

## Changes
- Replace `Locale::Tag::Simple` with `ICU4X::Locale` in Bundle initialization
- Simplify resolver and function modules by using `ICU4X::Locale` directly (no conversion needed)
- Remove `locale` gem dependency from gemspec
- Update RBS type signatures and documentation

Closes #93
