### PR TITLE
:recycle: Refactor Bundle::AST to use Data classes

### DIFF
--- a/lib/foxtail/bundle.rb
+++ b/lib/foxtail/bundle.rb
@@ -67,7 +67,7 @@ module Foxtail
     def add_resource(resource, allow_overrides: false)
       resource.entries.each do |entry|
         # In fluent-bundle format, terms have '-' prefix in id
-        if entry[:id]&.start_with?("-")
+        if entry.id&.start_with?("-")
           add_term_entry(entry, allow_overrides)
         else
           add_message_entry(entry, allow_overrides)
@@ -116,7 +116,7 @@ module Foxtail
 
       scope = Scope.new(self, **)
       resolver = Resolver.new(self)
-      resolver.resolve_pattern(message[:value], scope)
+      resolver.resolve_pattern(message.value, scope)
       # For now, return just the result
       # In full implementation, would return [result, scope.errors]
     end
@@ -134,7 +134,7 @@ module Foxtail
     end
 
     private def add_message_entry(entry, allow_overrides)
-      id = entry[:id]
+      id = entry.id
       if @messages.key?(id) && !allow_overrides
         # In full implementation, would add to errors
         return
@@ -144,7 +144,7 @@ module Foxtail
     end
 
     private def add_term_entry(entry, allow_overrides)
-      id = entry[:id]
+      id = entry.id
       if @terms.key?(id) && !allow_overrides
         # In full implementation, would add to errors
         return

--- a/lib/foxtail/bundle/ast.rb
+++ b/lib/foxtail/bundle/ast.rb
@@ -12,9 +12,6 @@ module Foxtail
       class StringLiteral
         # @param value [#to_s] The string value (will be converted to String)
         def initialize(value:) = super(value: value.to_s)
-
-        # @return [String] The AST node type identifier
-        def type = "str"
       end
 
       NumberLiteral = Data.define(:value, :precision)
@@ -26,9 +23,6 @@ module Foxtail
         # @param value [Numeric, String] The numeric value (will be converted to Float)
         # @param precision [Integer] Number of decimal places (default: 0)
         def initialize(value:, precision: 0) = super(value: Float(value), precision: Integer(precision))
-
-        # @return [String] The AST node type identifier
-        def type = "num"
       end
 
       VariableReference = Data.define(:name)
@@ -38,9 +32,6 @@ module Foxtail
       class VariableReference
         # @param name [#to_s] The variable name (will be converted to String)
         def initialize(name:) = super(name: name.to_s)
-
-        # @return [String] The AST node type identifier
-        def type = "var"
       end
 
       TermReference = Data.define(:name, :attr, :args)
@@ -54,9 +45,6 @@ module Foxtail
         # @param attr [#to_s, nil] The attribute name (default: nil)
         # @param args [Array] Arguments passed to the term (default: [])
         def initialize(name:, attr: nil, args: []) = super(name: name.to_s, attr: attr&.to_s, args:)
-
-        # @return [String] The AST node type identifier
-        def type = "term"
       end
 
       MessageReference = Data.define(:name, :attr)
@@ -68,9 +56,6 @@ module Foxtail
         # @param name [#to_s] The message identifier (will be converted to String)
         # @param attr [#to_s, nil] The attribute name (default: nil)
         def initialize(name:, attr: nil) = super(name: name.to_s, attr: attr&.to_s)
-
-        # @return [String] The AST node type identifier
-        def type = "mesg"
       end
 
       FunctionReference = Data.define(:name, :args)
@@ -82,9 +67,6 @@ module Foxtail
         # @param name [#to_s] The function name (will be converted to String)
         # @param args [Array] Function arguments (default: [])
         def initialize(name:, args: []) = super(name: name.to_s, args:)
-
-        # @return [String] The AST node type identifier
-        def type = "func"
       end
 
       NamedArgument = Data.define(:name, :value)
@@ -96,9 +78,6 @@ module Foxtail
         # @param name [#to_s] The argument name (will be converted to String)
         # @param value The argument value expression
         def initialize(name:, value:) = super(name: name.to_s, value:)
-
-        # @return [String] The AST node type identifier
-        def type = "narg"
       end
 
       SelectExpression = Data.define(:selector, :variants, :star)
@@ -112,9 +91,6 @@ module Foxtail
         # @param variants [Array<Variant>] The variant branches
         # @param star [Integer] Index of the default variant (default: 0)
         def initialize(selector:, variants:, star: 0) = super
-
-        # @return [String] The AST node type identifier
-        def type = "select"
       end
 
       # Variant for select expressions (no type field, no special initialization)
@@ -131,9 +107,6 @@ module Foxtail
         # @param value The message pattern (default: nil)
         # @param attributes [Hash, nil] Message attributes (default: nil)
         def initialize(id:, value: nil, attributes: nil) = super(id: id.to_s, value:, attributes:)
-
-        # @return [String] The AST node type identifier
-        def type = "message"
       end
 
       Term = Data.define(:id, :value, :attributes)
@@ -151,9 +124,6 @@ module Foxtail
           term_id = "-#{term_id}" unless term_id.start_with?("-")
           super(id: term_id, value:, attributes:)
         end
-
-        # @return [String] The AST node type identifier
-        def type = "term"
       end
 
       # Type checking helpers (following TypeScript union types)

--- a/lib/foxtail/bundle/ast.rb
+++ b/lib/foxtail/bundle/ast.rb
@@ -3,97 +3,180 @@
 module Foxtail
   class Bundle
     # Ruby port of fluent-bundle/src/ast.ts type system
-    # Lightweight Hash-based implementation maintaining TypeScript semantics
+    # Data class-based implementation for immutability and type safety
     module AST
-      # Helper methods for creating AST nodes
-      # Following fluent-bundle/ast.ts type definitions exactly
+      StringLiteral = Data.define(:value)
 
-      # Create a string literal: StringLiteral
-      def self.str(value) = {type: "str", value: value.to_s}
+      # String literal expression in Fluent patterns
+      # @!attribute value [r] [String] The string value
+      class StringLiteral
+        # @return [String] The AST node type identifier
+        def type = "str"
+      end
 
-      # Create a number literal: NumberLiteral
+      NumberLiteral = Data.define(:value, :precision)
+
+      # Number literal expression in Fluent patterns
+      # @!attribute value [r] [Float] The numeric value
+      # @!attribute precision [r] [Integer] Number of decimal places
+      class NumberLiteral
+        # @return [String] The AST node type identifier
+        def type = "num"
+      end
+
+      VariableReference = Data.define(:name)
+
+      # Variable reference expression ($variable) in Fluent patterns
+      # @!attribute name [r] [String] The variable name (without $ prefix)
+      class VariableReference
+        # @return [String] The AST node type identifier
+        def type = "var"
+      end
+
+      TermReference = Data.define(:name, :attr, :args)
+
+      # Term reference expression (-term) in Fluent patterns
+      # @!attribute name [r] [String] The term name (without - prefix)
+      # @!attribute attr [r] [String, nil] The attribute name if accessing an attribute
+      # @!attribute args [r] [Array] Arguments passed to the term
+      class TermReference
+        # @return [String] The AST node type identifier
+        def type = "term"
+      end
+
+      MessageReference = Data.define(:name, :attr)
+
+      # Message reference expression (message) in Fluent patterns
+      # @!attribute name [r] [String] The message identifier
+      # @!attribute attr [r] [String, nil] The attribute name if accessing an attribute
+      class MessageReference
+        # @return [String] The AST node type identifier
+        def type = "mesg"
+      end
+
+      FunctionReference = Data.define(:name, :args)
+
+      # Function call expression (FUNCTION()) in Fluent patterns
+      # @!attribute name [r] [String] The function name (uppercase by convention)
+      # @!attribute args [r] [Array] Function arguments (positional and named)
+      class FunctionReference
+        # @return [String] The AST node type identifier
+        def type = "func"
+      end
+
+      NamedArgument = Data.define(:name, :value)
+
+      # Named argument in function calls (key: value)
+      # @!attribute name [r] [String] The argument name
+      # @!attribute value [r] The argument value expression
+      class NamedArgument
+        # @return [String] The AST node type identifier
+        def type = "narg"
+      end
+
+      SelectExpression = Data.define(:selector, :variants, :star)
+
+      # Select expression for pluralization and variants
+      # @!attribute selector [r] The expression to match against
+      # @!attribute variants [r] [Array<Variant>] The variant branches
+      # @!attribute star [r] [Integer] Index of the default variant
+      class SelectExpression
+        # @return [String] The AST node type identifier
+        def type = "select"
+      end
+
+      # Variant for select expressions (no type field)
+      Variant = Data.define(:key, :value)
+
+      Message = Data.define(:id, :value, :attributes)
+
+      # Message entry in fluent-bundle compatible format
+      # @!attribute id [r] [String] The message identifier
+      # @!attribute value [r] The message pattern (String or Array)
+      # @!attribute attributes [r] [Hash, nil] Message attributes
+      class Message
+        # @return [String] The AST node type identifier
+        def type = "message"
+      end
+
+      Term = Data.define(:id, :value, :attributes)
+
+      # Term entry in fluent-bundle compatible format
+      # @!attribute id [r] [String] The term identifier (with - prefix)
+      # @!attribute value [r] The term pattern (String or Array)
+      # @!attribute attributes [r] [Hash, nil] Term attributes
+      class Term
+        # @return [String] The AST node type identifier
+        def type = "term"
+      end
+
+      # Factory methods for convenient node creation
+      # Following fluent-bundle/ast.ts type definitions
+
+      # Create a string literal
+      def self.str(value) = StringLiteral[value.to_s]
+
+      # Create a number literal
       # @param value [Numeric] The numeric value to convert
       # @param precision [Integer] Number of decimal places (default: 0)
       # @raise [TypeError] when precision is nil or cannot be converted to integer
-      def self.num(value, precision: 0) = {type: "num", value: Float(value), precision: Integer(precision)}
+      def self.num(value, precision: 0) = NumberLiteral[Float(value), Integer(precision)]
 
-      # Create a variable reference: VariableReference
-      def self.var(name) = {type: "var", name: name.to_s}
+      # Create a variable reference
+      def self.var(name) = VariableReference[name.to_s]
 
-      # Create a term reference: TermReference
-      def self.term(name, attr: nil, args: [])
-        node = {type: "term", name: name.to_s}
-        node[:attr] = attr&.to_s
-        node[:args] = args # Always include args field
-        node
-      end
+      # Create a term reference
+      def self.term(name, attr: nil, args: []) = TermReference[name.to_s, attr&.to_s, args]
 
-      # Create a message reference: MessageReference
-      def self.mesg(name, attr: nil)
-        node = {type: "mesg", name: name.to_s}
-        node[:attr] = attr&.to_s
-        node
-      end
+      # Create a message reference
+      def self.mesg(name, attr: nil) = MessageReference[name.to_s, attr&.to_s]
 
-      # Create a function reference: FunctionReference
-      def self.func(name, args: [])
-        node = {type: "func", name: name.to_s}
-        node[:args] = args # Always include args field
-        node
-      end
+      # Create a function reference
+      def self.func(name, args: []) = FunctionReference[name.to_s, args]
 
