### PR TITLE
:fire: Remove unused Foxtail::ROOT constant

### DIFF
--- a/lib/foxtail.rb
+++ b/lib/foxtail.rb
@@ -1,15 +1,10 @@
 # frozen_string_literal: true
 
-require "pathname"
 require "zeitwerk"
 require_relative "foxtail/version"
 
 # Ruby implementation of Project Fluent localization system
 module Foxtail
-  # Root directory of the gem
-  ROOT = Pathname(__dir__).parent.expand_path.freeze
-  public_constant :ROOT
-
   # Configure Zeitwerk loader for this gem
   loader = Zeitwerk::Loader.for_gem
 


### PR DESCRIPTION
## Summary

Remove the unused `Foxtail::ROOT` constant from `lib/foxtail.rb`.

## Changes

- Remove `ROOT` constant definition
- Remove `public_constant :ROOT` declaration
- Remove unnecessary `require "pathname"`

Closes #100