### PR TITLE
:recycle: Refactor Bundle AST to use symbol keys

### DIFF
--- a/lib/foxtail/bundle.rb
+++ b/lib/foxtail/bundle.rb
@@ -67,7 +67,7 @@ module Foxtail
     def add_resource(resource, allow_overrides: false)
       resource.entries.each do |entry|
         # In fluent-bundle format, terms have '-' prefix in id
-        if entry["id"]&.start_with?("-")
+        if entry[:id]&.start_with?("-")
           add_term_entry(entry, allow_overrides)
         else
           add_message_entry(entry, allow_overrides)
@@ -116,7 +116,7 @@ module Foxtail
 
       scope = Scope.new(self, **)
       resolver = Resolver.new(self)
-      resolver.resolve_pattern(message["value"], scope)
+      resolver.resolve_pattern(message[:value], scope)
       # For now, return just the result
       # In full implementation, would return [result, scope.errors]
     end
@@ -134,7 +134,7 @@ module Foxtail
     end
 
     private def add_message_entry(entry, allow_overrides)
-      id = entry["id"]
+      id = entry[:id]
       if @messages.key?(id) && !allow_overrides
         # In full implementation, would add to errors
         return
@@ -144,7 +144,7 @@ module Foxtail
     end
 
     private def add_term_entry(entry, allow_overrides)
-      id = entry["id"]
+      id = entry[:id]
       if @terms.key?(id) && !allow_overrides
         # In full implementation, would add to errors
         return

--- a/lib/foxtail/bundle/ast.rb
+++ b/lib/foxtail/bundle/ast.rb
@@ -9,69 +9,50 @@ module Foxtail
       # Following fluent-bundle/ast.ts type definitions exactly
 
       # Create a string literal: StringLiteral
-      def self.str(value)
-        {"type" => "str", "value" => value.to_s}
-      end
+      def self.str(value) = {type: "str", value: value.to_s}
 
       # Create a number literal: NumberLiteral
       # @param value [Numeric] The numeric value to convert
       # @param precision [Integer] Number of decimal places (default: 0)
       # @raise [TypeError] when precision is nil or cannot be converted to integer
-      def self.num(value, precision: 0)
-        {
-          "type" => "num",
-          "value" => Float(value),
-          "precision" => Integer(precision)
-        }
-      end
+      def self.num(value, precision: 0) = {type: "num", value: Float(value), precision: Integer(precision)}
 
       # Create a variable reference: VariableReference
-      def self.var(name)
-        {"type" => "var", "name" => name.to_s}
-      end
+      def self.var(name) = {type: "var", name: name.to_s}
 
       # Create a term reference: TermReference
       def self.term(name, attr: nil, args: [])
-        node = {"type" => "term", "name" => name.to_s}
-        node["attr"] = attr&.to_s
-        node["args"] = args # Always include args field
+        node = {type: "term", name: name.to_s}
+        node[:attr] = attr&.to_s
+        node[:args] = args # Always include args field
         node
       end
 
       # Create a message reference: MessageReference
       def self.mesg(name, attr: nil)
-        node = {"type" => "mesg", "name" => name.to_s}
-        node["attr"] = attr&.to_s
+        node = {type: "mesg", name: name.to_s}
+        node[:attr] = attr&.to_s
         node
       end
 
       # Create a function reference: FunctionReference
       def self.func(name, args: [])
-        node = {"type" => "func", "name" => name.to_s}
-        node["args"] = args # Always include args field
+        node = {type: "func", name: name.to_s}
+        node[:args] = args # Always include args field
         node
       end
 
       # Create a select expression: SelectExpression
-      def self.select(selector, variants, star: 0)
-        {
-          "type" => "select",
-          "selector" => selector,
-          "variants" => variants,
-          "star" => star
-        }
-      end
+      def self.select(selector, variants, star: 0) = {type: "select", selector:, variants:, star:}
 
       # Create a variant: Variant
-      def self.variant(key, value)
-        {"key" => key, "value" => value}
-      end
+      def self.variant(key, value) = {key:, value:}
 
       # Create a message: Message (fluent-bundle compatible format)
       def self.message(id, value: nil, attributes: {})
-        node = {"type" => "message", "id" => id.to_s}
-        node["value"] = value if value
-        node["attributes"] = attributes if attributes&.any?
+        node = {type: "message", id: id.to_s}
+        node[:value] = value if value
+        node[:attributes] = attributes if attributes&.any?
         node
       end
 
@@ -79,16 +60,16 @@ module Foxtail
       def self.term_def(id, value, attributes: {})
         # Ensure term ID has '-' prefix for bundle format
         term_id = id.to_s.start_with?("-") ? id.to_s : "-#{id}"
-        node = {"type" => "term", "id" => term_id}
-        node["value"] = value
-        node["attributes"] = attributes if attributes&.any?
+        node = {type: "term", id: term_id}
+        node[:value] = value
+        node[:attributes] = attributes if attributes&.any?
         node
       end
 
       # Type checking helpers (following TypeScript union types)
       # Check if node is a literal (string or number)
       def self.literal?(node)
-        node.is_a?(Hash) && %w[str num].include?(node["type"])
+        node.is_a?(Hash) && %w[str num].include?(node[:type])
       end
 
       # Check if node is an expression
@@ -96,7 +77,7 @@ module Foxtail
         return true if literal?(node)
         return false unless node.is_a?(Hash)
 
-        %w[var term mesg func select].include?(node["type"])
+        %w[var term mesg func select].include?(node[:type])
       end
 
       # Check if node can be a pattern element

--- a/lib/foxtail/bundle/ast_converter.rb
+++ b/lib/foxtail/bundle/ast_converter.rb
@@ -201,9 +201,9 @@ module Foxtail
             if expr.arguments.named
               expr.arguments.named.each do |named_arg|
                 args << {
-                  "type" => "narg",
-                  "name" => named_arg.name.name,
-                  "value" => convert_expression(named_arg.value)
+                  type: "narg",
+                  name: named_arg.name.name,
+                  value: convert_expression(named_arg.value)
                 }
               end
             end