-      # Create a select expression: SelectExpression
-      def self.select(selector, variants, star: 0) = {type: "select", selector:, variants:, star:}
+      # Create a named argument
+      def self.narg(name, value) = NamedArgument[name.to_s, value]
 
-      # Create a variant: Variant
-      def self.variant(key, value) = {key:, value:}
+      # Create a select expression
+      def self.select(selector, variants, star: 0) = SelectExpression[selector, variants, star]
 
-      # Create a message: Message (fluent-bundle compatible format)
-      def self.message(id, value: nil, attributes: {})
-        node = {type: "message", id: id.to_s}
-        node[:value] = value if value
-        node[:attributes] = attributes if attributes&.any?
-        node
-      end
+      # Create a variant
+      def self.variant(key, value) = Variant[key, value]
 
-      # Create a term: Term (fluent-bundle compatible format)
-      def self.term_def(id, value, attributes: {})
+      # Create a message entry
+      def self.message(id, value: nil, attributes: nil) = Message[id.to_s, value, attributes]
+
+      # Create a term entry
+      def self.term_def(id, value, attributes: nil)
         # Ensure term ID has '-' prefix for bundle format
         term_id = id.to_s.start_with?("-") ? id.to_s : "-#{id}"
-        node = {type: "term", id: term_id}
-        node[:value] = value
-        node[:attributes] = attributes if attributes&.any?
-        node
+        Term[term_id, value, attributes]
       end
 
       # Type checking helpers (following TypeScript union types)
+
       # Check if node is a literal (string or number)
-      def self.literal?(node)
-        node.is_a?(Hash) && %w[str num].include?(node[:type])
-      end
+      def self.literal?(node) = node.is_a?(StringLiteral) || node.is_a?(NumberLiteral)
 
       # Check if node is an expression
       def self.expression?(node)
         return true if literal?(node)
-        return false unless node.is_a?(Hash)
 
-        %w[var term mesg func select].include?(node[:type])
+        node.is_a?(VariableReference) ||
+          node.is_a?(TermReference) ||
+          node.is_a?(MessageReference) ||
+          node.is_a?(FunctionReference) ||
+          node.is_a?(SelectExpression)
       end
 
       # Check if node can be a pattern element
-      def self.pattern_element?(node)
-        node.is_a?(String) || expression?(node)
-      end
+      def self.pattern_element?(node) = node.is_a?(String) || expression?(node)
 
       # Check if node is a complex pattern (array of pattern elements)
-      def self.complex_pattern?(node)
-        node.is_a?(Array) && node.all? {|el| pattern_element?(el) }
-      end
+      def self.complex_pattern?(node) = node.is_a?(Array) && node.all? {|el| pattern_element?(el) }
 
       # Check if node is any valid pattern
-      def self.pattern?(node)
-        node.is_a?(String) || complex_pattern?(node)
-      end
+      def self.pattern?(node) = node.is_a?(String) || complex_pattern?(node)
     end
   end
 end

--- a/lib/foxtail/bundle/ast_converter.rb
+++ b/lib/foxtail/bundle/ast_converter.rb
@@ -200,11 +200,7 @@ module Foxtail
             # Add named arguments
             if expr.arguments.named
               expr.arguments.named.each do |named_arg|
-                args << {
-                  type: "narg",
-                  name: named_arg.name.name,
-                  value: convert_expression(named_arg.value)
-                }
+                args << AST.narg(named_arg.name.name, convert_expression(named_arg.value))
               end
             end
           end
@@ -248,14 +244,14 @@ module Foxtail
         end
       end
 
-      # Convert attributes hash
+      # Convert attributes hash (returns nil if empty)
       private def convert_attributes(parser_attributes)
-        attributes = {}
+        return nil if parser_attributes.empty?
 
+        attributes = {}
         parser_attributes.each do |attr|
           attributes[attr.id.name] = convert_attribute_pattern(attr.value)
         end
-
         attributes
       end
 
@@ -302,7 +298,7 @@ module Foxtail
         }
 
         # If contains expressions, keep as array; if all strings, join
-        has_expressions = converted.any?(Hash)
+        has_expressions = converted.any? {|el| AST.expression?(el) }
         if has_expressions
           converted
         else

--- a/lib/foxtail/resource.rb
+++ b/lib/foxtail/resource.rb
@@ -71,17 +71,17 @@ module Foxtail
 
     # Get entries by type
     def messages
-      @entries.select {|entry| entry[:id] && !entry[:id].start_with?("-") }
+      @entries.select {|entry| entry.id && !entry.id.start_with?("-") }
     end
 
     # Get term entries (IDs starting with "-")
     def terms
-      @entries.select {|entry| entry[:id]&.start_with?("-") }
+      @entries.select {|entry| entry.id&.start_with?("-") }
     end
 
     # Find entry by ID
     def find(id)
-      @entries.find {|entry| entry[:id] == id }
+      @entries.find {|entry| entry.id == id }
     end
   end
 end

--- a/spec/foxtail/bundle/ast_converter_spec.rb
+++ b/spec/foxtail/bundle/ast_converter_spec.rb
@@ -33,19 +33,19 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
 
       # Check message
       hello_msg = entries[0]
-      expect(hello_msg.type).to eq("message")
+      expect(hello_msg).to be_a(Foxtail::Bundle::AST::Message)
       expect(hello_msg.id).to eq("hello")
       expect(hello_msg.value).to be_an(Array)
 
       # Check term
       brand_term = entries[1]
-      expect(brand_term.type).to eq("term")
+      expect(brand_term).to be_a(Foxtail::Bundle::AST::Term)
       expect(brand_term.id).to eq("-brand")
       expect(brand_term.value).to eq("Firefox")
 
       # Check simple message
       goodbye_msg = entries[2]
-      expect(goodbye_msg.type).to eq("message")
+      expect(goodbye_msg).to be_a(Foxtail::Bundle::AST::Message)
       expect(goodbye_msg.id).to eq("goodbye")
       expect(goodbye_msg.value).to eq("Goodbye!")
     end
@@ -59,11 +59,11 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
     it "converts parser message to bundle AST message" do
       result = converter.convert_message(parser_message)
 
-      expect(result.type).to eq("message")
+      expect(result).to be_a(Foxtail::Bundle::AST::Message)
       expect(result.id).to eq("hello")
       expect(result.value).to be_an(Array)
       expect(result.value[0]).to eq("Hello, ")
-      expect(result.value[1].type).to eq("var")
+      expect(result.value[1]).to be_a(Foxtail::Bundle::AST::VariableReference)
       expect(result.value[1].name).to eq("name")
       expect(result.value[2]).to eq("!")
     end
@@ -93,7 +93,7 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
     it "converts parser term to bundle AST term" do
       result = converter.convert_term(parser_term)
 
-      expect(result.type).to eq("term")
+      expect(result).to be_a(Foxtail::Bundle::AST::Term)
       expect(result.id).to eq("-brand")
       expect(result.value).to eq("Firefox")
     end
@@ -123,7 +123,7 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
 
         expect(result).to be_an(Array)
         expect(result[0]).to eq("Hello, ")
-        expect(result[1].type).to eq("var")
+        expect(result[1]).to be_a(Foxtail::Bundle::AST::VariableReference)
         expect(result[1].name).to eq("name")
         expect(result[2]).to eq("!")
       end
@@ -139,7 +139,7 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
       var_placeable = pattern_elements[0]
       result = converter.__send__(:convert_expression, var_placeable.expression)
 
-      expect(result.type).to eq("var")
+      expect(result).to be_a(Foxtail::Bundle::AST::VariableReference)
       expect(result.name).to eq("var")
     end
 
@@ -147,7 +147,7 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
       msg_placeable = pattern_elements[2]
       result = converter.__send__(:convert_expression, msg_placeable.expression)
 
-      expect(result.type).to eq("mesg")
+      expect(result).to be_a(Foxtail::Bundle::AST::MessageReference)
       expect(result.name).to eq("hello")
     end
 
@@ -155,7 +155,7 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
       term_placeable = pattern_elements[4]
       result = converter.__send__(:convert_expression, term_placeable.expression)
 
-      expect(result.type).to eq("term")
+      expect(result).to be_a(Foxtail::Bundle::AST::TermReference)
       expect(result.name).to eq("term")
     end
 
@@ -163,11 +163,11 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
       func_placeable = pattern_elements[6]
       result = converter.__send__(:convert_expression, func_placeable.expression)
 
-      expect(result.type).to eq("func")
+      expect(result).to be_a(Foxtail::Bundle::AST::FunctionReference)
       expect(result.name).to eq("NUMBER")
       expect(result.args).to be_an(Array)
       expect(result.args.length).to eq(1)
-      expect(result.args[0].type).to eq("var")
+      expect(result.args[0]).to be_a(Foxtail::Bundle::AST::VariableReference)
       expect(result.args[0].name).to eq("count")
     end
 
@@ -177,21 +177,21 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
       func_placeable = parser_resource.body.first.value.elements[0]
       result = converter.__send__(:convert_expression, func_placeable.expression)
 
-      expect(result.type).to eq("func")
+      expect(result).to be_a(Foxtail::Bundle::AST::FunctionReference)
       expect(result.name).to eq("FUNC")
       expect(result.args).to be_an(Array)
       expect(result.args.length).to eq(2)
 
       # First named argument
-      expect(result.args[0].type).to eq("narg")
+      expect(result.args[0]).to be_a(Foxtail::Bundle::AST::NamedArgument)
       expect(result.args[0].name).to eq("arg1")
-      expect(result.args[0].value.type).to eq("num")
+      expect(result.args[0].value).to be_a(Foxtail::Bundle::AST::NumberLiteral)
       expect(result.args[0].value.value).to eq(1.0)
 
       # Second named argument
-      expect(result.args[1].type).to eq("narg")
+      expect(result.args[1]).to be_a(Foxtail::Bundle::AST::NamedArgument)
       expect(result.args[1].name).to eq("arg2")
-      expect(result.args[1].value.type).to eq("str")
+      expect(result.args[1].value).to be_a(Foxtail::Bundle::AST::StringLiteral)
       expect(result.args[1].value.value).to eq("hello")
     end
 
@@ -221,8 +221,8 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
     it "converts select expressions" do
       result = converter.__send__(:convert_expression, select_expr)
 
-      expect(result.type).to eq("select")
-      expect(result.selector.type).to eq("var")
+      expect(result).to be_a(Foxtail::Bundle::AST::SelectExpression)
+      expect(result.selector).to be_a(Foxtail::Bundle::AST::VariableReference)
       expect(result.selector.name).to eq("count")
       expect(result.variants).to be_an(Array)
       expect(result.variants.length).to eq(3)
@@ -234,15 +234,15 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
       variants = result.variants
 
       # Number literal key
-      expect(variants[0].key.type).to eq("num")
+      expect(variants[0].key).to be_a(Foxtail::Bundle::AST::NumberLiteral)
       expect(variants[0].key.value).to eq(0.0)
 
       # String literal key
-      expect(variants[1].key.type).to eq("str")
+      expect(variants[1].key).to be_a(Foxtail::Bundle::AST::StringLiteral)
       expect(variants[1].key.value).to eq("one")
 
       # Default variant key
