### PR TITLE
:fire: Remove unused Function[] method

### DIFF
--- a/lib/foxtail/function.rb
+++ b/lib/foxtail/function.rb
@@ -15,11 +15,6 @@ module Foxtail
       }
     end
 
-    # Access individual function by name
-    # @param name [String] Function name ("NUMBER" or "DATETIME")
-    # @return [#call] Callable that accepts (value, locale:, **options)
-    def self.[](name) = defaults[name]
-
     # Format number using ICU4X
     # @param value [Numeric] Number to format
     # @param locale [ICU4X::Locale] Locale for formatting

--- a/spec/foxtail/function_spec.rb
+++ b/spec/foxtail/function_spec.rb
@@ -1,20 +1,6 @@
 # frozen_string_literal: true
 
-require "time"
-
 RSpec.describe Foxtail::Function do
-  describe "[]" do
-    it "provides access to NUMBER and DATETIME functions" do
-      expect(Foxtail::Function["NUMBER"]).not_to be_nil
-      expect(Foxtail::Function["DATETIME"]).not_to be_nil
-    end
-
-    it "returns callable functions" do
-      expect(Foxtail::Function["NUMBER"]).to respond_to(:call)
-      expect(Foxtail::Function["DATETIME"]).to respond_to(:call)
-    end
-  end
-
   describe ".defaults" do
     it "returns ICU4X-based function Methods" do
       result = Foxtail::Function.defaults


### PR DESCRIPTION
## Summary
Remove the unused `Function[]` method that was only used in tests.

## Changes
- Remove `Function.[]` method from `lib/foxtail/function.rb`
- Remove corresponding tests from `spec/foxtail/function_spec.rb`