--- a/lib/foxtail/resource.rb
+++ b/lib/foxtail/resource.rb
@@ -71,17 +71,17 @@ module Foxtail
 
     # Get entries by type
     def messages
-      @entries.select {|entry| entry["id"] && !entry["id"].start_with?("-") }
+      @entries.select {|entry| entry[:id] && !entry[:id].start_with?("-") }
     end
 
     # Get term entries (IDs starting with "-")
     def terms
-      @entries.select {|entry| entry["id"]&.start_with?("-") }
+      @entries.select {|entry| entry[:id]&.start_with?("-") }
     end
 
     # Find entry by ID
     def find(id)
-      @entries.find {|entry| entry["id"] == id }
+      @entries.find {|entry| entry[:id] == id }
     end
   end
 end

--- a/spec/foxtail/bundle/ast_converter_spec.rb
+++ b/spec/foxtail/bundle/ast_converter_spec.rb
@@ -33,21 +33,21 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
 
       # Check message
       hello_msg = entries[0]
-      expect(hello_msg["type"]).to eq("message")
-      expect(hello_msg["id"]).to eq("hello")
-      expect(hello_msg["value"]).to be_an(Array)
+      expect(hello_msg[:type]).to eq("message")
+      expect(hello_msg[:id]).to eq("hello")
+      expect(hello_msg[:value]).to be_an(Array)
 
       # Check term
       brand_term = entries[1]
-      expect(brand_term["type"]).to eq("term")
-      expect(brand_term["id"]).to eq("-brand")
-      expect(brand_term["value"]).to eq("Firefox")
+      expect(brand_term[:type]).to eq("term")
+      expect(brand_term[:id]).to eq("-brand")
+      expect(brand_term[:value]).to eq("Firefox")
 
       # Check simple message
       goodbye_msg = entries[2]
-      expect(goodbye_msg["type"]).to eq("message")
-      expect(goodbye_msg["id"]).to eq("goodbye")
-      expect(goodbye_msg["value"]).to eq("Goodbye!")
+      expect(goodbye_msg[:type]).to eq("message")
+      expect(goodbye_msg[:id]).to eq("goodbye")
+      expect(goodbye_msg[:value]).to eq("Goodbye!")
     end
   end
 
@@ -59,13 +59,13 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
     it "converts parser message to bundle AST message" do
       result = converter.convert_message(parser_message)
 
-      expect(result["type"]).to eq("message")
-      expect(result["id"]).to eq("hello")
-      expect(result["value"]).to be_an(Array)
-      expect(result["value"][0]).to eq("Hello, ")
-      expect(result["value"][1]["type"]).to eq("var")
-      expect(result["value"][1]["name"]).to eq("name")
-      expect(result["value"][2]).to eq("!")
+      expect(result[:type]).to eq("message")
+      expect(result[:id]).to eq("hello")
+      expect(result[:value]).to be_an(Array)
+      expect(result[:value][0]).to eq("Hello, ")
+      expect(result[:value][1][:type]).to eq("var")
+      expect(result[:value][1][:name]).to eq("name")
+      expect(result[:value][2]).to eq("!")
     end
 
     context "with attributes" do
@@ -79,8 +79,8 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
       it "converts message attributes" do
         result = converter.convert_message(parser_message)
 
-        expect(result["attributes"]).to be_a(Hash)
-        expect(result["attributes"]["title"]).to eq("Page title")
+        expect(result[:attributes]).to be_a(Hash)
+        expect(result[:attributes]["title"]).to eq("Page title")
       end
     end
   end
@@ -93,9 +93,9 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
     it "converts parser term to bundle AST term" do
       result = converter.convert_term(parser_term)
 
-      expect(result["type"]).to eq("term")
-      expect(result["id"]).to eq("-brand")
-      expect(result["value"]).to eq("Firefox")
+      expect(result[:type]).to eq("term")
+      expect(result[:id]).to eq("-brand")
+      expect(result[:value]).to eq("Firefox")
     end
   end
 
@@ -123,8 +123,8 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
 
         expect(result).to be_an(Array)
         expect(result[0]).to eq("Hello, ")
-        expect(result[1]["type"]).to eq("var")
-        expect(result[1]["name"]).to eq("name")
+        expect(result[1][:type]).to eq("var")
+        expect(result[1][:name]).to eq("name")
         expect(result[2]).to eq("!")
       end
     end
@@ -139,36 +139,36 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
       var_placeable = pattern_elements[0]
       result = converter.__send__(:convert_expression, var_placeable.expression)
 
-      expect(result["type"]).to eq("var")
-      expect(result["name"]).to eq("var")
+      expect(result[:type]).to eq("var")
+      expect(result[:name]).to eq("var")
     end
 
     it "converts message references" do
       msg_placeable = pattern_elements[2]
       result = converter.__send__(:convert_expression, msg_placeable.expression)
 
-      expect(result["type"]).to eq("mesg")
-      expect(result["name"]).to eq("hello")
+      expect(result[:type]).to eq("mesg")
+      expect(result[:name]).to eq("hello")
     end
 
     it "converts term references" do
       term_placeable = pattern_elements[4]
       result = converter.__send__(:convert_expression, term_placeable.expression)
 
-      expect(result["type"]).to eq("term")
-      expect(result["name"]).to eq("term")
+      expect(result[:type]).to eq("term")
+      expect(result[:name]).to eq("term")
     end
 
     it "converts function references with positional arguments" do
       func_placeable = pattern_elements[6]
       result = converter.__send__(:convert_expression, func_placeable.expression)
 