-      expect(variants[2].key.type).to eq("str")
+      expect(variants[2].key).to be_a(Foxtail::Bundle::AST::StringLiteral)
       expect(variants[2].key.value).to eq("other")
     end
   end
@@ -265,21 +265,21 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
       it "converts number literals from select expression" do
         zero_variant = select_expr.variants[0]
         result = converter.__send__(:convert_literal, zero_variant.key)
-        expect(result.type).to eq("num")
+        expect(result).to be_a(Foxtail::Bundle::AST::NumberLiteral)
         expect(result.value).to eq(0.0)
       end
 
       it "converts identifier literals from select expression" do
         one_variant = select_expr.variants[1]
         result = converter.__send__(:convert_literal, one_variant.key)
-        expect(result.type).to eq("str")
+        expect(result).to be_a(Foxtail::Bundle::AST::StringLiteral)
         expect(result.value).to eq("one")
       end
 
       it "converts default identifier literals from select expression" do
         other_variant = select_expr.variants[2]
         result = converter.__send__(:convert_literal, other_variant.key)
-        expect(result.type).to eq("str")
+        expect(result).to be_a(Foxtail::Bundle::AST::StringLiteral)
         expect(result.value).to eq("other")
       end
     end

--- a/spec/foxtail/bundle/ast_converter_spec.rb
+++ b/spec/foxtail/bundle/ast_converter_spec.rb
@@ -33,21 +33,21 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
 
       # Check message
       hello_msg = entries[0]
-      expect(hello_msg[:type]).to eq("message")
-      expect(hello_msg[:id]).to eq("hello")
-      expect(hello_msg[:value]).to be_an(Array)
+      expect(hello_msg.type).to eq("message")
+      expect(hello_msg.id).to eq("hello")
+      expect(hello_msg.value).to be_an(Array)
 
       # Check term
       brand_term = entries[1]
-      expect(brand_term[:type]).to eq("term")
-      expect(brand_term[:id]).to eq("-brand")
-      expect(brand_term[:value]).to eq("Firefox")
+      expect(brand_term.type).to eq("term")
+      expect(brand_term.id).to eq("-brand")
+      expect(brand_term.value).to eq("Firefox")
 
       # Check simple message
       goodbye_msg = entries[2]
-      expect(goodbye_msg[:type]).to eq("message")
-      expect(goodbye_msg[:id]).to eq("goodbye")
-      expect(goodbye_msg[:value]).to eq("Goodbye!")
+      expect(goodbye_msg.type).to eq("message")
+      expect(goodbye_msg.id).to eq("goodbye")
+      expect(goodbye_msg.value).to eq("Goodbye!")
     end
   end
 
@@ -59,13 +59,13 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
     it "converts parser message to bundle AST message" do
       result = converter.convert_message(parser_message)
 
-      expect(result[:type]).to eq("message")
-      expect(result[:id]).to eq("hello")
-      expect(result[:value]).to be_an(Array)
-      expect(result[:value][0]).to eq("Hello, ")
-      expect(result[:value][1][:type]).to eq("var")
-      expect(result[:value][1][:name]).to eq("name")
-      expect(result[:value][2]).to eq("!")
+      expect(result.type).to eq("message")
+      expect(result.id).to eq("hello")
+      expect(result.value).to be_an(Array)
+      expect(result.value[0]).to eq("Hello, ")
+      expect(result.value[1].type).to eq("var")
+      expect(result.value[1].name).to eq("name")
+      expect(result.value[2]).to eq("!")
     end
 
     context "with attributes" do
@@ -79,8 +79,8 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
       it "converts message attributes" do
         result = converter.convert_message(parser_message)
 
-        expect(result[:attributes]).to be_a(Hash)
-        expect(result[:attributes]["title"]).to eq("Page title")
+        expect(result.attributes).to be_a(Hash)
+        expect(result.attributes["title"]).to eq("Page title")
       end
     end
   end
@@ -93,9 +93,9 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
     it "converts parser term to bundle AST term" do
       result = converter.convert_term(parser_term)
 
-      expect(result[:type]).to eq("term")
-      expect(result[:id]).to eq("-brand")
-      expect(result[:value]).to eq("Firefox")
+      expect(result.type).to eq("term")
+      expect(result.id).to eq("-brand")
+      expect(result.value).to eq("Firefox")
     end
   end
 
@@ -123,8 +123,8 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
 
         expect(result).to be_an(Array)
         expect(result[0]).to eq("Hello, ")
-        expect(result[1][:type]).to eq("var")
-        expect(result[1][:name]).to eq("name")
+        expect(result[1].type).to eq("var")
+        expect(result[1].name).to eq("name")
         expect(result[2]).to eq("!")
       end
     end
@@ -139,36 +139,36 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
       var_placeable = pattern_elements[0]
       result = converter.__send__(:convert_expression, var_placeable.expression)
 
-      expect(result[:type]).to eq("var")
-      expect(result[:name]).to eq("var")
+      expect(result.type).to eq("var")
+      expect(result.name).to eq("var")
     end
 
     it "converts message references" do
       msg_placeable = pattern_elements[2]
       result = converter.__send__(:convert_expression, msg_placeable.expression)
 
-      expect(result[:type]).to eq("mesg")
-      expect(result[:name]).to eq("hello")
+      expect(result.type).to eq("mesg")
+      expect(result.name).to eq("hello")
     end
 
     it "converts term references" do
       term_placeable = pattern_elements[4]
       result = converter.__send__(:convert_expression, term_placeable.expression)
 
-      expect(result[:type]).to eq("term")
-      expect(result[:name]).to eq("term")
+      expect(result.type).to eq("term")
+      expect(result.name).to eq("term")
     end
 
     it "converts function references with positional arguments" do
       func_placeable = pattern_elements[6]
       result = converter.__send__(:convert_expression, func_placeable.expression)
 
-      expect(result[:type]).to eq("func")
-      expect(result[:name]).to eq("NUMBER")
-      expect(result[:args]).to be_an(Array)
-      expect(result[:args].length).to eq(1)
-      expect(result[:args][0][:type]).to eq("var")
-      expect(result[:args][0][:name]).to eq("count")
+      expect(result.type).to eq("func")
+      expect(result.name).to eq("NUMBER")
+      expect(result.args).to be_an(Array)
+      expect(result.args.length).to eq(1)
+      expect(result.args[0].type).to eq("var")
+      expect(result.args[0].name).to eq("count")
     end
 
     it "converts function references with named arguments" do
@@ -177,22 +177,22 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
       func_placeable = parser_resource.body.first.value.elements[0]
       result = converter.__send__(:convert_expression, func_placeable.expression)
 
-      expect(result[:type]).to eq("func")
-      expect(result[:name]).to eq("FUNC")
-      expect(result[:args]).to be_an(Array)
-      expect(result[:args].length).to eq(2)
+      expect(result.type).to eq("func")
+      expect(result.name).to eq("FUNC")
+      expect(result.args).to be_an(Array)
+      expect(result.args.length).to eq(2)
 
       # First named argument
-      expect(result[:args][0][:type]).to eq("narg")
-      expect(result[:args][0][:name]).to eq("arg1")
-      expect(result[:args][0][:value][:type]).to eq("num")
-      expect(result[:args][0][:value][:value]).to eq(1.0)
+      expect(result.args[0].type).to eq("narg")
+      expect(result.args[0].name).to eq("arg1")
+      expect(result.args[0].value.type).to eq("num")
+      expect(result.args[0].value.value).to eq(1.0)
 
       # Second named argument
-      expect(result[:args][1][:type]).to eq("narg")
-      expect(result[:args][1][:name]).to eq("arg2")
-      expect(result[:args][1][:value][:type]).to eq("str")
-      expect(result[:args][1][:value][:value]).to eq("hello")
+      expect(result.args[1].type).to eq("narg")
+      expect(result.args[1].name).to eq("arg2")
+      expect(result.args[1].value.type).to eq("str")
+      expect(result.args[1].value.value).to eq("hello")
     end
 
     it "processes escape sequences in text elements" do
@@ -200,7 +200,7 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
       parser_resource = Foxtail::Parser.new.parse(ftl_source)
       result = converter.convert_resource(parser_resource)
 
-      expect(result.first[:value]).to eq("Text with \"quotes\" and \\backslash and A")
+      expect(result.first.value).to eq("Text with \"quotes\" and \\backslash and A")
     end
   end
 
@@ -221,29 +221,29 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
     it "converts select expressions" do
       result = converter.__send__(:convert_expression, select_expr)
 
-      expect(result[:type]).to eq("select")
-      expect(result[:selector][:type]).to eq("var")
-      expect(result[:selector][:name]).to eq("count")
-      expect(result[:variants]).to be_an(Array)
-      expect(result[:variants].length).to eq(3)
-      expect(result[:star]).to eq(2) # Index of default variant
+      expect(result.type).to eq("select")
+      expect(result.selector.type).to eq("var")
+      expect(result.selector.name).to eq("count")
+      expect(result.variants).to be_an(Array)
+      expect(result.variants.length).to eq(3)
+      expect(result.star).to eq(2) # Index of default variant
     end
 
     it "converts variant keys correctly" do
       result = converter.__send__(:convert_expression, select_expr)
-      variants = result[:variants]
+      variants = result.variants
 
       # Number literal key
-      expect(variants[0][:key][:type]).to eq("num")
-      expect(variants[0][:key][:value]).to eq(0.0)
+      expect(variants[0].key.type).to eq("num")
+      expect(variants[0].key.value).to eq(0.0)
 
       # String literal key
-      expect(variants[1][:key][:type]).to eq("str")
-      expect(variants[1][:key][:value]).to eq("one")
+      expect(variants[1].key.type).to eq("str")
+      expect(variants[1].key.value).to eq("one")
 
       # Default variant key
-      expect(variants[2][:key][:type]).to eq("str")
-      expect(variants[2][:key][:value]).to eq("other")
+      expect(variants[2].key.type).to eq("str")
+      expect(variants[2].key.value).to eq("other")
     end
   end
 
@@ -265,22 +265,22 @@ RSpec.describe Foxtail::Bundle::ASTConverter do
       it "converts number literals from select expression" do
         zero_variant = select_expr.variants[0]
         result = converter.__send__(:convert_literal, zero_variant.key)
-        expect(result[:type]).to eq("num")
-        expect(result[:value]).to eq(0.0)
+        expect(result.type).to eq("num")
+        expect(result.value).to eq(0.0)
       end
 
       it "converts identifier literals from select expression" do
         one_variant = select_expr.variants[1]
         result = converter.__send__(:convert_literal, one_variant.key)
-        expect(result[:type]).to eq("str")
-        expect(result[:value]).to eq("one")
+        expect(result.type).to eq("str")
+        expect(result.value).to eq("one")
       end
 
       it "converts default identifier literals from select expression" do
         other_variant = select_expr.variants[2]
         result = converter.__send__(:convert_literal, other_variant.key)
-        expect(result[:type]).to eq("str")
-        expect(result[:value]).to eq("other")
+        expect(result.type).to eq("str")
+        expect(result.value).to eq("other")
       end
     end
   end

