### PR TITLE
:recycle: Use anonymous keyword arguments where possible

### DIFF
--- a/lib/foxtail/bundle.rb
+++ b/lib/foxtail/bundle.rb
@@ -110,11 +110,11 @@ module Foxtail
     # @example Pluralization
     #   bundle.format("emails", count: 1)
     #   # => "You have one email." (assuming plural message)
-    def format(id, **args)
+    def format(id, **)
       message = message(id)
       return id.to_s unless message
 
-      scope = Scope.new(self, **args)
+      scope = Scope.new(self, **)
       resolver = Resolver.new(self)
       resolver.resolve_pattern(message["value"], scope)
       # For now, return just the result
@@ -122,8 +122,8 @@ module Foxtail
     end
 
     # Format a pattern with the given arguments (using Resolver)
-    def format_pattern(pattern, errors: nil, **args)
-      scope = Scope.new(self, **args)
+    def format_pattern(pattern, errors: nil, **)
+      scope = Scope.new(self, **)
       resolver = Resolver.new(self)
       result = resolver.resolve_pattern(pattern, scope)
 

--- a/lib/foxtail/bundle/scope.rb
+++ b/lib/foxtail/bundle/scope.rb
@@ -56,8 +56,8 @@ module Foxtail
       end
 
       # Create a child scope (for function calls)
-      def child_scope(**new_args)
-        child = self.class.new(@bundle, **@args, **new_args)
+      def child_scope(**)
+        child = self.class.new(@bundle, **@args, **)
         child.instance_variable_set(:@locals, @locals.dup)
         child.instance_variable_set(:@dirty, @dirty.dup)
         child


### PR DESCRIPTION
## Summary
Use Ruby 3.0+ anonymous keyword arguments (`**`) for methods that only forward kwargs.

## Changes
- Replace `**args` with `**` in `Bundle#format` and `Bundle#format_pattern`
- Replace `**new_args` with `**` in `Scope#child_scope`

## Test Plan
- Run `bundle exec rspec` - all 236 examples pass
