### PR TITLE
:recycle: Refactor to use keyword arguments and symbol keys

### DIFF
--- a/lib/foxtail/bundle/ast_converter.rb
+++ b/lib/foxtail/bundle/ast_converter.rb
@@ -9,10 +9,11 @@ module Foxtail
       AST = Foxtail::Bundle::AST
       private_constant :AST
 
-      def initialize(options={})
-        @skip_junk = options.fetch(:skip_junk, true)
-        @skip_comments = options.fetch(:skip_comments, true)
-        @strict = options.fetch(:strict, false)
+      # @param skip_junk [Boolean] Skip invalid entries (default: true)
+      # @param skip_comments [Boolean] Skip comment entries (default: true)
+      def initialize(skip_junk: true, skip_comments: true)
+        @skip_junk = skip_junk
+        @skip_comments = skip_comments
         @errors = []
       end
 

--- a/lib/foxtail/bundle/scope.rb
+++ b/lib/foxtail/bundle/scope.rb
@@ -11,7 +11,7 @@ module Foxtail
       attr_reader :errors
       attr_reader :dirty
 
-      def initialize(bundle, args={})
+      def initialize(bundle, **args)
         @bundle = bundle
         @args = args      # External variables passed to format()
         @locals = {}      # Local variables (set within functions)
@@ -21,12 +21,12 @@ module Foxtail
 
       # Get a variable value (checks locals first, then args)
       def variable(name)
-        @locals[name] || @args[name.to_sym] || @args[name.to_s]
+        @locals[name.to_sym] || @args[name.to_sym]
       end
 
       # Set a local variable (used within functions)
       def set_local(name, value)
-        @locals[name.to_s] = value
+        @locals[name.to_sym] = value
       end
 
       # Track a message/term ID to detect circular references
@@ -56,8 +56,8 @@ module Foxtail
       end
 
       # Create a child scope (for function calls)
-      def child_scope(new_args={})
-        child = self.class.new(@bundle, @args.merge(new_args))
+      def child_scope(**new_args)
+        child = self.class.new(@bundle, **@args, **new_args)
         child.instance_variable_set(:@locals, @locals.dup)
         child.instance_variable_set(:@dirty, @dirty.dup)
         child

--- a/lib/foxtail/resource.rb
+++ b/lib/foxtail/resource.rb
@@ -15,9 +15,8 @@ module Foxtail
     # Parse FTL source string into a Resource
     #
     # @param source [String] FTL source text to parse
-    # @param options [Hash] Parsing options
-    # @option options [Boolean] :skip_junk Skip invalid entries (default: true)
-    # @option options [Boolean] :skip_comments Skip comment entries (default: true)
+    # @param skip_junk [Boolean] Skip invalid entries (default: true)
+    # @param skip_comments [Boolean] Skip comment entries (default: true)
     # @return [Foxtail::Resource] New resource with parsed entries
     # @raise [ArgumentError] if source is not a string
     #
@@ -27,20 +26,25 @@ module Foxtail
     #     goodbye = Goodbye!
     #   FTL
     #   resource = Foxtail::Resource.from_string(source)
-    def self.from_string(source, **options)
+    def self.from_string(source, skip_junk: true, skip_comments: true)
       parser = Parser.new
       parser_resource = parser.parse(source)
 
-      converter = Bundle::ASTConverter.new(options)
+      converter = Bundle::ASTConverter.new(skip_junk:, skip_comments:)
       entries = converter.convert_resource(parser_resource)
 
       new(entries, errors: converter.errors)
     end
 
     # Parse FTL file into a Resource
-    def self.from_file(path, **)
+    #
+    # @param path [Pathname] Path to FTL file
+    # @param skip_junk [Boolean] Skip invalid entries (default: true)
+    # @param skip_comments [Boolean] Skip comment entries (default: true)
+    # @return [Foxtail::Resource] New resource with parsed entries
+    def self.from_file(path, skip_junk: true, skip_comments: true)
       source = path.read
-      from_string(source, **)
+      from_string(source, skip_junk:, skip_comments:)
     end
 
     def initialize(entries, errors: [])

--- a/spec/foxtail/bundle/ast_converter_spec.rb
+++ b/spec/foxtail/bundle/ast_converter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
     end
 
     it "accepts custom options" do
-      custom_converter = Foxtail::Bundle::ASTConverter.new(skip_junk: false, skip_comments: false, strict: true)
+      custom_converter = Foxtail::Bundle::ASTConverter.new(skip_junk: false, skip_comments: false)
       expect(custom_converter.errors).to eq([])
     end
   end