--- a/spec/foxtail/bundle/ast_spec.rb
+++ b/spec/foxtail/bundle/ast_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Foxtail::Bundle::AST do
     it "creates a string literal node" do
       result = Foxtail::Bundle::AST::StringLiteral[value: "hello"]
       expect(result).to be_a(Foxtail::Bundle::AST::StringLiteral)
-      expect(result.type).to eq("str")
       expect(result.value).to eq("hello")
     end
 
@@ -19,7 +18,6 @@ RSpec.describe Foxtail::Bundle::AST do
     it "creates a number literal node with default precision" do
       result = Foxtail::Bundle::AST::NumberLiteral[value: 42.5]
       expect(result).to be_a(Foxtail::Bundle::AST::NumberLiteral)
-      expect(result.type).to eq("num")
       expect(result.value).to eq(42.5)
       expect(result.precision).to eq(0)
     end
@@ -47,7 +45,6 @@ RSpec.describe Foxtail::Bundle::AST do
     it "creates a variable reference node" do
       result = Foxtail::Bundle::AST::VariableReference[name: "username"]
       expect(result).to be_a(Foxtail::Bundle::AST::VariableReference)
-      expect(result.type).to eq("var")
       expect(result.name).to eq("username")
     end
 
@@ -61,7 +58,6 @@ RSpec.describe Foxtail::Bundle::AST do
     it "creates a term reference node" do
       result = Foxtail::Bundle::AST::TermReference[name: "brand"]
       expect(result).to be_a(Foxtail::Bundle::AST::TermReference)
-      expect(result.type).to eq("term")
       expect(result.name).to eq("brand")
       expect(result.attr).to be_nil
       expect(result.args).to eq([])
@@ -92,7 +88,6 @@ RSpec.describe Foxtail::Bundle::AST do
     it "creates a message reference node" do
       result = Foxtail::Bundle::AST::MessageReference[name: "hello"]
       expect(result).to be_a(Foxtail::Bundle::AST::MessageReference)
-      expect(result.type).to eq("mesg")
       expect(result.name).to eq("hello")
       expect(result.attr).to be_nil
     end
@@ -108,7 +103,6 @@ RSpec.describe Foxtail::Bundle::AST do
     it "creates a function reference node" do
       result = Foxtail::Bundle::AST::FunctionReference[name: "NUMBER"]
       expect(result).to be_a(Foxtail::Bundle::AST::FunctionReference)
-      expect(result.type).to eq("func")
       expect(result.name).to eq("NUMBER")
       expect(result.args).to eq([])
     end
@@ -136,7 +130,6 @@ RSpec.describe Foxtail::Bundle::AST do
 
       result = Foxtail::Bundle::AST::SelectExpression[selector:, variants:]
       expect(result).to be_a(Foxtail::Bundle::AST::SelectExpression)
-      expect(result.type).to eq("select")
       expect(result.selector).to eq(selector)
       expect(result.variants).to eq(variants)
       expect(result.star).to eq(0)
@@ -169,7 +162,6 @@ RSpec.describe Foxtail::Bundle::AST do
     it "creates a message node" do
       result = Foxtail::Bundle::AST::Message[id: "hello"]
       expect(result).to be_a(Foxtail::Bundle::AST::Message)
-      expect(result.type).to eq("message")
       expect(result.id).to eq("hello")
       expect(result.value).to be_nil
       expect(result.attributes).to be_nil
@@ -201,7 +193,6 @@ RSpec.describe Foxtail::Bundle::AST do
       value = "Firefox"
       result = Foxtail::Bundle::AST::Term[id: "brand", value:]
       expect(result).to be_a(Foxtail::Bundle::AST::Term)
-      expect(result.type).to eq("term")
       expect(result.id).to eq("-brand")
       expect(result.value).to eq(value)
     end

--- a/spec/foxtail/bundle/ast_spec.rb
+++ b/spec/foxtail/bundle/ast_spec.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
 RSpec.describe Foxtail::Bundle::AST do
-  describe ".str" do
+  describe Foxtail::Bundle::AST::StringLiteral do
     it "creates a string literal node" do
-      result = Foxtail::Bundle::AST.str("hello")
+      result = Foxtail::Bundle::AST::StringLiteral[value: "hello"]
       expect(result).to be_a(Foxtail::Bundle::AST::StringLiteral)
       expect(result.type).to eq("str")
       expect(result.value).to eq("hello")
     end
 
     it "converts non-string values to string" do
-      result = Foxtail::Bundle::AST.str(42)
+      result = Foxtail::Bundle::AST::StringLiteral[value: 42]
       expect(result.value).to eq("42")
     end
   end
 
-  describe ".num" do
+  describe Foxtail::Bundle::AST::NumberLiteral do
     it "creates a number literal node with default precision" do
-      result = Foxtail::Bundle::AST.num(42.5)
+      result = Foxtail::Bundle::AST::NumberLiteral[value: 42.5]
       expect(result).to be_a(Foxtail::Bundle::AST::NumberLiteral)
       expect(result.type).to eq("num")
       expect(result.value).to eq(42.5)
@@ -25,41 +25,41 @@ RSpec.describe Foxtail::Bundle::AST do
     end
 
     it "converts string numbers to float" do
-      result = Foxtail::Bundle::AST.num("42.5")
+      result = Foxtail::Bundle::AST::NumberLiteral[value: "42.5"]
       expect(result.value).to eq(42.5)
       expect(result.precision).to eq(0)
     end
 
     it "includes precision when provided" do