-      expect(result["type"]).to eq("func")
-      expect(result["name"]).to eq("NUMBER")
-      expect(result["args"]).to be_an(Array)
-      expect(result["args"].length).to eq(1)
-      expect(result["args"][0]["type"]).to eq("var")
-      expect(result["args"][0]["name"]).to eq("count")
+      expect(result[:type]).to eq("func")
+      expect(result[:name]).to eq("NUMBER")
+      expect(result[:args]).to be_an(Array)
+      expect(result[:args].length).to eq(1)
+      expect(result[:args][0][:type]).to eq("var")
+      expect(result[:args][0][:name]).to eq("count")
     end
 
     it "converts function references with named arguments" do
@@ -177,22 +177,22 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
       func_placeable = parser_resource.body.first.value.elements[0]
       result = converter.__send__(:convert_expression, func_placeable.expression)
 
-      expect(result["type"]).to eq("func")
-      expect(result["name"]).to eq("FUNC")
-      expect(result["args"]).to be_an(Array)
-      expect(result["args"].length).to eq(2)
+      expect(result[:type]).to eq("func")
+      expect(result[:name]).to eq("FUNC")
+      expect(result[:args]).to be_an(Array)
+      expect(result[:args].length).to eq(2)
 
       # First named argument
-      expect(result["args"][0]["type"]).to eq("narg")
-      expect(result["args"][0]["name"]).to eq("arg1")
-      expect(result["args"][0]["value"]["type"]).to eq("num")
-      expect(result["args"][0]["value"]["value"]).to eq(1.0)
+      expect(result[:args][0][:type]).to eq("narg")
+      expect(result[:args][0][:name]).to eq("arg1")
+      expect(result[:args][0][:value][:type]).to eq("num")
+      expect(result[:args][0][:value][:value]).to eq(1.0)
 
       # Second named argument
-      expect(result["args"][1]["type"]).to eq("narg")
-      expect(result["args"][1]["name"]).to eq("arg2")
-      expect(result["args"][1]["value"]["type"]).to eq("str")
-      expect(result["args"][1]["value"]["value"]).to eq("hello")
+      expect(result[:args][1][:type]).to eq("narg")
+      expect(result[:args][1][:name]).to eq("arg2")
+      expect(result[:args][1][:value][:type]).to eq("str")
+      expect(result[:args][1][:value][:value]).to eq("hello")
     end
 
     it "processes escape sequences in text elements" do
@@ -200,7 +200,7 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
       parser_resource = Foxtail::Parser.new.parse(ftl_source)
       result = converter.convert_resource(parser_resource)
 
-      expect(result.first["value"]).to eq("Text with \"quotes\" and \\backslash and A")
+      expect(result.first[:value]).to eq("Text with \"quotes\" and \\backslash and A")
     end
   end
 
@@ -221,29 +221,29 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
     it "converts select expressions" do
       result = converter.__send__(:convert_expression, select_expr)
 
-      expect(result["type"]).to eq("select")
-      expect(result["selector"]["type"]).to eq("var")
-      expect(result["selector"]["name"]).to eq("count")
-      expect(result["variants"]).to be_an(Array)
-      expect(result["variants"].length).to eq(3)
-      expect(result["star"]).to eq(2) # Index of default variant
+      expect(result[:type]).to eq("select")
+      expect(result[:selector][:type]).to eq("var")
+      expect(result[:selector][:name]).to eq("count")
+      expect(result[:variants]).to be_an(Array)
+      expect(result[:variants].length).to eq(3)
+      expect(result[:star]).to eq(2) # Index of default variant
     end
 
     it "converts variant keys correctly" do
       result = converter.__send__(:convert_expression, select_expr)
-      variants = result["variants"]
+      variants = result[:variants]
 
       # Number literal key
-      expect(variants[0]["key"]["type"]).to eq("num")
-      expect(variants[0]["key"]["value"]).to eq(0.0)
+      expect(variants[0][:key][:type]).to eq("num")
+      expect(variants[0][:key][:value]).to eq(0.0)
 
       # String literal key
-      expect(variants[1]["key"]["type"]).to eq("str")
-      expect(variants[1]["key"]["value"]).to eq("one")
+      expect(variants[1][:key][:type]).to eq("str")
+      expect(variants[1][:key][:value]).to eq("one")
 
       # Default variant key
-      expect(variants[2]["key"]["type"]).to eq("str")
-      expect(variants[2]["key"]["value"]).to eq("other")
+      expect(variants[2][:key][:type]).to eq("str")
+      expect(variants[2][:key][:value]).to eq("other")
     end
   end
 
@@ -265,22 +265,22 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
       it "converts number literals from select expression" do
         zero_variant = select_expr.variants[0]
         result = converter.__send__(:convert_literal, zero_variant.key)
-        expect(result["type"]).to eq("num")
-        expect(result["value"]).to eq(0.0)
+        expect(result[:type]).to eq("num")
+        expect(result[:value]).to eq(0.0)
       end
 
       it "converts identifier literals from select expression" do
         one_variant = select_expr.variants[1]
         result = converter.__send__(:convert_literal, one_variant.key)
-        expect(result["type"]).to eq("str")
-        expect(result["value"]).to eq("one")
+        expect(result[:type]).to eq("str")
+        expect(result[:value]).to eq("one")
       end
 
       it "converts default identifier literals from select expression" do
         other_variant = select_expr.variants[2]
         result = converter.__send__(:convert_literal, other_variant.key)
-        expect(result["type"]).to eq("str")
-        expect(result["value"]).to eq("other")
+        expect(result[:type]).to eq("str")
+        expect(result[:value]).to eq("other")
       end
     end
   end

--- a/spec/foxtail/bundle/ast_spec.rb
+++ b/spec/foxtail/bundle/ast_spec.rb
@@ -4,29 +4,29 @@ RSpec.describe Foxtail::Bundle::AST do
   describe ".str" do
     it "creates a string literal node" do
       result = Foxtail::Bundle::AST.str("hello")