--- a/spec/foxtail/bundle/resolver_spec.rb
+++ b/spec/foxtail/bundle/resolver_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Foxtail::Bundle::Resolver do
   let(:bundle) { Foxtail::Bundle.new(locale("en")) }
   let(:resolver) { Foxtail::Bundle::Resolver.new(bundle) }
-  let(:scope) { Foxtail::Bundle::Scope.new(bundle, {name: "World", count: 5}) }
+  let(:scope) { Foxtail::Bundle::Scope.new(bundle, name: "World", count: 5) }
 
   describe "#initialize" do
     it "stores the bundle reference" do
@@ -209,7 +209,7 @@ RSpec.describe Foxtail::Bundle::Resolver do
       }
 
       test_date = Time.new(2023, 6, 15)
-      scope_with_date = Foxtail::Bundle::Scope.new(bundle, {date: test_date})
+      scope_with_date = Foxtail::Bundle::Scope.new(bundle, date: test_date)
 
       result = resolver.resolve_expression(expr, scope_with_date)
       expect(result).to eq("2023") # Should format only the year
@@ -313,12 +313,12 @@ RSpec.describe Foxtail::Bundle::Resolver do
       }
 
       # Test count = 1 (should match "one")
-      scope_with_one = Foxtail::Bundle::Scope.new(bundle, {count: 1})
+      scope_with_one = Foxtail::Bundle::Scope.new(bundle, count: 1)
       result = resolver.resolve_expression(expr, scope_with_one)
       expect(result).to eq("one item")
 
       # Test count = 2 (should match "other")
-      scope_with_two = Foxtail::Bundle::Scope.new(bundle, {count: 2})
+      scope_with_two = Foxtail::Bundle::Scope.new(bundle, count: 2)
       result = resolver.resolve_expression(expr, scope_with_two)
       expect(result).to eq("many items")
     end
@@ -336,12 +336,12 @@ RSpec.describe Foxtail::Bundle::Resolver do
       }
 
       # Exact numeric match should take precedence
-      scope_with_zero = Foxtail::Bundle::Scope.new(bundle, {count: 0})
+      scope_with_zero = Foxtail::Bundle::Scope.new(bundle, count: 0)
       result = resolver.resolve_expression(expr, scope_with_zero)
       expect(result).to eq("no items")
 
       # Plural rule matching for non-exact matches
-      scope_with_one = Foxtail::Bundle::Scope.new(bundle, {count: 1})
+      scope_with_one = Foxtail::Bundle::Scope.new(bundle, count: 1)
       result = resolver.resolve_expression(expr, scope_with_one)
       expect(result).to eq("one item")
     end
@@ -362,7 +362,7 @@ RSpec.describe Foxtail::Bundle::Resolver do
         "star" => 1
       }
 
-      scope_with_one = Foxtail::Bundle::Scope.new(bundle, {count: 1})
+      scope_with_one = Foxtail::Bundle::Scope.new(bundle, count: 1)
       result = resolver.resolve_expression(expr, scope_with_one)
       expect(result).to eq("many items") # Should fall back to default
     end

--- a/spec/foxtail/bundle/scope_spec.rb
+++ b/spec/foxtail/bundle/scope_spec.rb
@@ -2,8 +2,8 @@
 
 RSpec.describe Foxtail::Bundle::Scope do
   let(:bundle) { Foxtail::Bundle.new(locale("en")) }
-  let(:args) { {:name => "World", :count => 5, "email" => "test@example.com"} }
-  let(:scope) { Foxtail::Bundle::Scope.new(bundle, args) }
+  let(:args) { {name: "World", count: 5, email: "test@example.com"} }
+  let(:scope) { Foxtail::Bundle::Scope.new(bundle, **args) }
 
   describe "#initialize" do
     it "sets bundle and args" do
@@ -28,12 +28,9 @@ RSpec.describe Foxtail::Bundle::Scope do
   end
 
   describe "#variable" do
-    it "gets variables from args (symbol keys)" do
+    it "gets variables from args" do
       expect(scope.variable("name")).to eq("World")
       expect(scope.variable("count")).to eq(5)
-    end
-
-    it "gets variables from args (string keys)" do
       expect(scope.variable("email")).to eq("test@example.com")
     end
 
@@ -53,20 +50,20 @@ RSpec.describe Foxtail::Bundle::Scope do
   end
 
   describe "#set_local" do
-    it "sets local variables as strings" do
+    it "sets local variables as symbols" do
       scope.set_local("local_var", "value")