-      result = Foxtail::Bundle::AST.num(42.5, precision: 2)
+      result = Foxtail::Bundle::AST::NumberLiteral[value: 42.5, precision: 2]
       expect(result.value).to eq(42.5)
       expect(result.precision).to eq(2)
     end
 
     it "raises error when precision is nil" do
       expect {
-        Foxtail::Bundle::AST.num(42.5, precision: nil)
-      }.to raise_error(TypeError, "can't convert nil into Integer")
+        Foxtail::Bundle::AST::NumberLiteral[value: 42.5, precision: nil]
+      }.to raise_error(TypeError, /can't convert nil into Integer/)
     end
   end
 
-  describe ".var" do
+  describe Foxtail::Bundle::AST::VariableReference do
     it "creates a variable reference node" do
-      result = Foxtail::Bundle::AST.var("username")
+      result = Foxtail::Bundle::AST::VariableReference[name: "username"]
       expect(result).to be_a(Foxtail::Bundle::AST::VariableReference)
       expect(result.type).to eq("var")
       expect(result.name).to eq("username")
     end
 
     it "converts non-string names to string" do
-      result = Foxtail::Bundle::AST.var(:username)
+      result = Foxtail::Bundle::AST::VariableReference[name: :username]
       expect(result.name).to eq("username")
     end
   end
 
-  describe ".term" do
+  describe Foxtail::Bundle::AST::TermReference do
     it "creates a term reference node" do
-      result = Foxtail::Bundle::AST.term("brand")
+      result = Foxtail::Bundle::AST::TermReference[name: "brand"]
       expect(result).to be_a(Foxtail::Bundle::AST::TermReference)
       expect(result.type).to eq("term")
       expect(result.name).to eq("brand")
@@ -68,29 +68,29 @@ RSpec.describe Foxtail::Bundle::AST do
     end
 
     it "includes attribute when provided" do
-      result = Foxtail::Bundle::AST.term("brand", attr: "title")
+      result = Foxtail::Bundle::AST::TermReference[name: "brand", attr: "title"]
       expect(result.name).to eq("brand")
       expect(result.attr).to eq("title")
       expect(result.args).to eq([])
     end
 
     it "includes args when provided" do
-      args = [Foxtail::Bundle::AST.str("value")]
-      result = Foxtail::Bundle::AST.term("brand", args:)
+      args = [Foxtail::Bundle::AST::StringLiteral[value: "value"]]
+      result = Foxtail::Bundle::AST::TermReference[name: "brand", args:]
       expect(result.name).to eq("brand")
       expect(result.attr).to be_nil
       expect(result.args).to eq(args)
     end
 
     it "includes empty args array" do
-      result = Foxtail::Bundle::AST.term("brand", args: [])
+      result = Foxtail::Bundle::AST::TermReference[name: "brand", args: []]
       expect(result.args).to eq([])
     end
   end
 
-  describe ".mesg" do
+  describe Foxtail::Bundle::AST::MessageReference do
     it "creates a message reference node" do
-      result = Foxtail::Bundle::AST.mesg("hello")
+      result = Foxtail::Bundle::AST::MessageReference[name: "hello"]
       expect(result).to be_a(Foxtail::Bundle::AST::MessageReference)
       expect(result.type).to eq("mesg")
       expect(result.name).to eq("hello")
@@ -98,15 +98,15 @@ RSpec.describe Foxtail::Bundle::AST do
     end
 
     it "includes attribute when provided" do
-      result = Foxtail::Bundle::AST.mesg("hello", attr: "title")
+      result = Foxtail::Bundle::AST::MessageReference[name: "hello", attr: "title"]
       expect(result.name).to eq("hello")
       expect(result.attr).to eq("title")
     end
   end
 
-  describe ".func" do
+  describe Foxtail::Bundle::AST::FunctionReference do
     it "creates a function reference node" do
-      result = Foxtail::Bundle::AST.func("NUMBER")
+      result = Foxtail::Bundle::AST::FunctionReference[name: "NUMBER"]
       expect(result).to be_a(Foxtail::Bundle::AST::FunctionReference)
       expect(result.type).to eq("func")
       expect(result.name).to eq("NUMBER")
@@ -114,27 +114,27 @@ RSpec.describe Foxtail::Bundle::AST do
     end
 
     it "includes args when provided" do
-      args = [Foxtail::Bundle::AST.str("value")]
-      result = Foxtail::Bundle::AST.func("NUMBER", args:)
+      args = [Foxtail::Bundle::AST::StringLiteral[value: "value"]]
+      result = Foxtail::Bundle::AST::FunctionReference[name: "NUMBER", args:]
       expect(result.name).to eq("NUMBER")
       expect(result.args).to eq(args)
     end
 
     it "includes empty args array" do
-      result = Foxtail::Bundle::AST.func("NUMBER", args: [])
+      result = Foxtail::Bundle::AST::FunctionReference[name: "NUMBER", args: []]
       expect(result.args).to eq([])
     end
   end
 
-  describe ".select" do
+  describe Foxtail::Bundle::AST::SelectExpression do
     it "creates a select expression node" do
-      selector = Foxtail::Bundle::AST.var("count")
+      selector = Foxtail::Bundle::AST::VariableReference[name: "count"]
       variants = [
-        Foxtail::Bundle::AST.variant(Foxtail::Bundle::AST.num(0), "none"),
-        Foxtail::Bundle::AST.variant(Foxtail::Bundle::AST.str("other"), "many")
+        Foxtail::Bundle::AST::Variant[key: Foxtail::Bundle::AST::NumberLiteral[value: 0], value: "none"],
+        Foxtail::Bundle::AST::Variant[key: Foxtail::Bundle::AST::StringLiteral[value: "other"], value: "many"]
       ]
 
-      result = Foxtail::Bundle::AST.select(selector, variants)
+      result = Foxtail::Bundle::AST::SelectExpression[selector:, variants:]
       expect(result).to be_a(Foxtail::Bundle::AST::SelectExpression)
       expect(result.type).to eq("select")
       expect(result.selector).to eq(selector)
@@ -143,31 +143,31 @@ RSpec.describe Foxtail::Bundle::AST do
     end
 
     it "accepts custom star index" do
-      selector = Foxtail::Bundle::AST.var("count")
-      variants = [Foxtail::Bundle::AST.variant(Foxtail::Bundle::AST.str("other"), "many")]
+      selector = Foxtail::Bundle::AST::VariableReference[name: "count"]
+      variants = [Foxtail::Bundle::AST::Variant[key: Foxtail::Bundle::AST::StringLiteral[value: "other"], value: "many"]]
 
-      result = Foxtail::Bundle::AST.select(selector, variants, star: 1)
+      result = Foxtail::Bundle::AST::SelectExpression[selector:, variants:, star: 1]
       expect(result.selector).to eq(selector)
       expect(result.variants).to eq(variants)
       expect(result.star).to eq(1)
     end
   end
 
-  describe ".variant" do
+  describe Foxtail::Bundle::AST::Variant do
     it "creates a variant node" do
-      key = Foxtail::Bundle::AST.str("one")
+      key = Foxtail::Bundle::AST::StringLiteral[value: "one"]
       value = "single item"
 
-      result = Foxtail::Bundle::AST.variant(key, value)
+      result = Foxtail::Bundle::AST::Variant[key:, value:]
       expect(result).to be_a(Foxtail::Bundle::AST::Variant)
       expect(result.key).to eq(key)
       expect(result.value).to eq(value)
     end
   end
 
-  describe ".message" do
+  describe Foxtail::Bundle::AST::Message do
     it "creates a message node" do
-      result = Foxtail::Bundle::AST.message("hello")
+      result = Foxtail::Bundle::AST::Message[id: "hello"]
       expect(result).to be_a(Foxtail::Bundle::AST::Message)
       expect(result.type).to eq("message")
       expect(result.id).to eq("hello")
@@ -177,39 +177,45 @@ RSpec.describe Foxtail::Bundle::AST do
 
     it "includes value when provided" do
       value = "Hello world"
-      result = Foxtail::Bundle::AST.message("hello", value:)
+      result = Foxtail::Bundle::AST::Message[id: "hello", value:]
       expect(result.id).to eq("hello")
       expect(result.value).to eq(value)
     end
 
     it "includes attributes when provided" do
       attributes = {"title" => "Greeting"}
-      result = Foxtail::Bundle::AST.message("hello", attributes:)
+      result = Foxtail::Bundle::AST::Message[id: "hello", attributes:]
       expect(result.id).to eq("hello")
       expect(result.attributes).to eq(attributes)
     end
 
     it "accepts nil attributes" do
-      result = Foxtail::Bundle::AST.message("hello", attributes: nil)
+      result = Foxtail::Bundle::AST::Message[id: "hello", attributes: nil]
       expect(result.id).to eq("hello")
       expect(result.attributes).to be_nil
     end
   end
 
-  describe ".term_def" do
-    it "creates a term definition node" do
+  describe Foxtail::Bundle::AST::Term do
+    it "creates a term definition node with - prefix" do
       value = "Firefox"
-      result = Foxtail::Bundle::AST.term_def("brand", value)
+      result = Foxtail::Bundle::AST::Term[id: "brand", value:]
       expect(result).to be_a(Foxtail::Bundle::AST::Term)
       expect(result.type).to eq("term")
       expect(result.id).to eq("-brand")
       expect(result.value).to eq(value)
     end
 
+    it "preserves existing - prefix" do
+      value = "Firefox"
+      result = Foxtail::Bundle::AST::Term[id: "-brand", value:]
+      expect(result.id).to eq("-brand")
+    end
+
     it "includes attributes when provided" do
       value = "Firefox"
       attributes = {"case" => "nominative"}
-      result = Foxtail::Bundle::AST.term_def("brand", value, attributes:)
+      result = Foxtail::Bundle::AST::Term[id: "brand", value:, attributes:]
       expect(result.id).to eq("-brand")
       expect(result.value).to eq(value)
       expect(result.attributes).to eq(attributes)
@@ -217,7 +223,7 @@ RSpec.describe Foxtail::Bundle::AST do
 
     it "accepts nil attributes" do
       value = "Firefox"
-      result = Foxtail::Bundle::AST.term_def("brand", value, attributes: nil)
+      result = Foxtail::Bundle::AST::Term[id: "brand", value:, attributes: nil]
       expect(result.id).to eq("-brand")
       expect(result.attributes).to be_nil
     end
@@ -226,17 +232,17 @@ RSpec.describe Foxtail::Bundle::AST do
   describe "type checking helpers" do
     describe ".literal?" do
       it "returns true for string literals" do
-        node = Foxtail::Bundle::AST.str("hello")
+        node = Foxtail::Bundle::AST::StringLiteral[value: "hello"]
         expect(Foxtail::Bundle::AST.literal?(node)).to be true
       end
 
       it "returns true for number literals" do
-        node = Foxtail::Bundle::AST.num(42)
+        node = Foxtail::Bundle::AST::NumberLiteral[value: 42]
         expect(Foxtail::Bundle::AST.literal?(node)).to be true
       end
 
       it "returns false for non-literals" do
-        node = Foxtail::Bundle::AST.var("name")
+        node = Foxtail::Bundle::AST::VariableReference[name: "name"]
         expect(Foxtail::Bundle::AST.literal?(node)).to be false
       end
 
@@ -248,36 +254,36 @@ RSpec.describe Foxtail::Bundle::AST do
 
     describe ".expression?" do
       it "returns true for literals" do
-        str_node = Foxtail::Bundle::AST.str("hello")
-        num_node = Foxtail::Bundle::AST.num(42)
+        str_node = Foxtail::Bundle::AST::StringLiteral[value: "hello"]
+        num_node = Foxtail::Bundle::AST::NumberLiteral[value: 42]
         expect(Foxtail::Bundle::AST.expression?(str_node)).to be true
         expect(Foxtail::Bundle::AST.expression?(num_node)).to be true
       end
 
       it "returns true for variable references" do
-        node = Foxtail::Bundle::AST.var("name")
+        node = Foxtail::Bundle::AST::VariableReference[name: "name"]
         expect(Foxtail::Bundle::AST.expression?(node)).to be true
       end
 
       it "returns true for term references" do
-        node = Foxtail::Bundle::AST.term("brand")
+        node = Foxtail::Bundle::AST::TermReference[name: "brand"]
         expect(Foxtail::Bundle::AST.expression?(node)).to be true
       end
 
       it "returns true for message references" do
-        node = Foxtail::Bundle::AST.mesg("hello")
+        node = Foxtail::Bundle::AST::MessageReference[name: "hello"]
         expect(Foxtail::Bundle::AST.expression?(node)).to be true
       end
 
       it "returns true for function references" do
-        node = Foxtail::Bundle::AST.func("NUMBER")
+        node = Foxtail::Bundle::AST::FunctionReference[name: "NUMBER"]
         expect(Foxtail::Bundle::AST.expression?(node)).to be true
       end
 
       it "returns true for select expressions" do
-        selector = Foxtail::Bundle::AST.var("count")
-        variants = [Foxtail::Bundle::AST.variant(Foxtail::Bundle::AST.str("other"), "many")]
-        node = Foxtail::Bundle::AST.select(selector, variants)
+        selector = Foxtail::Bundle::AST::VariableReference[name: "count"]
+        variants = [Foxtail::Bundle::AST::Variant[key: Foxtail::Bundle::AST::StringLiteral[value: "other"], value: "many"]]
+        node = Foxtail::Bundle::AST::SelectExpression[selector:, variants:]
         expect(Foxtail::Bundle::AST.expression?(node)).to be true
       end
 
@@ -294,7 +300,7 @@ RSpec.describe Foxtail::Bundle::AST do
       end
 
       it "returns true for expressions" do
-        node = Foxtail::Bundle::AST.var("name")
+        node = Foxtail::Bundle::AST::VariableReference[name: "name"]
         expect(Foxtail::Bundle::AST.pattern_element?(node)).to be true
       end
 
@@ -308,7 +314,7 @@ RSpec.describe Foxtail::Bundle::AST do
       it "returns true for arrays of pattern elements" do
         pattern = [
           "Hello, ",
-          Foxtail::Bundle::AST.var("name"),
+          Foxtail::Bundle::AST::VariableReference[name: "name"],
           "!"
         ]
         expect(Foxtail::Bundle::AST.complex_pattern?(pattern)).to be true
@@ -331,7 +337,7 @@ RSpec.describe Foxtail::Bundle::AST do
       end
 
       it "returns true for complex patterns" do
-        pattern = ["Hello, ", Foxtail::Bundle::AST.var("name")]
+        pattern = ["Hello, ", Foxtail::Bundle::AST::VariableReference[name: "name"]]
         expect(Foxtail::Bundle::AST.pattern?(pattern)).to be true
       end
 

--- a/spec/foxtail/bundle/ast_spec.rb
+++ b/spec/foxtail/bundle/ast_spec.rb
@@ -4,29 +4,36 @@ RSpec.describe Foxtail::Bundle::AST do
   describe ".str" do
     it "creates a string literal node" do
       result = Foxtail::Bundle::AST.str("hello")
-      expect(result).to eq({type: "str", value: "hello"})
+      expect(result).to be_a(Foxtail::Bundle::AST::StringLiteral)
+      expect(result.type).to eq("str")
+      expect(result.value).to eq("hello")
     end
 
     it "converts non-string values to string" do
       result = Foxtail::Bundle::AST.str(42)
-      expect(result).to eq({type: "str", value: "42"})
+      expect(result.value).to eq("42")
     end
   end
 
   describe ".num" do
     it "creates a number literal node with default precision" do
       result = Foxtail::Bundle::AST.num(42.5)
-      expect(result).to eq({type: "num", value: 42.5, precision: 0})
+      expect(result).to be_a(Foxtail::Bundle::AST::NumberLiteral)
+      expect(result.type).to eq("num")
+      expect(result.value).to eq(42.5)
+      expect(result.precision).to eq(0)
     end
 
     it "converts string numbers to float" do
       result = Foxtail::Bundle::AST.num("42.5")
-      expect(result).to eq({type: "num", value: 42.5, precision: 0})
+      expect(result.value).to eq(42.5)
+      expect(result.precision).to eq(0)
     end
 
     it "includes precision when provided" do
       result = Foxtail::Bundle::AST.num(42.5, precision: 2)
-      expect(result).to eq({type: "num", value: 42.5, precision: 2})
+      expect(result.value).to eq(42.5)
+      expect(result.precision).to eq(2)
     end
 
     it "raises error when precision is nil" do
@@ -39,65 +46,83 @@ RSpec.describe Foxtail::Bundle::AST do
   describe ".var" do
     it "creates a variable reference node" do
       result = Foxtail::Bundle::AST.var("username")
-      expect(result).to eq({type: "var", name: "username"})
+      expect(result).to be_a(Foxtail::Bundle::AST::VariableReference)
+      expect(result.type).to eq("var")
+      expect(result.name).to eq("username")
     end
 
     it "converts non-string names to string" do
       result = Foxtail::Bundle::AST.var(:username)
-      expect(result).to eq({type: "var", name: "username"})
+      expect(result.name).to eq("username")
     end
   end
 
   describe ".term" do
     it "creates a term reference node" do
       result = Foxtail::Bundle::AST.term("brand")
-      expect(result).to eq({type: "term", name: "brand", attr: nil, args: []})
+      expect(result).to be_a(Foxtail::Bundle::AST::TermReference)
+      expect(result.type).to eq("term")
+      expect(result.name).to eq("brand")
+      expect(result.attr).to be_nil
+      expect(result.args).to eq([])
     end
 
     it "includes attribute when provided" do
       result = Foxtail::Bundle::AST.term("brand", attr: "title")
-      expect(result).to eq({type: "term", name: "brand", attr: "title", args: []})
+      expect(result.name).to eq("brand")
+      expect(result.attr).to eq("title")
+      expect(result.args).to eq([])
     end
 
     it "includes args when provided" do
       args = [Foxtail::Bundle::AST.str("value")]
       result = Foxtail::Bundle::AST.term("brand", args:)
-      expect(result).to eq({type: "term", name: "brand", attr: nil, args:})
+      expect(result.name).to eq("brand")
+      expect(result.attr).to be_nil
+      expect(result.args).to eq(args)
     end
 
     it "includes empty args array" do
       result = Foxtail::Bundle::AST.term("brand", args: [])
-      expect(result).to eq({type: "term", name: "brand", attr: nil, args: []})
+      expect(result.args).to eq([])
     end
   end
 
   describe ".mesg" do
     it "creates a message reference node" do
       result = Foxtail::Bundle::AST.mesg("hello")
-      expect(result).to eq({type: "mesg", name: "hello", attr: nil})
+      expect(result).to be_a(Foxtail::Bundle::AST::MessageReference)
+      expect(result.type).to eq("mesg")
+      expect(result.name).to eq("hello")
+      expect(result.attr).to be_nil
     end
 
     it "includes attribute when provided" do
       result = Foxtail::Bundle::AST.mesg("hello", attr: "title")
-      expect(result).to eq({type: "mesg", name: "hello", attr: "title"})
+      expect(result.name).to eq("hello")
+      expect(result.attr).to eq("title")
     end
   end
 
   describe ".func" do
     it "creates a function reference node" do
       result = Foxtail::Bundle::AST.func("NUMBER")
-      expect(result).to eq({type: "func", name: "NUMBER", args: []})
+      expect(result).to be_a(Foxtail::Bundle::AST::FunctionReference)
+      expect(result.type).to eq("func")
+      expect(result.name).to eq("NUMBER")
+      expect(result.args).to eq([])
     end
 
     it "includes args when provided" do
       args = [Foxtail::Bundle::AST.str("value")]
       result = Foxtail::Bundle::AST.func("NUMBER", args:)
-      expect(result).to eq({type: "func", name: "NUMBER", args:})
+      expect(result.name).to eq("NUMBER")
+      expect(result.args).to eq(args)
     end
 
     it "includes empty args array" do
       result = Foxtail::Bundle::AST.func("NUMBER", args: [])
-      expect(result).to eq({type: "func", name: "NUMBER", args: []})
+      expect(result.args).to eq([])
     end
   end
 
@@ -110,12 +135,11 @@ RSpec.describe Foxtail::Bundle::AST do
       ]
 
       result = Foxtail::Bundle::AST.select(selector, variants)