-      expect(result).to eq({"type" => "str", "value" => "hello"})
+      expect(result).to eq({type: "str", value: "hello"})
     end
 
     it "converts non-string values to string" do
       result = Foxtail::Bundle::AST.str(42)
-      expect(result).to eq({"type" => "str", "value" => "42"})
+      expect(result).to eq({type: "str", value: "42"})
     end
   end
 
   describe ".num" do
     it "creates a number literal node with default precision" do
       result = Foxtail::Bundle::AST.num(42.5)
-      expect(result).to eq({"type" => "num", "value" => 42.5, "precision" => 0})
+      expect(result).to eq({type: "num", value: 42.5, precision: 0})
     end
 
     it "converts string numbers to float" do
       result = Foxtail::Bundle::AST.num("42.5")
-      expect(result).to eq({"type" => "num", "value" => 42.5, "precision" => 0})
+      expect(result).to eq({type: "num", value: 42.5, precision: 0})
     end
 
     it "includes precision when provided" do
       result = Foxtail::Bundle::AST.num(42.5, precision: 2)
-      expect(result).to eq({"type" => "num", "value" => 42.5, "precision" => 2})
+      expect(result).to eq({type: "num", value: 42.5, precision: 2})
     end
 
     it "raises error when precision is nil" do
@@ -39,65 +39,65 @@ RSpec.describe Foxtail::Bundle::AST do
   describe ".var" do
     it "creates a variable reference node" do
       result = Foxtail::Bundle::AST.var("username")
-      expect(result).to eq({"type" => "var", "name" => "username"})
+      expect(result).to eq({type: "var", name: "username"})
     end
 
     it "converts non-string names to string" do
       result = Foxtail::Bundle::AST.var(:username)
-      expect(result).to eq({"type" => "var", "name" => "username"})
+      expect(result).to eq({type: "var", name: "username"})
     end
   end
 
   describe ".term" do
     it "creates a term reference node" do
       result = Foxtail::Bundle::AST.term("brand")
-      expect(result).to eq({"type" => "term", "name" => "brand", "attr" => nil, "args" => []})
+      expect(result).to eq({type: "term", name: "brand", attr: nil, args: []})
     end
 
     it "includes attribute when provided" do
       result = Foxtail::Bundle::AST.term("brand", attr: "title")
-      expect(result).to eq({"type" => "term", "name" => "brand", "attr" => "title", "args" => []})
+      expect(result).to eq({type: "term", name: "brand", attr: "title", args: []})
     end
 
     it "includes args when provided" do
       args = [Foxtail::Bundle::AST.str("value")]
       result = Foxtail::Bundle::AST.term("brand", args:)
-      expect(result).to eq({"type" => "term", "name" => "brand", "attr" => nil, "args" => args})
+      expect(result).to eq({type: "term", name: "brand", attr: nil, args:})
     end
 
     it "includes empty args array" do
       result = Foxtail::Bundle::AST.term("brand", args: [])
-      expect(result).to eq({"type" => "term", "name" => "brand", "attr" => nil, "args" => []})
+      expect(result).to eq({type: "term", name: "brand", attr: nil, args: []})
     end
   end
 
   describe ".mesg" do
     it "creates a message reference node" do
       result = Foxtail::Bundle::AST.mesg("hello")
-      expect(result).to eq({"type" => "mesg", "name" => "hello", "attr" => nil})
+      expect(result).to eq({type: "mesg", name: "hello", attr: nil})
     end
 
     it "includes attribute when provided" do
       result = Foxtail::Bundle::AST.mesg("hello", attr: "title")
-      expect(result).to eq({"type" => "mesg", "name" => "hello", "attr" => "title"})
+      expect(result).to eq({type: "mesg", name: "hello", attr: "title"})
     end
   end
 
   describe ".func" do
     it "creates a function reference node" do
       result = Foxtail::Bundle::AST.func("NUMBER")
-      expect(result).to eq({"type" => "func", "name" => "NUMBER", "args" => []})
+      expect(result).to eq({type: "func", name: "NUMBER", args: []})
     end
 
     it "includes args when provided" do
       args = [Foxtail::Bundle::AST.str("value")]
       result = Foxtail::Bundle::AST.func("NUMBER", args:)
-      expect(result).to eq({"type" => "func", "name" => "NUMBER", "args" => args})
+      expect(result).to eq({type: "func", name: "NUMBER", args:})
     end
 
     it "includes empty args array" do
       result = Foxtail::Bundle::AST.func("NUMBER", args: [])
-      expect(result).to eq({"type" => "func", "name" => "NUMBER", "args" => []})
+      expect(result).to eq({type: "func", name: "NUMBER", args: []})
     end
   end
 
@@ -111,10 +111,10 @@ RSpec.describe Foxtail::Bundle::AST do
 
       result = Foxtail::Bundle::AST.select(selector, variants)
       expect(result).to eq({
-        "type" => "select",
-        "selector" => selector,
-        "variants" => variants,
-        "star" => 0
+        type: "select",
+        selector:,
+        variants:,
+        star: 0
       })
     end
 
@@ -124,10 +124,10 @@ RSpec.describe Foxtail::Bundle::AST do
 
       result = Foxtail::Bundle::AST.select(selector, variants, star: 1)
       expect(result).to eq({
-        "type" => "select",
-        "selector" => selector,
-        "variants" => variants,
-        "star" => 1
+        type: "select",
+        selector:,
+        variants:,
+        star: 1
       })
     end
   end
@@ -138,31 +138,31 @@ RSpec.describe Foxtail::Bundle::AST do
       value = "single item"
 
       result = Foxtail::Bundle::AST.variant(key, value)
-      expect(result).to eq({"key" => key, "value" => value})
+      expect(result).to eq({key:, value:})
     end
   end
 
   describe ".message" do
     it "creates a message node" do
       result = Foxtail::Bundle::AST.message("hello")