-      expect(scope.locals["local_var"]).to eq("value")
+      expect(scope.locals[:local_var]).to eq("value")
     end
 
-    it "converts keys to strings" do
+    it "converts keys to symbols" do
       scope.set_local(:symbol_key, "value")
-      expect(scope.locals["symbol_key"]).to eq("value")
+      expect(scope.locals[:symbol_key]).to eq("value")
     end
 
     it "overwrites existing locals" do
       scope.set_local("var", "first")
       scope.set_local("var", "second")
-      expect(scope.locals["var"]).to eq("second")
+      expect(scope.locals[:var]).to eq("second")
     end
   end
 
@@ -136,7 +133,7 @@ RSpec.describe Foxtail::Bundle::Scope do
 
     it "creates a child scope with merged args" do
       child_args = {child_key: "child_value"}
-      child = scope.child_scope(child_args)
+      child = scope.child_scope(**child_args)
 
       expect(child.bundle).to eq(bundle)
       expect(child.args).to include(args)
@@ -149,7 +146,7 @@ RSpec.describe Foxtail::Bundle::Scope do
 
       # Modifications don't affect parent
       child.set_local("child_local", "value")
-      expect(scope.locals).not_to have_key("child_local")
+      expect(scope.locals).not_to have_key(:child_local)
     end
 
     it "copies dirty set from parent" do
@@ -190,13 +187,14 @@ RSpec.describe Foxtail::Bundle::Scope do
 
     it "returns merged args and locals" do
       all_vars = scope.all_variables
-      expect(all_vars).to include(args)
-      expect(all_vars["local_var"]).to eq("local_value")
+      expect(all_vars[:count]).to eq(5)
+      expect(all_vars[:email]).to eq("test@example.com")
+      expect(all_vars[:local_var]).to eq("local_value")
     end
 
     it "prioritizes locals over args in merged result" do
       all_vars = scope.all_variables
-      expect(all_vars["name"]).to eq("overridden")
+      expect(all_vars[:name]).to eq("overridden")
     end
 
     it "doesn't modify original args or locals" do

--- a/spec/foxtail/bundle_spec.rb
+++ b/spec/foxtail/bundle_spec.rb
@@ -195,9 +195,9 @@ RSpec.describe Foxtail::Bundle do
         expect(result).to eq("Hello, {$name}!")
       end
 
-      it "handles string and symbol keys" do
+      it "handles multiple variables" do
         result1 = bundle.format("greeting", name: "Alice")
-        result2 = bundle.format("greeting", "name" => "Bob")
+        result2 = bundle.format("greeting", name: "Bob")
         expect(result1).to eq("Hello, Alice!")
         expect(result2).to eq("Hello, Bob!")
       end
@@ -254,14 +254,14 @@ RSpec.describe Foxtail::Bundle do
 
     it "formats array patterns" do
       pattern = ["Hello, ", {"type" => "var", "name" => "name"}, "!"]
-      result = bundle.format_pattern(pattern, {name: "World"})
+      result = bundle.format_pattern(pattern, name: "World")
       expect(result).to eq("Hello, World!")
     end
 
     it "collects errors when provided" do
       pattern = [{"type" => "var", "name" => "missing"}]
       errors = []
-      result = bundle.format_pattern(pattern, {}, errors)
+      result = bundle.format_pattern(pattern, errors:)
 
       expect(result).to eq("{$missing}")
       expect(errors).not_to be_empty

--- a/spec/foxtail/resource_spec.rb
+++ b/spec/foxtail/resource_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Foxtail::Resource do
     end
 
     it "accepts converter options" do
-      resource = Foxtail::Resource.from_string(ftl_source, skip_junk: false, strict: true)
+      resource = Foxtail::Resource.from_string(ftl_source, skip_junk: false)
       expect(resource.entries.size).to eq(3)
     end
   end


### PR DESCRIPTION
## Summary
Refactor methods using positional hash arguments to use proper Ruby keyword arguments and standardize on symbol keys throughout the codebase.

## Changes
- Replace `args={}` with `**args` in `Bundle#format`, `Bundle#format_pattern`, `Scope#initialize`, `Scope#child_scope`
- Replace `options={}` with explicit keyword arguments in `ASTConverter#initialize` and `Resource.from_string/from_file`
- Standardize on symbol keys for both `@args` and `@locals` in Scope
- Remove unused `@strict` option (dead code) from ASTConverter

## Test Plan
- Run `bundle exec rspec` - all 236 examples pass
- Run `bundle exec rubocop` - no offenses detected