-      expect(result).to eq({
-        type: "select",
-        selector:,
-        variants:,
-        star: 0
-      })
+      expect(result).to be_a(Foxtail::Bundle::AST::SelectExpression)
+      expect(result.type).to eq("select")
+      expect(result.selector).to eq(selector)
+      expect(result.variants).to eq(variants)
+      expect(result.star).to eq(0)
     end
 
     it "accepts custom star index" do
@@ -123,12 +147,9 @@ RSpec.describe Foxtail::Bundle::AST do
       variants = [Foxtail::Bundle::AST.variant(Foxtail::Bundle::AST.str("other"), "many")]
 
       result = Foxtail::Bundle::AST.select(selector, variants, star: 1)
-      expect(result).to eq({
-        type: "select",
-        selector:,
-        variants:,
-        star: 1
-      })
+      expect(result.selector).to eq(selector)
+      expect(result.variants).to eq(variants)
+      expect(result.star).to eq(1)
     end
   end
 
@@ -138,31 +159,40 @@ RSpec.describe Foxtail::Bundle::AST do
       value = "single item"
 
       result = Foxtail::Bundle::AST.variant(key, value)
-      expect(result).to eq({key:, value:})
+      expect(result).to be_a(Foxtail::Bundle::AST::Variant)
+      expect(result.key).to eq(key)
+      expect(result.value).to eq(value)
     end
   end
 
   describe ".message" do
     it "creates a message node" do
       result = Foxtail::Bundle::AST.message("hello")
-      expect(result).to eq({type: "message", id: "hello"})
+      expect(result).to be_a(Foxtail::Bundle::AST::Message)
+      expect(result.type).to eq("message")
+      expect(result.id).to eq("hello")
+      expect(result.value).to be_nil
+      expect(result.attributes).to be_nil
     end
 
     it "includes value when provided" do
       value = "Hello world"
       result = Foxtail::Bundle::AST.message("hello", value:)
-      expect(result).to eq({type: "message", id: "hello", value:})
+      expect(result.id).to eq("hello")
+      expect(result.value).to eq(value)
     end
 
     it "includes attributes when provided" do
       attributes = {"title" => "Greeting"}
       result = Foxtail::Bundle::AST.message("hello", attributes:)
-      expect(result).to eq({type: "message", id: "hello", attributes:})
+      expect(result.id).to eq("hello")
+      expect(result.attributes).to eq(attributes)
     end
 
-    it "omits empty attributes hash" do
-      result = Foxtail::Bundle::AST.message("hello", attributes: {})
-      expect(result).to eq({type: "message", id: "hello"})
+    it "accepts nil attributes" do
+      result = Foxtail::Bundle::AST.message("hello", attributes: nil)
+      expect(result.id).to eq("hello")
+      expect(result.attributes).to be_nil
     end
   end
 
@@ -170,20 +200,26 @@ RSpec.describe Foxtail::Bundle::AST do
     it "creates a term definition node" do
       value = "Firefox"
       result = Foxtail::Bundle::AST.term_def("brand", value)
-      expect(result).to eq({type: "term", id: "-brand", value:})
+      expect(result).to be_a(Foxtail::Bundle::AST::Term)
+      expect(result.type).to eq("term")
+      expect(result.id).to eq("-brand")
+      expect(result.value).to eq(value)
     end
 
     it "includes attributes when provided" do
       value = "Firefox"
       attributes = {"case" => "nominative"}
       result = Foxtail::Bundle::AST.term_def("brand", value, attributes:)
-      expect(result).to eq({type: "term", id: "-brand", value:, attributes:})
+      expect(result.id).to eq("-brand")
+      expect(result.value).to eq(value)
+      expect(result.attributes).to eq(attributes)
     end
 
-    it "omits empty attributes hash" do
+    it "accepts nil attributes" do
       value = "Firefox"
-      result = Foxtail::Bundle::AST.term_def("brand", value, attributes: {})
-      expect(result).to eq({type: "term", id: "-brand", value:})
+      result = Foxtail::Bundle::AST.term_def("brand", value, attributes: nil)
+      expect(result.id).to eq("-brand")
+      expect(result.attributes).to be_nil
     end
   end
 
@@ -204,7 +240,7 @@ RSpec.describe Foxtail::Bundle::AST do
         expect(Foxtail::Bundle::AST.literal?(node)).to be false
       end
 
-      it "returns false for non-hash values" do
+      it "returns false for non-Data values" do
         expect(Foxtail::Bundle::AST.literal?("string")).to be false
         expect(Foxtail::Bundle::AST.literal?(42)).to be false
       end
@@ -248,7 +284,7 @@ RSpec.describe Foxtail::Bundle::AST do
       it "returns false for non-expressions" do
         expect(Foxtail::Bundle::AST.expression?("string")).to be false
         expect(Foxtail::Bundle::AST.expression?(42)).to be false
-        expect(Foxtail::Bundle::AST.expression?({type: "unknown"})).to be false
+        expect(Foxtail::Bundle::AST.expression?({})).to be false
       end
     end
 
@@ -264,7 +300,7 @@ RSpec.describe Foxtail::Bundle::AST do
 
       it "returns false for non-pattern elements" do
         expect(Foxtail::Bundle::AST.pattern_element?(42)).to be false
-        expect(Foxtail::Bundle::AST.pattern_element?({type: "unknown"})).to be false
+        expect(Foxtail::Bundle::AST.pattern_element?({})).to be false
       end
     end
 
@@ -301,7 +337,7 @@ RSpec.describe Foxtail::Bundle::AST do
 
       it "returns false for non-patterns" do
         expect(Foxtail::Bundle::AST.pattern?(42)).to be false
-        expect(Foxtail::Bundle::AST.pattern?({type: "unknown"})).to be false
+        expect(Foxtail::Bundle::AST.pattern?({})).to be false
       end
     end
   end

--- a/spec/foxtail/bundle/resolver_spec.rb
+++ b/spec/foxtail/bundle/resolver_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe Foxtail::Bundle::Resolver do
     end
 
     it "resolves array patterns" do
-      pattern = ["Hello, ", {type: "var", name: "name"}, "!"]
+      pattern = ["Hello, ", Foxtail::Bundle::AST.var("name"), "!"]
       result = resolver.resolve_pattern(pattern, scope)
       expect(result).to eq("Hello, World!")
     end
 
     it "resolves single expression patterns" do
-      pattern = {type: "var", name: "name"}
+      pattern = Foxtail::Bundle::AST.var("name")
       result = resolver.resolve_pattern(pattern, scope)
       expect(result).to eq("World")
     end
@@ -37,41 +37,42 @@ RSpec.describe Foxtail::Bundle::Resolver do
 
   describe "#resolve_expression" do
     it "resolves string literals" do
-      expr = {type: "str", value: "hello"}
+      expr = Foxtail::Bundle::AST.str("hello")
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("hello")
     end
 
     it "resolves number literals" do
-      expr = {type: "num", value: 42.5}
+      expr = Foxtail::Bundle::AST.num(42.5)
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq(42.5)
     end
 
     it "resolves number literals with precision" do
-      expr = {type: "num", value: 42.567, precision: 2}
+      expr = Foxtail::Bundle::AST.num(42.567, precision: 2)
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq(42.567)
     end
 
     it "resolves variable references" do
-      expr = {type: "var", name: "name"}
+      expr = Foxtail::Bundle::AST.var("name")
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("World")
     end
 
     it "handles missing variables" do
-      expr = {type: "var", name: "missing"}
+      expr = Foxtail::Bundle::AST.var("missing")
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("{$missing}")
       expect(scope.errors).to include("Unknown variable: $missing")
     end
 
     it "handles unknown expression types" do