-      expect(result).to eq({"type" => "message", "id" => "hello"})
+      expect(result).to eq({type: "message", id: "hello"})
     end
 
     it "includes value when provided" do
       value = "Hello world"
       result = Foxtail::Bundle::AST.message("hello", value:)
-      expect(result).to eq({"type" => "message", "id" => "hello", "value" => value})
+      expect(result).to eq({type: "message", id: "hello", value:})
     end
 
     it "includes attributes when provided" do
       attributes = {"title" => "Greeting"}
       result = Foxtail::Bundle::AST.message("hello", attributes:)
-      expect(result).to eq({"type" => "message", "id" => "hello", "attributes" => attributes})
+      expect(result).to eq({type: "message", id: "hello", attributes:})
     end
 
     it "omits empty attributes hash" do
       result = Foxtail::Bundle::AST.message("hello", attributes: {})
-      expect(result).to eq({"type" => "message", "id" => "hello"})
+      expect(result).to eq({type: "message", id: "hello"})
     end
   end
 
@@ -170,20 +170,20 @@ RSpec.describe Foxtail::Bundle::AST do
     it "creates a term definition node" do
       value = "Firefox"
       result = Foxtail::Bundle::AST.term_def("brand", value)
-      expect(result).to eq({"type" => "term", "id" => "-brand", "value" => value})
+      expect(result).to eq({type: "term", id: "-brand", value:})
     end
 
     it "includes attributes when provided" do
       value = "Firefox"
       attributes = {"case" => "nominative"}
       result = Foxtail::Bundle::AST.term_def("brand", value, attributes:)
-      expect(result).to eq({"type" => "term", "id" => "-brand", "value" => value, "attributes" => attributes})
+      expect(result).to eq({type: "term", id: "-brand", value:, attributes:})
     end
 
     it "omits empty attributes hash" do
       value = "Firefox"
       result = Foxtail::Bundle::AST.term_def("brand", value, attributes: {})
-      expect(result).to eq({"type" => "term", "id" => "-brand", "value" => value})
+      expect(result).to eq({type: "term", id: "-brand", value:})
     end
   end
 
@@ -248,7 +248,7 @@ RSpec.describe Foxtail::Bundle::AST do
       it "returns false for non-expressions" do
         expect(Foxtail::Bundle::AST.expression?("string")).to be false
         expect(Foxtail::Bundle::AST.expression?(42)).to be false
-        expect(Foxtail::Bundle::AST.expression?({"type" => "unknown"})).to be false
+        expect(Foxtail::Bundle::AST.expression?({type: "unknown"})).to be false
       end
     end
 
@@ -264,7 +264,7 @@ RSpec.describe Foxtail::Bundle::AST do
 
       it "returns false for non-pattern elements" do
         expect(Foxtail::Bundle::AST.pattern_element?(42)).to be false
-        expect(Foxtail::Bundle::AST.pattern_element?({"type" => "unknown"})).to be false
+        expect(Foxtail::Bundle::AST.pattern_element?({type: "unknown"})).to be false
       end
     end
 
@@ -301,7 +301,7 @@ RSpec.describe Foxtail::Bundle::AST do
 
       it "returns false for non-patterns" do
         expect(Foxtail::Bundle::AST.pattern?(42)).to be false
-        expect(Foxtail::Bundle::AST.pattern?({"type" => "unknown"})).to be false
+        expect(Foxtail::Bundle::AST.pattern?({type: "unknown"})).to be false
       end
     end
   end

--- a/spec/foxtail/bundle/resolver_spec.rb
+++ b/spec/foxtail/bundle/resolver_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe Foxtail::Bundle::Resolver do
     end
 
     it "resolves array patterns" do
-      pattern = ["Hello, ", {"type" => "var", "name" => "name"}, "!"]
+      pattern = ["Hello, ", {type: "var", name: "name"}, "!"]
       result = resolver.resolve_pattern(pattern, scope)
       expect(result).to eq("Hello, World!")
     end
 
     it "resolves single expression patterns" do
-      pattern = {"type" => "var", "name" => "name"}
+      pattern = {type: "var", name: "name"}
       result = resolver.resolve_pattern(pattern, scope)
       expect(result).to eq("World")
     end
@@ -37,38 +37,38 @@ RSpec.describe Foxtail::Bundle::Resolver do
 
   describe "#resolve_expression" do
     it "resolves string literals" do
-      expr = {"type" => "str", "value" => "hello"}
+      expr = {type: "str", value: "hello"}
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("hello")
     end
 
     it "resolves number literals" do
-      expr = {"type" => "num", "value" => 42.5}
+      expr = {type: "num", value: 42.5}
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq(42.5)
     end
 
     it "resolves number literals with precision" do
-      expr = {"type" => "num", "value" => 42.567, "precision" => 2}
+      expr = {type: "num", value: 42.567, precision: 2}
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq(42.567)
     end
 
     it "resolves variable references" do
-      expr = {"type" => "var", "name" => "name"}
+      expr = {type: "var", name: "name"}
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("World")
     end
 
     it "handles missing variables" do
-      expr = {"type" => "var", "name" => "missing"}
+      expr = {type: "var", name: "missing"}
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("{$missing}")
       expect(scope.errors).to include("Unknown variable: $missing")
     end
 
     it "handles unknown expression types" do
-      expr = {"type" => "unknown", "value" => "test"}
+      expr = {type: "unknown", value: "test"}
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("{unknown}")
       expect(scope.errors).to include("Unknown expression type: unknown")
@@ -82,13 +82,13 @@ RSpec.describe Foxtail::Bundle::Resolver do
     before { bundle.add_resource(resource) }
 
     it "resolves term references" do
-      expr = {"type" => "term", "name" => "brand"}
+      expr = {type: "term", name: "brand"}
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("Firefox")
     end
 
     it "handles missing terms" do
