### PR TITLE
:sparkles: Add Junk and Comment Data classes

### DIFF
--- a/lib/foxtail/bundle/ast.rb
+++ b/lib/foxtail/bundle/ast.rb
@@ -126,6 +126,15 @@ module Foxtail
         end
       end
 
+      # Junk entry for unparseable content
+      # @!attribute content [r] [String] The raw unparseable content
+      # @!attribute annotations [r] [Array<Hash>] Parser annotations/errors
+      Junk = Data.define(:content, :annotations)
+
+      # Comment entry for FTL comments
+      # @!attribute content [r] [String] The comment text
+      Comment = Data.define(:content)
+
       # Type checking helpers (following TypeScript union types)
 
       # Check if node is a literal (string or number)

--- a/lib/foxtail/bundle/ast_converter.rb
+++ b/lib/foxtail/bundle/ast_converter.rb
@@ -306,20 +306,12 @@ module Foxtail
 
       # Handle junk entries
       private def handle_junk(junk)
-        @errors << {
-          type: "junk",
-          content: junk.content,
-          annotations: junk.annotations.map(&:to_h)
-        }
+        @errors << AST::Junk[content: junk.content, annotations: junk.annotations.map(&:to_h)]
       end
 
       # Handle comment entries
       private def handle_comment(comment)
-        # Could be used for debugging or metadata
-        @errors << {
-          type: "comment",
-          content: comment.content
-        }
+        @errors << AST::Comment[content: comment.content]
       end
     end
   end


### PR DESCRIPTION
## Summary
- Add `AST::Junk` Data class for unparseable content with annotations
- Add `AST::Comment` Data class for FTL comment entries
- Update `ASTConverter` to use Data classes instead of Hashes

## Test Plan
- All 237 specs pass
- RuboCop shows no offenses