-      expr = {type: "unknown", value: "test"}
-      result = resolver.resolve_expression(expr, scope)
-      expect(result).to eq("{unknown}")
-      expect(scope.errors).to include("Unknown expression type: unknown")
+      # Create a mock object that isn't a known expression type
+      unknown_expr = Object.new
+      result = resolver.resolve_expression(unknown_expr, scope)
+      expect(result).to include("Object")
+      expect(scope.errors.any? {|e| e.include?("Unknown expression type") }).to be true
     end
   end
 
@@ -82,13 +83,13 @@ RSpec.describe Foxtail::Bundle::Resolver do
     before { bundle.add_resource(resource) }
 
     it "resolves term references" do
-      expr = {type: "term", name: "brand"}
+      expr = Foxtail::Bundle::AST.term("brand")
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("Firefox")
     end
 
     it "handles missing terms" do
-      expr = {type: "term", name: "missing"}
+      expr = Foxtail::Bundle::AST.term("missing")
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("{-missing}")
       expect(scope.errors).to include("Unknown term: -missing")
@@ -101,7 +102,7 @@ RSpec.describe Foxtail::Bundle::Resolver do
       bundle.add_resource(resource_a, allow_overrides: true)
       bundle.add_resource(resource_b, allow_overrides: true)
 
-      expr = {type: "term", name: "a"}
+      expr = Foxtail::Bundle::AST.term("a")
       result = resolver.resolve_expression(expr, scope)
       # Should return the circular reference fallback
       expect(result).to match(/\{-[ab]\}/)
@@ -116,13 +117,13 @@ RSpec.describe Foxtail::Bundle::Resolver do
     before { bundle.add_resource(resource) }
 
     it "resolves message references" do
-      expr = {type: "mesg", name: "hello"}
+      expr = Foxtail::Bundle::AST.mesg("hello")
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("Hello world")
     end
 
     it "handles missing messages" do
-      expr = {type: "mesg", name: "missing"}
+      expr = Foxtail::Bundle::AST.mesg("missing")
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("{missing}")
       expect(scope.errors).to include("Unknown message: missing")
@@ -135,13 +136,13 @@ RSpec.describe Foxtail::Bundle::Resolver do
     let(:resolver_with_func) { Foxtail::Bundle::Resolver.new(bundle_with_func) }
 
     it "resolves function calls" do
-      expr = {type: "func", name: "TEST", args: [{type: "str", value: "input"}]}
+      expr = Foxtail::Bundle::AST.func("TEST", args: [Foxtail::Bundle::AST.str("input")])
       result = resolver_with_func.resolve_expression(expr, scope)
       expect(result).to eq("Function result: input")
     end
 
     it "handles missing functions" do
-      expr = {type: "func", name: "MISSING", args: []}
+      expr = Foxtail::Bundle::AST.func("MISSING", args: [])
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("{MISSING()}")
       expect(scope.errors).to include("Unknown function: MISSING")
@@ -152,7 +153,7 @@ RSpec.describe Foxtail::Bundle::Resolver do
       bundle_with_error = Foxtail::Bundle.new(locale("en"), functions: {"ERROR" => error_function})
       resolver_with_error = Foxtail::Bundle::Resolver.new(bundle_with_error)
 
-      expr = {type: "func", name: "ERROR", args: []}
+      expr = Foxtail::Bundle::AST.func("ERROR", args: [])
       result = resolver_with_error.resolve_expression(expr, scope)
       expect(result).to eq("{ERROR()}")
       expect(scope.errors).to include("Function error in ERROR: Test error")
@@ -163,15 +164,11 @@ RSpec.describe Foxtail::Bundle::Resolver do
       bundle_with_options = Foxtail::Bundle.new(locale("en"), functions: {"FORMAT" => options_function})
       resolver_with_options = Foxtail::Bundle::Resolver.new(bundle_with_options)
 
-      expr = {
-        type: "func",
-        name: "FORMAT",
-        args: [
-          {type: "num", value: 42.5},
-          {type: "narg", name: "style", value: {type: "str", value: "currency"}},
-          {type: "narg", name: "minimumFractionDigits", value: {type: "num", value: 2.0}}
-        ]
-      }
+      expr = Foxtail::Bundle::AST.func("FORMAT", args: [
+        Foxtail::Bundle::AST.num(42.5),
+        Foxtail::Bundle::AST.narg("style", Foxtail::Bundle::AST.str("currency")),
+        Foxtail::Bundle::AST.narg("minimumFractionDigits", Foxtail::Bundle::AST.num(2.0))
+      ])
 
       result = resolver_with_options.resolve_expression(expr, scope)
       expect(result).to include("42.5")
@@ -183,14 +180,10 @@ RSpec.describe Foxtail::Bundle::Resolver do
 
     it "resolves NUMBER function calls with named arguments" do
       # Test with actual NUMBER function
-      expr = {
-        type: "func",
-        name: "NUMBER",
-        args: [
-          {type: "num", value: 1234.56},
-          {type: "narg", name: "minimumFractionDigits", value: {type: "num", value: 2.0}}
-        ]
-      }
+      expr = Foxtail::Bundle::AST.func("NUMBER", args: [
+        Foxtail::Bundle::AST.num(1234.56),
+        Foxtail::Bundle::AST.narg("minimumFractionDigits", Foxtail::Bundle::AST.num(2.0))
+      ])
 
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("1,234.56") # Should format with 2 decimal places (with locale formatting)
@@ -199,14 +192,10 @@ RSpec.describe Foxtail::Bundle::Resolver do
     it "resolves DATETIME function calls with named arguments" do
       skip "ICU4X requires date_style or time_style; component-only formatting (year: numeric) is not supported"
       # Test with actual DATETIME function
-      expr = {
-        type: "func",
-        name: "DATETIME",
-        args: [
-          {type: "var", name: "date"},
-          {type: "narg", name: "year", value: {type: "str", value: "numeric"}}
-        ]
-      }
+      expr = Foxtail::Bundle::AST.func("DATETIME", args: [
+        Foxtail::Bundle::AST.var("date"),
+        Foxtail::Bundle::AST.narg("year", Foxtail::Bundle::AST.str("numeric"))
+      ])
 
       test_date = Time.new(2023, 6, 15)
       scope_with_date = Foxtail::Bundle::Scope.new(bundle, date: test_date)
@@ -218,48 +207,45 @@ RSpec.describe Foxtail::Bundle::Resolver do
 
   describe "#resolve_select_expression" do
     it "resolves select expressions with number matching" do