-      expr = {"type" => "term", "name" => "missing"}
+      expr = {type: "term", name: "missing"}
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("{-missing}")
       expect(scope.errors).to include("Unknown term: -missing")
@@ -101,7 +101,7 @@ RSpec.describe Foxtail::Bundle::Resolver do
       bundle.add_resource(resource_a, allow_overrides: true)
       bundle.add_resource(resource_b, allow_overrides: true)
 
-      expr = {"type" => "term", "name" => "a"}
+      expr = {type: "term", name: "a"}
       result = resolver.resolve_expression(expr, scope)
       # Should return the circular reference fallback
       expect(result).to match(/\{-[ab]\}/)
@@ -116,13 +116,13 @@ RSpec.describe Foxtail::Bundle::Resolver do
     before { bundle.add_resource(resource) }
 
     it "resolves message references" do
-      expr = {"type" => "mesg", "name" => "hello"}
+      expr = {type: "mesg", name: "hello"}
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("Hello world")
     end
 
     it "handles missing messages" do
-      expr = {"type" => "mesg", "name" => "missing"}
+      expr = {type: "mesg", name: "missing"}
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("{missing}")
       expect(scope.errors).to include("Unknown message: missing")
@@ -135,13 +135,13 @@ RSpec.describe Foxtail::Bundle::Resolver do
     let(:resolver_with_func) { Foxtail::Bundle::Resolver.new(bundle_with_func) }
 
     it "resolves function calls" do
-      expr = {"type" => "func", "name" => "TEST", "args" => [{"type" => "str", "value" => "input"}]}
+      expr = {type: "func", name: "TEST", args: [{type: "str", value: "input"}]}
       result = resolver_with_func.resolve_expression(expr, scope)
       expect(result).to eq("Function result: input")
     end
 
     it "handles missing functions" do
-      expr = {"type" => "func", "name" => "MISSING", "args" => []}
+      expr = {type: "func", name: "MISSING", args: []}
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("{MISSING()}")
       expect(scope.errors).to include("Unknown function: MISSING")
@@ -152,7 +152,7 @@ RSpec.describe Foxtail::Bundle::Resolver do
       bundle_with_error = Foxtail::Bundle.new(locale("en"), functions: {"ERROR" => error_function})
       resolver_with_error = Foxtail::Bundle::Resolver.new(bundle_with_error)
 
-      expr = {"type" => "func", "name" => "ERROR", "args" => []}
+      expr = {type: "func", name: "ERROR", args: []}
       result = resolver_with_error.resolve_expression(expr, scope)
       expect(result).to eq("{ERROR()}")
       expect(scope.errors).to include("Function error in ERROR: Test error")
