### PR TITLE
:boom: Change Bundle to accept single locale instead of array

### DIFF
--- a/spec/foxtail/bundle_spec.rb
+++ b/spec/foxtail/bundle_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe Foxtail::Bundle do
   describe "#initialize" do
     it "accepts a single locale" do
       bundle = Foxtail::Bundle.new(locale("en-US"))
-      expect(bundle.locales.map(&:to_s)).to eq(["en-US"])
+      expect(bundle.locale.to_s).to eq("en-US")
     end
 
-    it "accepts multiple locales" do
-      bundle = Foxtail::Bundle.new([locale("en-US"), locale("en")])
-      expect(bundle.locales.map(&:to_s)).to eq(%w[en-US en])
+    it "rejects non-ICU4X::Locale arguments" do
+      expect { Foxtail::Bundle.new("en-US") }.to raise_error(ArgumentError, /must be an ICU4X::Locale/)
+      expect { Foxtail::Bundle.new(nil) }.to raise_error(ArgumentError, /must be an ICU4X::Locale/)
     end
 
     it "sets default options" do


### PR DESCRIPTION
## Summary

Change `Bundle` to accept a single `ICU4X::Locale` instead of an array, aligning with ICU4X's design philosophy.

## Background

- **fluent.js**: Passes locale array to JavaScript's `Intl` API for locale negotiation
- **ICU4X**: Handles fallback internally through locale's parent chain (e.g., `ja-JP → ja → und`)

Since ICU4X manages fallback automatically, accepting multiple locales is unnecessary and misleading.

## Changes

- `Bundle#initialize` now accepts single `ICU4X::Locale` (raises `ArgumentError` otherwise)
- `attr_reader :locales` → `attr_reader :locale`
- Simplified `Resolver` to use single locale directly

Closes #102