-      expr = {
-        type: "select",
-        selector: {type: "var", name: "count"},
-        variants: [
-          {key: {type: "num", value: 0}, value: "none"},
-          {key: {type: "num", value: 5}, value: "five"},
-          {key: {type: "str", value: "other"}, value: "many"}
+      expr = Foxtail::Bundle::AST.select(
+        Foxtail::Bundle::AST.var("count"),
+        [
+          Foxtail::Bundle::AST.variant(Foxtail::Bundle::AST.num(0), "none"),
+          Foxtail::Bundle::AST.variant(Foxtail::Bundle::AST.num(5), "five"),
+          Foxtail::Bundle::AST.variant(Foxtail::Bundle::AST.str("other"), "many")
         ],
         star: 2
-      }
+      )
 
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("five")
     end
 
     it "uses default variant when no match" do
-      expr = {
-        type: "select",
-        selector: {type: "var", name: "count"},
-        variants: [
-          {key: {type: "num", value: 0}, value: "none"},
-          {key: {type: "str", value: "other"}, value: "many"}
+      expr = Foxtail::Bundle::AST.select(
+        Foxtail::Bundle::AST.var("count"),
+        [
+          Foxtail::Bundle::AST.variant(Foxtail::Bundle::AST.num(0), "none"),
+          Foxtail::Bundle::AST.variant(Foxtail::Bundle::AST.str("other"), "many")
         ],
         star: 1
-      }
+      )
 
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("many")
     end
 
     it "resolves complex variant values" do
-      expr = {
-        type: "select",
-        selector: {type: "var", name: "count"},
-        variants: [
-          {
-            key: {type: "num", value: 5},
-            value: ["You have ", {type: "var", name: "count"}, " items"]
-          }
+      expr = Foxtail::Bundle::AST.select(
+        Foxtail::Bundle::AST.var("count"),
+        [
+          Foxtail::Bundle::AST.variant(
+            Foxtail::Bundle::AST.num(5),
+            ["You have ", Foxtail::Bundle::AST.var("count"), " items"]
+          )
         ],
         star: 0
-      }
+      )
 
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("You have 5 items")
@@ -280,19 +266,19 @@ RSpec.describe Foxtail::Bundle::Resolver do
     before { bundle.add_resource(resource) }
 
     it "resolves message attributes" do
-      expr = {type: "mesg", name: "hello", attr: "title"}
+      expr = Foxtail::Bundle::AST.mesg("hello", attr: "title")
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("Greeting")
     end
 
     it "resolves term attributes" do
-      expr = {type: "term", name: "brand", attr: "version"}
+      expr = Foxtail::Bundle::AST.term("brand", attr: "version")
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("89.0")
     end
 
     it "handles missing attributes" do
-      expr = {type: "mesg", name: "hello", attr: "missing"}
+      expr = Foxtail::Bundle::AST.mesg("hello", attr: "missing")
       result = resolver.resolve_expression(expr, scope)
       expect(result).to eq("{hello.missing}")
       expect(scope.errors).to include("Unknown message attribute: hello.missing")
@@ -302,15 +288,14 @@ RSpec.describe Foxtail::Bundle::Resolver do
   describe "plural category matching" do
     it "matches plural categories using ICU4X plural rules" do
       # Test English plural rules (1 is "one", others are "other")
-      expr = {
-        type: "select",
-        selector: {type: "var", name: "count"},
-        variants: [
-          {key: {type: "str", value: "one"}, value: "one item"},
-          {key: {type: "str", value: "other"}, value: "many items"}
+      expr = Foxtail::Bundle::AST.select(
+        Foxtail::Bundle::AST.var("count"),
+        [
+          Foxtail::Bundle::AST.variant(Foxtail::Bundle::AST.str("one"), "one item"),
+          Foxtail::Bundle::AST.variant(Foxtail::Bundle::AST.str("other"), "many items")
         ],
         star: 1
-      }
+      )
 
       # Test count = 1 (should match "one")
       scope_with_one = Foxtail::Bundle::Scope.new(bundle, count: 1)
@@ -324,16 +309,15 @@ RSpec.describe Foxtail::Bundle::Resolver do
     end
 
     it "handles numeric selectors with string variants" do
-      expr = {
-        type: "select",
-        selector: {type: "var", name: "count"},
-        variants: [
-          {key: {type: "num", value: 0}, value: "no items"},
-          {key: {type: "str", value: "one"}, value: "one item"},
-          {key: {type: "str", value: "other"}, value: "many items"}
+      expr = Foxtail::Bundle::AST.select(
+        Foxtail::Bundle::AST.var("count"),
+        [
+          Foxtail::Bundle::AST.variant(Foxtail::Bundle::AST.num(0), "no items"),
+          Foxtail::Bundle::AST.variant(Foxtail::Bundle::AST.str("one"), "one item"),
+          Foxtail::Bundle::AST.variant(Foxtail::Bundle::AST.str("other"), "many items")
         ],
         star: 2
-      }
+      )
 
       # Exact numeric match should take precedence
       scope_with_zero = Foxtail::Bundle::Scope.new(bundle, count: 0)
@@ -352,15 +336,14 @@ RSpec.describe Foxtail::Bundle::Resolver do
       allow(ICU4X::PluralRules).to receive(:new).and_return(plural_rules_double)
       allow(plural_rules_double).to receive(:select).and_raise("Error")
 
-      expr = {
-        type: "select",
-        selector: {type: "var", name: "count"},
-        variants: [
-          {key: {type: "str", value: "one"}, value: "one item"},
-          {key: {type: "str", value: "other"}, value: "many items"}
+      expr = Foxtail::Bundle::AST.select(
+        Foxtail::Bundle::AST.var("count"),
+        [
+          Foxtail::Bundle::AST.variant(Foxtail::Bundle::AST.str("one"), "one item"),
+          Foxtail::Bundle::AST.variant(Foxtail::Bundle::AST.str("other"), "many items")
         ],
         star: 1
-      }
+      )
 
       scope_with_one = Foxtail::Bundle::Scope.new(bundle, count: 1)
       result = resolver.resolve_expression(expr, scope_with_one)

--- a/spec/foxtail/bundle_spec.rb
+++ b/spec/foxtail/bundle_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Foxtail::Bundle do
 
       # Should still have original message
       message = bundle.message("hello")
-      expect(message[:value]).to be_an(Array) # Original complex pattern
+      expect(message.value).to be_an(Array) # Original complex pattern
     end
 
     it "allows overrides when specified" do
@@ -104,7 +104,7 @@ RSpec.describe Foxtail::Bundle do
 
       # Should have new message
       message = bundle.message("hello")
-      expect(message[:value]).to eq("Different message")
+      expect(message.value).to eq("Different message")
     end
   end
 
@@ -121,9 +121,9 @@ RSpec.describe Foxtail::Bundle do
 
     it "retrieves messages" do
       message = bundle.message("hello")
-      expect(message).to be_a(Hash)
-      expect(message[:id]).to eq("hello")
-      expect(message[:attributes]).to be_nil
+      expect(message).to be_a(Foxtail::Bundle::AST::Message)
+      expect(message.id).to eq("hello")
+      expect(message.attributes).to be_nil
     end
 
     it "returns nil for nonexistent messages" do
@@ -149,9 +149,9 @@ RSpec.describe Foxtail::Bundle do
 
     it "retrieves terms" do
       term = bundle.term("-brand")
-      expect(term).to be_a(Hash)
-      expect(term[:id]).to eq("-brand")
-      expect(term[:attributes]).to be_nil
+      expect(term).to be_a(Foxtail::Bundle::AST::Term)
+      expect(term.id).to eq("-brand")
+      expect(term.attributes).to be_nil
     end
 
     it "returns nil for nonexistent terms" do
@@ -253,13 +253,13 @@ RSpec.describe Foxtail::Bundle do
     end
 
     it "formats array patterns" do
-      pattern = ["Hello, ", {type: "var", name: "name"}, "!"]
+      pattern = ["Hello, ", Foxtail::Bundle::AST.var("name"), "!"]
       result = bundle.format_pattern(pattern, name: "World")
       expect(result).to eq("Hello, World!")
     end
 
     it "collects errors when provided" do
-      pattern = [{type: "var", name: "missing"}]
+      pattern = [Foxtail::Bundle::AST.var("missing")]
       errors = []
       result = bundle.format_pattern(pattern, errors:)
 

--- a/spec/foxtail/bundle_spec.rb
+++ b/spec/foxtail/bundle_spec.rb
@@ -253,13 +253,13 @@ RSpec.describe Foxtail::Bundle do
     end
 
     it "formats array patterns" do
-      pattern = ["Hello, ", Foxtail::Bundle::AST.var("name"), "!"]
+      pattern = ["Hello, ", Foxtail::Bundle::AST::VariableReference[name: "name"], "!"]
       result = bundle.format_pattern(pattern, name: "World")
       expect(result).to eq("Hello, World!")
     end
 
     it "collects errors when provided" do
-      pattern = [Foxtail::Bundle::AST.var("missing")]
+      pattern = [Foxtail::Bundle::AST::VariableReference[name: "missing"]]
       errors = []
       result = bundle.format_pattern(pattern, errors:)
 

--- a/spec/foxtail/resource_spec.rb
+++ b/spec/foxtail/resource_spec.rb
@@ -25,23 +25,23 @@ RSpec.describe Foxtail::Resource do
       resource = Foxtail::Resource.from_string(ftl_source)
 
       hello_msg = resource.entries[0]
-      expect(hello_msg[:type]).to eq("message")
-      expect(hello_msg[:id]).to eq("hello")
-      expect(hello_msg[:value]).to be_an(Array)
+      expect(hello_msg.type).to eq("message")
+      expect(hello_msg.id).to eq("hello")
+      expect(hello_msg.value).to be_an(Array)
 
       goodbye_msg = resource.entries[2]
-      expect(goodbye_msg[:type]).to eq("message")
-      expect(goodbye_msg[:id]).to eq("goodbye")
-      expect(goodbye_msg[:value]).to eq("Goodbye world")
+      expect(goodbye_msg.type).to eq("message")
+      expect(goodbye_msg.id).to eq("goodbye")
+      expect(goodbye_msg.value).to eq("Goodbye world")
     end
 
     it "creates proper term entries" do
       resource = Foxtail::Resource.from_string(ftl_source)
 
       brand_term = resource.entries[1]
-      expect(brand_term[:type]).to eq("term")
-      expect(brand_term[:id]).to eq("-brand")
-      expect(brand_term[:value]).to eq("Firefox")
+      expect(brand_term.type).to eq("term")
+      expect(brand_term.id).to eq("-brand")
+      expect(brand_term.value).to eq("Firefox")
     end
 
     it "accepts converter options" do
@@ -68,8 +68,8 @@ RSpec.describe Foxtail::Resource do
       resource = Foxtail::Resource.from_file(Pathname(temp_file.path))
 
       expect(resource.entries.size).to eq(1)
-      expect(resource.entries.first[:id]).to eq("test")
-      expect(resource.entries.first[:value]).to eq("Test message")
+      expect(resource.entries.first.id).to eq("test")
+      expect(resource.entries.first.value).to eq("Test message")
     end
 
     it "handles file encoding properly" do
@@ -118,7 +118,7 @@ RSpec.describe Foxtail::Resource do
 
     describe "Enumerable" do
       it "includes Enumerable and provides map functionality" do
-        yielded_ids = resource.map {|entry| entry[:id] }
+        yielded_ids = resource.map(&:id)
         expect(yielded_ids).to eq(["hello", "-brand", "goodbye", "-company"])
       end
     end
@@ -127,8 +127,8 @@ RSpec.describe Foxtail::Resource do
       it "returns only message entries" do
         messages = resource.messages
         expect(messages.size).to eq(2)
-        expect(messages.map {|m| m[:id] }).to eq(%w[hello goodbye])
-        expect(messages.all? {|m| m[:type] == "message" }).to be true
+        expect(messages.map(&:id)).to eq(%w[hello goodbye])
+        expect(messages.all? {|m| m.type == "message" }).to be true
       end
     end
 
@@ -136,22 +136,22 @@ RSpec.describe Foxtail::Resource do
       it "returns only term entries" do
         terms = resource.terms
         expect(terms.size).to eq(2)
-        expect(terms.map {|t| t[:id] }).to eq(["-brand", "-company"])
-        expect(terms.all? {|t| t[:type] == "term" }).to be true
+        expect(terms.map(&:id)).to eq(["-brand", "-company"])
+        expect(terms.all? {|t| t.type == "term" }).to be true
       end
     end
 
     describe "#find" do
       it "finds entry by ID" do
         entry = resource.find("hello")
-        expect(entry[:type]).to eq("message")
-        expect(entry[:id]).to eq("hello")
+        expect(entry.type).to eq("message")
+        expect(entry.id).to eq("hello")
       end
 
       it "finds term entry by ID" do
         entry = resource.find("-brand")
-        expect(entry[:type]).to eq("term")
-        expect(entry[:id]).to eq("-brand")
+        expect(entry.type).to eq("term")
+        expect(entry.id).to eq("-brand")
       end
 
       it "returns nil when entry not found" do

--- a/spec/foxtail/resource_spec.rb
+++ b/spec/foxtail/resource_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe Foxtail::Resource do
       resource = Foxtail::Resource.from_string(ftl_source)
 
       hello_msg = resource.entries[0]
-      expect(hello_msg.type).to eq("message")
+      expect(hello_msg).to be_a(Foxtail::Bundle::AST::Message)
       expect(hello_msg.id).to eq("hello")
       expect(hello_msg.value).to be_an(Array)
 
       goodbye_msg = resource.entries[2]
-      expect(goodbye_msg.type).to eq("message")
+      expect(goodbye_msg).to be_a(Foxtail::Bundle::AST::Message)
       expect(goodbye_msg.id).to eq("goodbye")
       expect(goodbye_msg.value).to eq("Goodbye world")
     end
@@ -39,7 +39,7 @@ RSpec.describe Foxtail::Resource do
       resource = Foxtail::Resource.from_string(ftl_source)
 
       brand_term = resource.entries[1]
-      expect(brand_term.type).to eq("term")
+      expect(brand_term).to be_a(Foxtail::Bundle::AST::Term)
       expect(brand_term.id).to eq("-brand")
       expect(brand_term.value).to eq("Firefox")
     end
@@ -128,7 +128,7 @@ RSpec.describe Foxtail::Resource do
         messages = resource.messages
         expect(messages.size).to eq(2)
         expect(messages.map(&:id)).to eq(%w[hello goodbye])
-        expect(messages.all? {|m| m.type == "message" }).to be true
+        expect(messages.all?(Foxtail::Bundle::AST::Message)).to be true
       end
     end
 
@@ -137,20 +137,20 @@ RSpec.describe Foxtail::Resource do
         terms = resource.terms
         expect(terms.size).to eq(2)
         expect(terms.map(&:id)).to eq(["-brand", "-company"])
-        expect(terms.all? {|t| t.type == "term" }).to be true
+        expect(terms.all?(Foxtail::Bundle::AST::Term)).to be true
       end
     end
 
     describe "#find" do
       it "finds entry by ID" do
         entry = resource.find("hello")
-        expect(entry.type).to eq("message")
+        expect(entry).to be_a(Foxtail::Bundle::AST::Message)
         expect(entry.id).to eq("hello")
       end
 
       it "finds term entry by ID" do
         entry = resource.find("-brand")
-        expect(entry.type).to eq("term")
+        expect(entry).to be_a(Foxtail::Bundle::AST::Term)
         expect(entry.id).to eq("-brand")
       end
 


### PR DESCRIPTION
## Summary
Refactor Bundle::AST from Hash-based structures to Ruby Data classes with initialize overrides for cleaner, more idiomatic code.

## Changes
- Convert AST nodes from Hash to Data classes with type-safe initialization
- Replace factory methods with direct Data class instantiation using `[]` syntax
- Use initialize overrides for default values, type conversions, and Term `-` prefix

## Test Plan
- All 237 specs pass
- README examples verified working
- fluent.js compatibility maintained at 97/98 (99.0%)