@@ -164,12 +164,12 @@ RSpec.describe Foxtail::Bundle::Resolver do
       resolver_with_options = Foxtail::Bundle::Resolver.new(bundle_with_options)
 
       expr = {
-        "type" => "func",
-        "name" => "FORMAT",
-        "args" => [
-          {"type" => "num", "value" => 42.5},
-          {"type" => "narg", "name" => "style", "value" => {"type" => "str", "value" => "currency"}},
-          {"type" => "narg", "name" => "minimumFractionDigits", "value" => {"type" => "num", "value" => 2.0}}
+        type: "func",
+        name: "FORMAT",
+        args: [
+          {type: "num", value: 42.5},
+          {type: "narg", name: "style", value: {type: "str", value: "currency"}},
+          {type: "narg", name: "minimumFractionDigits", value: {type: "num", value: 2.0}}
         ]
       }
 
@@ -184,11 +184,11 @@ RSpec.describe Foxtail::Bundle::Resolver do
     it "resolves NUMBER function calls with named arguments" do
       # Test with actual NUMBER function
       expr = {
-        "type" => "func",
-        "name" => "NUMBER",
-        "args" => [
-          {"type" => "num", "value" => 1234.56},
-          {"type" => "narg", "name" => "minimumFractionDigits", "value" => {"type" => "num", "value" => 2.0}}
+        type: "func",
+        name: "NUMBER",
+        args: [
+          {type: "num", value: 1234.56},
+          {type: "narg", name: "minimumFractionDigits", value: {type: "num", value: 2.0}}
         ]
       }
 
@@ -200,11 +200,11 @@ RSpec.describe Foxtail::Bundle::Resolver do
       skip "ICU4X requires date_style or time_style; component-only formatting (year: numeric) is not supported"
       # Test with actual DATETIME function
       expr = {
-        "type" => "func",
-        "name" => "DATETIME",
-        "args" => [
-          {"type" => "var", "name" => "date"},
-          {"type" => "narg", "name" => "year", "value" => {"type" => "str", "value" => "numeric"}}
+        type: "func",
+        name: "DATETIME",
+        args: [
+          {type: "var", name: "date"},
+          {type: "narg", name: "year", value: {type: "str", value: "numeric"}}
         ]
       }
 
@@ -219,14 +219,14 @@ RSpec.describe Foxtail::Bundle::Resolver do
   describe "#resolve_select_expression" do
     it "resolves select expressions with number matching" do
       expr = {
-        "type" => "select",
-        "selector" => {"type" => "var", "name" => "count"},
-        "variants" => [
-          {"key" => {"type" => "num", "value" => 0}, "value" => "none"},
-          {"key" => {"type" => "num", "value" => 5}, "value" => "five"},
-          {"key" => {"type" => "str", "value" => "other"}, "value" => "many"}
+        type: "select",
+        selector: {type: "var", name: "count"},
+        variants: [
+          {key: {type: "num", value: 0}, value: "none"},
+          {key: {type: "num", value: 5}, value: "five"},
+          {key: {type: "str", value: "other"}, value: "many"}
         ],
-        "star" => 2
+        star: 2
       }
 
       result = resolver.resolve_expression(expr, scope)
@@ -235,13 +235,13 @@ RSpec.describe Foxtail::Bundle::Resolver do
 
     it "uses default variant when no match" do
       expr = {
-        "type" => "select",
-        "selector" => {"type" => "var", "name" => "count"},
-        "variants" => [
-          {"key" => {"type" => "num", "value" => 0}, "value" => "none"},
-          {"key" => {"type" => "str", "value" => "other"}, "value" => "many"}
+        type: "select",
+        selector: {type: "var", name: "count"},
+        variants: [
+          {key: {type: "num", value: 0}, value: "none"},
+          {key: {type: "str", value: "other"}, value: "many"}
         ],
-        "star" => 1
+        star: 1
       }
 
       result = resolver.resolve_expression(expr, scope)
@@ -250,15 +250,15 @@ RSpec.describe Foxtail::Bundle::Resolver do
 
     it "resolves complex variant values" do
       expr = {
-        "type" => "select",
-        "selector" => {"type" => "var", "name" => "count"},
-        "variants" => [
+        type: "select",
+        selector: {type: "var", name: "count"},
+        variants: [
           {
-            "key" => {"type" => "num", "value" => 5},
-            "value" => ["You have ", {"type" => "var", "name" => "count"}, " items"]
+            key: {type: "num", value: 5},
+            value: ["You have ", {type: "var", name: "count"}, " items"]
           }
         ],
-        "star" => 0
+        star: 0
       }
 
       result = resolver.resolve_expression(expr, scope)
@@ -280,19 +280,19 @@ RSpec.describe Foxtail::Bundle::Resolver do
     before { bundle.add_resource(resource) }
 
     it "resolves message attributes" do
-      expr = {"type" => "mesg", "name" => "hello", "attr" => "title"}
+      expr = {type: "mesg", name: "hello", attr: "title"}
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("Greeting")
     end
 
     it "resolves term attributes" do
-      expr = {"type" => "term", "name" => "brand", "attr" => "version"}
+      expr = {type: "term", name: "brand", attr: "version"}
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("89.0")
     end
 
     it "handles missing attributes" do
-      expr = {"type" => "mesg", "name" => "hello", "attr" => "missing"}
+      expr = {type: "mesg", name: "hello", attr: "missing"}
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("{hello.missing}")
       expect(scope.errors).to include("Unknown message attribute: hello.missing")
@@ -303,13 +303,13 @@ RSpec.describe Foxtail::Bundle::Resolver do
     it "matches plural categories using ICU4X plural rules" do
       # Test English plural rules (1 is "one", others are "other")
       expr = {
-        "type" => "select",
-        "selector" => {"type" => "var", "name" => "count"},
-        "variants" => [
-          {"key" => {"type" => "str", "value" => "one"}, "value" => "one item"},
-          {"key" => {"type" => "str", "value" => "other"}, "value" => "many items"}
+        type: "select",
+        selector: {type: "var", name: "count"},
+        variants: [
+          {key: {type: "str", value: "one"}, value: "one item"},
+          {key: {type: "str", value: "other"}, value: "many items"}
         ],
-        "star" => 1
+        star: 1
       }
 
       # Test count = 1 (should match "one")
@@ -325,14 +325,14 @@ RSpec.describe Foxtail::Bundle::Resolver do
 
     it "handles numeric selectors with string variants" do
       expr = {
-        "type" => "select",
-        "selector" => {"type" => "var", "name" => "count"},
-        "variants" => [
-          {"key" => {"type" => "num", "value" => 0}, "value" => "no items"},
-          {"key" => {"type" => "str", "value" => "one"}, "value" => "one item"},
-          {"key" => {"type" => "str", "value" => "other"}, "value" => "many items"}
+        type: "select",
+        selector: {type: "var", name: "count"},
+        variants: [
+          {key: {type: "num", value: 0}, value: "no items"},
+          {key: {type: "str", value: "one"}, value: "one item"},
+          {key: {type: "str", value: "other"}, value: "many items"}
         ],
-        "star" => 2
+        star: 2
       }
 
       # Exact numeric match should take precedence
@@ -353,13 +353,13 @@ RSpec.describe Foxtail::Bundle::Resolver do
       allow(plural_rules_double).to receive(:select).and_raise("Error")
 
       expr = {
-        "type" => "select",
-        "selector" => {"type" => "var", "name" => "count"},
-        "variants" => [
-          {"key" => {"type" => "str", "value" => "one"}, "value" => "one item"},
-          {"key" => {"type" => "str", "value" => "other"}, "value" => "many items"}
+        type: "select",
+        selector: {type: "var", name: "count"},
+        variants: [
+          {key: {type: "str", value: "one"}, value: "one item"},
+          {key: {type: "str", value: "other"}, value: "many items"}
         ],
-        "star" => 1
+        star: 1
       }
 
       scope_with_one = Foxtail::Bundle::Scope.new(bundle, count: 1)

--- a/spec/foxtail/bundle_spec.rb
+++ b/spec/foxtail/bundle_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Foxtail::Bundle do
 
       # Should still have original message
       message = bundle.message("hello")
-      expect(message["value"]).to be_an(Array) # Original complex pattern
+      expect(message[:value]).to be_an(Array) # Original complex pattern
     end
 
     it "allows overrides when specified" do
@@ -104,7 +104,7 @@ RSpec.describe Foxtail::Bundle do
 
       # Should have new message
       message = bundle.message("hello")
-      expect(message["value"]).to eq("Different message")
+      expect(message[:value]).to eq("Different message")
     end
   end
 
@@ -122,8 +122,8 @@ RSpec.describe Foxtail::Bundle do
     it "retrieves messages" do
       message = bundle.message("hello")
       expect(message).to be_a(Hash)
-      expect(message["id"]).to eq("hello")
-      expect(message["attributes"]).to be_nil
+      expect(message[:id]).to eq("hello")
+      expect(message[:attributes]).to be_nil
     end
 
     it "returns nil for nonexistent messages" do
@@ -150,8 +150,8 @@ RSpec.describe Foxtail::Bundle do
     it "retrieves terms" do
       term = bundle.term("-brand")
       expect(term).to be_a(Hash)
-      expect(term["id"]).to eq("-brand")
-      expect(term["attributes"]).to be_nil
+      expect(term[:id]).to eq("-brand")
+      expect(term[:attributes]).to be_nil
     end
 
     it "returns nil for nonexistent terms" do
@@ -253,13 +253,13 @@ RSpec.describe Foxtail::Bundle do
     end
 
     it "formats array patterns" do
-      pattern = ["Hello, ", {"type" => "var", "name" => "name"}, "!"]
+      pattern = ["Hello, ", {type: "var", name: "name"}, "!"]
       result = bundle.format_pattern(pattern, name: "World")
       expect(result).to eq("Hello, World!")
     end
 
     it "collects errors when provided" do
-      pattern = [{"type" => "var", "name" => "missing"}]
+      pattern = [{type: "var", name: "missing"}]
       errors = []
       result = bundle.format_pattern(pattern, errors:)
 

--- a/spec/foxtail/resource_spec.rb
+++ b/spec/foxtail/resource_spec.rb
@@ -25,23 +25,23 @@ RSpec.describe Foxtail::Resource do
       resource = Foxtail::Resource.from_string(ftl_source)
 
       hello_msg = resource.entries[0]
-      expect(hello_msg["type"]).to eq("message")
-      expect(hello_msg["id"]).to eq("hello")
-      expect(hello_msg["value"]).to be_an(Array)
+      expect(hello_msg[:type]).to eq("message")
+      expect(hello_msg[:id]).to eq("hello")
+      expect(hello_msg[:value]).to be_an(Array)
 
       goodbye_msg = resource.entries[2]
-      expect(goodbye_msg["type"]).to eq("message")
-      expect(goodbye_msg["id"]).to eq("goodbye")
-      expect(goodbye_msg["value"]).to eq("Goodbye world")
+      expect(goodbye_msg[:type]).to eq("message")
+      expect(goodbye_msg[:id]).to eq("goodbye")
+      expect(goodbye_msg[:value]).to eq("Goodbye world")
     end
 
     it "creates proper term entries" do
       resource = Foxtail::Resource.from_string(ftl_source)
 
       brand_term = resource.entries[1]
-      expect(brand_term["type"]).to eq("term")
-      expect(brand_term["id"]).to eq("-brand")
-      expect(brand_term["value"]).to eq("Firefox")
+      expect(brand_term[:type]).to eq("term")
+      expect(brand_term[:id]).to eq("-brand")
+      expect(brand_term[:value]).to eq("Firefox")
     end
 
     it "accepts converter options" do
@@ -68,8 +68,8 @@ RSpec.describe Foxtail::Resource do
       resource = Foxtail::Resource.from_file(Pathname(temp_file.path))
 
       expect(resource.entries.size).to eq(1)
-      expect(resource.entries.first["id"]).to eq("test")
-      expect(resource.entries.first["value"]).to eq("Test message")
+      expect(resource.entries.first[:id]).to eq("test")
+      expect(resource.entries.first[:value]).to eq("Test message")
     end
 
     it "handles file encoding properly" do
@@ -118,7 +118,7 @@ RSpec.describe Foxtail::Resource do
 
     describe "Enumerable" do
       it "includes Enumerable and provides map functionality" do
-        yielded_ids = resource.map {|entry| entry["id"] }
+        yielded_ids = resource.map {|entry| entry[:id] }
         expect(yielded_ids).to eq(["hello", "-brand", "goodbye", "-company"])
       end
     end
@@ -127,8 +127,8 @@ RSpec.describe Foxtail::Resource do
       it "returns only message entries" do
         messages = resource.messages
         expect(messages.size).to eq(2)
-        expect(messages.map {|m| m["id"] }).to eq(%w[hello goodbye])
-        expect(messages.all? {|m| m["type"] == "message" }).to be true
+        expect(messages.map {|m| m[:id] }).to eq(%w[hello goodbye])
+        expect(messages.all? {|m| m[:type] == "message" }).to be true
       end
     end
 
@@ -136,22 +136,22 @@ RSpec.describe Foxtail::Resource do
       it "returns only term entries" do
         terms = resource.terms
         expect(terms.size).to eq(2)
-        expect(terms.map {|t| t["id"] }).to eq(["-brand", "-company"])
-        expect(terms.all? {|t| t["type"] == "term" }).to be true
+        expect(terms.map {|t| t[:id] }).to eq(["-brand", "-company"])
+        expect(terms.all? {|t| t[:type] == "term" }).to be true
       end
     end
 
     describe "#find" do
       it "finds entry by ID" do
         entry = resource.find("hello")
-        expect(entry["type"]).to eq("message")
-        expect(entry["id"]).to eq("hello")
+        expect(entry[:type]).to eq("message")
+        expect(entry[:id]).to eq("hello")
       end
 
       it "finds term entry by ID" do
         entry = resource.find("-brand")
-        expect(entry["type"]).to eq("term")
-        expect(entry["id"]).to eq("-brand")
+        expect(entry[:type]).to eq("term")
+        expect(entry[:id]).to eq("-brand")
       end
 
       it "returns nil when entry not found" do


### PR DESCRIPTION
## Summary

Refactor Bundle AST hashes to use Ruby-idiomatic symbol keys instead of string keys.

## Changes

- Convert hash keys from strings (`"type"`, `"value"`) to symbols (`:type`, `:value`)
- Keep hash values as strings for compatibility with user input (e.g., `{type: "message", id: "hello"}`)
- Update type checking helpers to compare against string values with `%w[]` syntax
- Update all spec files to use symbol keys in expectations

## Test Plan

- All 236 tests pass
- RuboCop shows no offenses
