### PR TITLE
:sparkles: Add Sequence class for language fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ A Ruby implementation of [Project Fluent](https://projectfluent.org/) - a modern
 | Architecture & design | [doc/architecture.md](doc/architecture.md) |
 | FTL syntax support | [doc/ftl-syntax.md](doc/ftl-syntax.md) |
 | Bundle system details | [doc/bundle-system.md](doc/bundle-system.md) |
+| Language fallback | [doc/sequence.md](doc/sequence.md) |
 | `icu4x` integration | [doc/icu4x-integration.md](doc/icu4x-integration.md) |
 | Testing strategy | [doc/testing.md](doc/testing.md) |
 

--- a/doc/sequence.md
+++ b/doc/sequence.md
@@ -1,0 +1,131 @@
+# Language Fallback with Sequence
+
+## Overview
+
+`Foxtail::Sequence` manages ordered sequences of Bundles for language fallback. It finds the first bundle that contains a requested message, enabling fallback chains like `en-US` → `en` → default.
+
+Equivalent to [@fluent/sequence](https://projectfluent.org/fluent.js/sequence/) in fluent.js.
+
+## Basic Usage
+
+```ruby
+# Create bundles for different locales
+en_us = Foxtail::Bundle.new(ICU4X::Locale.parse("en-US"))
+en_us.add_resource(Foxtail::Resource.from_string("hello = Hello!"))
+
+en = Foxtail::Bundle.new(ICU4X::Locale.parse("en"))
+en.add_resource(Foxtail::Resource.from_string("hello = Hello!"))
+
+ja = Foxtail::Bundle.new(ICU4X::Locale.parse("ja"))
+ja.add_resource(Foxtail::Resource.from_string("hello = こんにちは！"))
+
+# Create sequence in priority order
+sequence = Foxtail::Sequence.new(en_us, en, ja)
+
+# Format uses first matching bundle
+sequence.format("hello")  # => "Hello!"
+```
+
+## Language Fallback
+
+When a message is not found in the primary bundle, Sequence automatically falls back to the next bundle:
+
+```ruby
+en_us.add_resource(Foxtail::Resource.from_string("us-only = US English"))
+en.add_resource(Foxtail::Resource.from_string("en-only = English"))
+ja.add_resource(Foxtail::Resource.from_string("ja-only = 日本語"))
+
+sequence = Foxtail::Sequence.new(en_us, en, ja)
+
+sequence.format("us-only")  # => "US English" (from en_us)
+sequence.format("en-only")  # => "English" (from en, en_us doesn't have it)
+sequence.format("ja-only")  # => "日本語" (from ja)
+```
+
+## Finding Bundles
+
+Use `find` when you need to know which bundle contains a message:
+
+```ruby
+bundle = sequence.find("hello")
+if bundle
+  puts "Found in locale: #{bundle.locale}"
+  bundle.format("hello", name: "World")
+end
+```
+
+### Multiple IDs
+
+Find bundles for multiple IDs at once:
+
+```ruby
+bundles = sequence.find("hello", "goodbye", "thanks")
+# => [bundle_for_hello, bundle_for_goodbye, bundle_for_thanks]
+# nil for IDs not found in any bundle
+```
+
+## API Reference
+
+### `Sequence.new(*bundles)`
+
+Creates a new Sequence with bundles in priority order.
+
+```ruby
+sequence = Foxtail::Sequence.new(primary, fallback1, fallback2)
+
+# Also accepts an array
+sequence = Foxtail::Sequence.new(bundle_array)
+```
+
+### `#find(*ids)`
+
+Finds the first bundle containing each message ID.
+
+| Arguments | Return |
+|-----------|--------|
+| Single ID | `Bundle` or `nil` |
+| Multiple IDs | `Array<Bundle, nil>` |
+
+```ruby
+sequence.find("hello")           # => Bundle or nil
+sequence.find("a", "b", "c")     # => [Bundle, nil, Bundle]
+```
+
+### `#format(id, **kwargs)`
+
+Formats a message using the first matching bundle.
+
+```ruby
+sequence.format("hello", name: "World")
+# => "Hello, World!"
+
+sequence.format("nonexistent")
+# => "nonexistent" (returns ID if not found)
+```
+
+Same signature as `Bundle#format` for duck-typing compatibility.
+
+## Use Cases
+
+### User Preference Chains
+
+```ruby
+# User prefers Japanese, falls back to English
+user_bundles = [bundle_ja, bundle_en]
+sequence = Foxtail::Sequence.new(user_bundles)
+```
+
+### Regional Variants
+
+```ruby
+# British English → Generic English → Default
+sequence = Foxtail::Sequence.new(bundle_en_gb, bundle_en, bundle_default)
+```
+
+### Partial Translations
+
+```ruby
+# New locale with incomplete translations
+# Falls back to complete locale
+sequence = Foxtail::Sequence.new(bundle_new_locale, bundle_complete_locale)
+```

--- a/lib/foxtail/sequence.rb
+++ b/lib/foxtail/sequence.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Foxtail
+  # Manages ordered sequences of Bundles for language fallback.
+  #
+  # @example Basic usage
+  #   sequence = Foxtail::Sequence.new(bundle_en_us, bundle_en, bundle_default)
+  #   sequence.format("hello", name: "World")
+  #
+  # @example Finding the bundle that contains a message
+  #   bundle = sequence.find("hello")
+  #   puts "Using locale: #{bundle.locale}" if bundle
+  #
+  # @see https://projectfluent.org/fluent.js/sequence/
+  class Sequence
+    # Creates a new Sequence with the given bundles.
+    #
+    # @param bundles [Array<Bundle>] Bundles in priority order (first = highest priority)
+    def initialize(*bundles)
+      @bundles = bundles.flatten.freeze
+    end
+
+    # Finds the first bundle that contains a message with the given ID(s).
+    #
+    # @param ids [Array<String>] One or more message IDs to find
+    # @return [Bundle, nil] The first bundle containing the message (single ID)
+    # @return [Array<Bundle, nil>] Array of bundles for each ID (multiple IDs)
+    def find(*ids)
+      if ids.size == 1
+        find_bundle(ids.first)
+      else
+        ids.map {|id| find_bundle(id) }
+      end
+    end
+
+    # Formats a message using the first bundle that contains it.
+    #
+    # @param id [String] The message ID
+    # @param kwargs [Hash] Variables to pass to the message
+    # @return [String] The formatted message, or the ID if not found
+    def format(id, **)
+      bundle = find_bundle(id)
+      bundle ? bundle.format(id, **) : id.to_s
+    end
+
+    private def find_bundle(id) = @bundles.find {|bundle| bundle.message?(id) }
+  end
+end

--- a/spec/foxtail/sequence_spec.rb
+++ b/spec/foxtail/sequence_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+RSpec.describe Foxtail::Sequence do
+  let(:en_us_locale) { ICU4X::Locale.parse("en-US") }
+  let(:en_locale) { ICU4X::Locale.parse("en") }
+  let(:ja_locale) { ICU4X::Locale.parse("ja") }
+
+  let(:en_us_bundle) do
+    bundle = Foxtail::Bundle.new(en_us_locale)
+    resource = Foxtail::Resource.from_string(<<~FTL)
+      hello = Hello, {$name}!
+      us-only = US English only
+    FTL
+    bundle.add_resource(resource)
+    bundle
+  end
+
+  let(:en_bundle) do
+    bundle = Foxtail::Bundle.new(en_locale)
+    resource = Foxtail::Resource.from_string(<<~FTL)
+      hello = Hello, {$name}!
+      en-only = English only
+    FTL
+    bundle.add_resource(resource)
+    bundle
+  end
+
+  let(:ja_bundle) do
+    bundle = Foxtail::Bundle.new(ja_locale)
+    resource = Foxtail::Resource.from_string(<<~FTL)
+      hello = こんにちは、{$name}さん！
+      ja-only = 日本語のみ
+    FTL
+    bundle.add_resource(resource)
+    bundle
+  end
+
+  let(:sequence) { Foxtail::Sequence.new(en_us_bundle, en_bundle, ja_bundle) }
+
+  describe "#find" do
+    context "with single ID" do
+      it "returns the first bundle containing the message" do
+        expect(sequence.find("hello")).to eq(en_us_bundle)
+      end
+
+      it "returns nil when message is not found" do
+        expect(sequence.find("nonexistent")).to be_nil
+      end
+
+      it "returns fallback bundle when primary does not have the message" do
+        expect(sequence.find("en-only")).to eq(en_bundle)
+      end
+    end
+
+    context "with multiple IDs" do
+      it "returns array of bundles for each ID" do
+        result = sequence.find("us-only", "en-only", "ja-only")
+        expect(result).to eq([en_us_bundle, en_bundle, ja_bundle])
+      end
+
+      it "returns nil for IDs not found" do
+        result = sequence.find("hello", "nonexistent")
+        expect(result).to eq([en_us_bundle, nil])
+      end
+    end
+  end
+
+  describe "#format" do
+    it "formats message from the first matching bundle" do
+      expect(sequence.format("hello", name: "World")).to eq("Hello, World!")
+    end
+
+    it "returns message ID when not found" do
+      expect(sequence.format("nonexistent")).to eq("nonexistent")
+    end
+
+    it "uses fallback bundle when primary does not have the message" do
+      expect(sequence.format("ja-only")).to eq("日本語のみ")
+    end
+  end
+
+  describe "with empty sequence" do
+    let(:empty_sequence) { Foxtail::Sequence.new }
+
+    it "returns nil for find" do
+      expect(empty_sequence.find("hello")).to be_nil
+    end
+
+    it "returns message ID for format" do
+      expect(empty_sequence.format("hello")).to eq("hello")
+    end
+  end
+
+  describe "bundle priority" do
+    it "returns first bundle when multiple bundles have the same message" do
+      expect(sequence.find("hello")).to eq(en_us_bundle)
+    end
+
+    context "with reversed priority" do
+      let(:reversed_sequence) { Foxtail::Sequence.new(ja_bundle, en_bundle, en_us_bundle) }
+
+      it "returns first bundle in the new order" do
+        expect(reversed_sequence.find("hello")).to eq(ja_bundle)
+      end
+
+      it "formats using the first bundle" do
+        expect(reversed_sequence.format("hello", name: "World")).to eq("こんにちは、Worldさん！")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Add `Foxtail::Sequence` class for managing multi-language fallback chains, equivalent to @fluent/sequence in fluent.js.

## Changes
- Add `Sequence` class with `find` and `format` methods
- `find(*ids)` returns bundle(s) containing messages
- `format(id, **)` formats with automatic fallback, returns ID if not found
- Add comprehensive test suite (13 examples)
- Add documentation in doc/sequence.md

Fixes #124
