### PR TITLE
:sparkles: Add examples directory with executable usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,83 +44,39 @@ For details, see the [icu4x gem documentation](https://github.com/sakuro/icu4x).
 ### Basic Usage
 
 ```ruby
-require 'foxtail'
+require "foxtail"
+require "icu4x"
 
-# English (US)
-en_resource = Foxtail::Resource.from_string(<<~FTL)
-  hello = Hello, {$name}!
-  emails = You have {$count ->
-    [0] no emails
-    [one] one email
-   *[other] {$count} emails
+resource = Foxtail::Resource.from_string(<<~FTL)
+  hello = Hello, { $name }!
+  emails = You have { $count ->
+      [one] one email
+     *[other] { $count } emails
   }.
 FTL
 
-en_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("en-US"))
-en_bundle.add_resource(en_resource)
-en_bundle.format("hello", name: "Alice")
+bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("en-US"))
+bundle.add_resource(resource)
+
+bundle.format("hello", name: "Alice")
 # => "Hello, Alice!"
-en_bundle.format("emails", count: 1)
+
+bundle.format("emails", count: 1)
 # => "You have one email."
 
-# Japanese
-ja_resource = Foxtail::Resource.from_string(<<~FTL)
-  hello = こんにちは、{$name}さん！
-  emails = メールが{$count}件あります。
-FTL
-
-ja_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("ja"))
-ja_bundle.add_resource(ja_resource)
-ja_bundle.format("hello", name: "太郎")
-# => "こんにちは、太郎さん！"
-ja_bundle.format("emails", count: 1)
-# => "メールが1件あります。"
+bundle.format("emails", count: 5)
+# => "You have 5 emails."
 ```
 
-### Advanced Features
+### More Examples
 
-Numbers, dates, and currencies with international formatting using `icu4x`:
+See the [examples/](examples/) directory for executable demonstrations:
 
-```ruby
-# English (US)
-en_resource = Foxtail::Resource.from_string(<<~FTL)
-  price = The price is {NUMBER($amount, style: "currency", currency: "USD")}.
-  discount = Sale: {NUMBER($percent, style: "percent")} off!
-FTL
-
-en_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("en-US"))
-en_bundle.add_resource(en_resource)
-en_bundle.format("price", amount: 1234.50)
-# => "The price is $1,234.5."
-en_bundle.format("discount", percent: 0.15)
-# => "Sale: 15% off!"
-
-# Japanese
-ja_resource = Foxtail::Resource.from_string(<<~FTL)
-  price = 価格は{NUMBER($amount, style: "currency", currency: "JPY")}です。
-  discount = セール：{NUMBER($percent, style: "percent")}オフ！
-FTL
-
-ja_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("ja"))
-ja_bundle.add_resource(ja_resource)
-ja_bundle.format("price", amount: 1234)
-# => "価格は￥1,234です。"
-ja_bundle.format("discount", percent: 0.15)
-# => "セール：15%オフ！"
-
-# Pattern selection with strings
-pattern_resource = Foxtail::Resource.from_string(<<~FTL)
-  greeting = {$gender ->
-    [male] Hello, Mr. {$name}!
-    [female] Hello, Ms. {$name}!
-   *[other] Hello, {$name}!
-  }
-FTL
-
-en_bundle.add_resource(pattern_resource)
-en_bundle.format("greeting", gender: "male", name: "John")
-# => "Hello, Mr. John!"
-```
+- **Basic features**: Variables, selectors, terms, attributes
+- **Number/Date formatting**: Currency, percent, date styles
+- **Custom functions**: Adding your own formatters
+- **Multi-language apps**: Language fallback with `Sequence`
+- **E-commerce**: Real-world pricing and cart localization
 
 
 ## Development

--- a/doc/sequence.md
+++ b/doc/sequence.md
@@ -129,3 +129,7 @@ sequence = Foxtail::Sequence.new(bundle_en_gb, bundle_en, bundle_default)
 # Falls back to complete locale
 sequence = Foxtail::Sequence.new(bundle_new_locale, bundle_complete_locale)
 ```
+
+## Example
+
+See [examples/multilingual_app/](../examples/multilingual_app/) for a complete working example with FTL files.

--- a/examples/01_basic.rb
+++ b/examples/01_basic.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Example 01: Basic Messages and Variables
+#
+# This example demonstrates:
+# - Creating a Bundle with a locale
+# - Parsing FTL resources from strings
+# - Formatting messages with variables
+
+require "foxtail"
+
+# Create a bundle for English (US) locale
+bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("en-US"))
+
+# Parse FTL content and add to bundle
+resource = Foxtail::Resource.from_string(<<~FTL)
+  # Simple message
+  hello-world = Hello, World!
+
+  # Message with variable
+  greeting = Hello, { $name }!
+
+  # Message with multiple variables
+  welcome = Welcome to { $app }, { $user }!
+FTL
+
+bundle.add_resource(resource)
+
+# Format simple message
+puts bundle.format("hello-world")
+# => Hello, World!
+
+# Format message with variable
+puts bundle.format("greeting", name: "Alice")
+# => Hello, Alice!
+
+# Format message with multiple variables
+puts bundle.format("welcome", app: "Foxtail", user: "Bob")
+# => Welcome to Foxtail, Bob!
+
+# Missing variable renders as placeholder
+puts bundle.format("greeting")
+# => Hello, {$name}!

--- a/examples/02_selectors.rb
+++ b/examples/02_selectors.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Example 02: Selectors (Plurals, Gender, Numeric Matching)
+#
+# This example demonstrates:
+# - Plural forms with numeric values
+# - String-based selectors (gender, etc.)
+# - Exact numeric matching with fallback
+
+require "foxtail"
+
+bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("en-US"))
+
+resource = Foxtail::Resource.from_string(<<~FTL)
+  # Plural selector - matches plural categories (zero, one, two, few, many, other)
+  emails = You have { $count ->
+      [0] no emails
+      [one] one email
+     *[other] { $count } emails
+  }.
+
+  # String selector - matches exact string values
+  greeting = { $gender ->
+      [male] Hello, Mr. { $name }!
+      [female] Hello, Ms. { $name }!
+     *[other] Hello, { $name }!
+  }
+
+  # Numeric selector with exact matches
+  position = You are in { $place ->
+      [1] first
+      [2] second
+      [3] third
+     *[other] { $place }th
+  } place.
+FTL
+
+bundle.add_resource(resource)
+
+# Plural selector
+puts "--- Plural Selector ---"
+puts bundle.format("emails", count: 0)   # => You have no emails.
+puts bundle.format("emails", count: 1)   # => You have one email.
+puts bundle.format("emails", count: 5)   # => You have 5 emails.
+
+# Gender selector
+puts "\n--- Gender Selector ---"
+puts bundle.format("greeting", gender: "male", name: "John")
+# => Hello, Mr. John!
+puts bundle.format("greeting", gender: "female", name: "Jane")
+# => Hello, Ms. Jane!
+puts bundle.format("greeting", gender: "other", name: "Alex")
+# => Hello, Alex!
+
+# Numeric selector
+puts "\n--- Numeric Selector ---"
+puts bundle.format("position", place: 1)   # => You are in first place.
+puts bundle.format("position", place: 2)   # => You are in second place.
+puts bundle.format("position", place: 10)  # => You are in 10th place.

--- a/examples/03_attributes_and_terms.rb
+++ b/examples/03_attributes_and_terms.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Example 03: Attributes and Terms
+#
+# This example demonstrates:
+# - Term definitions (-term syntax)
+# - Term references in messages
+# - Message attributes (.attribute syntax)
+# - Referencing attributes within FTL
+
+require "foxtail"
+
+bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("en-US"))
+
+resource = Foxtail::Resource.from_string(<<~FTL)
+  # Term - reusable value (prefixed with -)
+  -brand = Foxtail
+
+  # Message referencing a term
+  about = About { -brand }
+
+  # Another term
+  -company = Acme Corp
+
+  # Multiple terms in one message
+  copyright = Copyright { -company }. Powered by { -brand }.
+
+  # Message with attributes (for localized HTML attributes, etc.)
+  login-button = Log In
+      .aria-label = Click to log in
+      .title = Login to your account
+
+  # Referencing message attribute from another message
+  login-help = { login-button.aria-label } to access your account.
+FTL
+
+bundle.add_resource(resource)
+
+# Term reference
+puts "--- Term Reference ---"
+puts bundle.format("about")
+# => About Foxtail
+
+# Multiple terms
+puts "\n--- Multiple Terms ---"
+puts bundle.format("copyright")
+# => Copyright Acme Corp. Powered by Foxtail.
+
+# Message value
+puts "\n--- Message with Attributes ---"
+puts bundle.format("login-button")
+# => Log In
+
+# Message attribute referenced from another message
+puts "\n--- Attribute Reference ---"
+puts bundle.format("login-help")
+# => Click to log in to access your account.

--- a/examples/04_number_format.rb
+++ b/examples/04_number_format.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Example 04: Number Formatting
+#
+# This example demonstrates:
+# - NUMBER function for locale-aware formatting
+# - Currency formatting
+# - Percentage formatting
+# - Decimal digit control
+
+require "foxtail"
+
+# English (US)
+en_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("en-US"))
+en_resource = Foxtail::Resource.from_string(<<~FTL)
+  # Basic number formatting
+  count = Total: { NUMBER($value) }
+
+  # Currency formatting
+  price = Price: { NUMBER($amount, style: "currency", currency: "USD") }
+
+  # Percentage
+  discount = Save { NUMBER($rate, style: "percent") }!
+
+  # Controlling decimal places
+  precise = Value: { NUMBER($num, minimumFractionDigits: 2, maximumFractionDigits: 2) }
+
+  # Large numbers with grouping
+  population = Population: { NUMBER($count) }
+FTL
+en_bundle.add_resource(en_resource)
+
+# Japanese
+ja_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("ja"))
+ja_resource = Foxtail::Resource.from_string(<<~FTL)
+  # Currency in Yen
+  price = 価格：{ NUMBER($amount, style: "currency", currency: "JPY") }
+
+  # Percentage
+  discount = { NUMBER($rate, style: "percent") }オフ！
+
+  # Large numbers
+  population = 人口：{ NUMBER($count) }人
+FTL
+ja_bundle.add_resource(ja_resource)
+
+puts "=== English (US) ==="
+
+puts en_bundle.format("count", value: 42)
+# => Total: 42
+
+puts en_bundle.format("price", amount: 1234.50)
+# => Price: $1,234.50
+
+puts en_bundle.format("discount", rate: 0.25)
+# => Save 25%!
+
+puts en_bundle.format("precise", num: 3.14159)
+# => Value: 3.14
+
+puts en_bundle.format("population", count: 1_000_000)
+# => Population: 1,000,000
+
+puts "\n=== Japanese ==="
+
+puts ja_bundle.format("price", amount: 1234)
+# => 価格：￥1,234
+
+puts ja_bundle.format("discount", rate: 0.25)
+# => 25%オフ！
+
+puts ja_bundle.format("population", count: 1_000_000)
+# => 人口：1,000,000人

--- a/examples/05_datetime_format.rb
+++ b/examples/05_datetime_format.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Example 05: Date/Time Formatting
+#
+# This example demonstrates:
+# - DATETIME function for locale-aware formatting
+# - Date styles (full, long, medium, short)
+# - Time styles
+# - Combined date and time
+
+require "foxtail"
+
+# English (US)
+en_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("en-US"))
+en_resource = Foxtail::Resource.from_string(<<~FTL)
+  # Date only - various styles
+  date-full = { DATETIME($date, dateStyle: "full") }
+  date-long = { DATETIME($date, dateStyle: "long") }
+  date-medium = { DATETIME($date, dateStyle: "medium") }
+  date-short = { DATETIME($date, dateStyle: "short") }
+
+  # Time only
+  time-full = { DATETIME($time, timeStyle: "full") }
+  time-short = { DATETIME($time, timeStyle: "short") }
+
+  # Combined
+  datetime = { DATETIME($dt, dateStyle: "medium", timeStyle: "short") }
+FTL
+en_bundle.add_resource(en_resource)
+
+# Japanese
+ja_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("ja"))
+ja_resource = Foxtail::Resource.from_string(<<~FTL)
+  date-full = { DATETIME($date, dateStyle: "full") }
+  date-medium = { DATETIME($date, dateStyle: "medium") }
+  datetime = { DATETIME($dt, dateStyle: "medium", timeStyle: "short") }
+FTL
+ja_bundle.add_resource(ja_resource)
+
+# Sample date/time
+sample_date = Time.new(2025, 1, 4, 14, 30, 0, "+09:00")
+
+puts "=== English (US) ==="
+puts "Full:   #{en_bundle.format("date-full", date: sample_date)}"
+puts "Long:   #{en_bundle.format("date-long", date: sample_date)}"
+puts "Medium: #{en_bundle.format("date-medium", date: sample_date)}"
+puts "Short:  #{en_bundle.format("date-short", date: sample_date)}"
+puts
+puts "Time (full):  #{en_bundle.format("time-full", time: sample_date)}"
+puts "Time (short): #{en_bundle.format("time-short", time: sample_date)}"
+puts
+puts "Combined: #{en_bundle.format("datetime", dt: sample_date)}"
+
+puts "\n=== Japanese ==="
+puts "Full:   #{ja_bundle.format("date-full", date: sample_date)}"
+puts "Medium: #{ja_bundle.format("date-medium", date: sample_date)}"
+puts "Combined: #{ja_bundle.format("datetime", dt: sample_date)}"

--- a/examples/06_custom_functions.rb
+++ b/examples/06_custom_functions.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# Example 06: Custom Functions
+#
+# This example demonstrates:
+# - Defining custom formatting functions
+# - Merging with default functions
+# - Using custom functions in FTL messages
+
+require "foxtail"
+
+# Define custom functions
+# Signature: (value, locale:, **options)
+# - value: The first positional argument from FTL
+# - locale: The bundle's locale (ICU4X::Locale)
+# - options: Named arguments from FTL as keyword arguments
+custom_functions = {
+  # UPPER function - converts text to uppercase
+  "UPPER" => ->(value, **_opts) { value.to_s.upcase },
+
+  # LOWER function - converts text to lowercase
+  "LOWER" => ->(value, **_opts) { value.to_s.downcase },
+
+  # REVERSE function - reverses text
+  "REVERSE" => ->(value, **_opts) { value.to_s.reverse }
+}
+
+# Merge with default functions (NUMBER, DATETIME) to keep them available
+all_functions = Foxtail::Function.defaults.merge(custom_functions)
+
+# Create bundle with merged functions
+bundle = Foxtail::Bundle.new(
+  ICU4X::Locale.parse("en-US"),
+  functions: all_functions
+)
+
+resource = Foxtail::Resource.from_string(<<~FTL)
+  # Using custom UPPER function
+  shout = { UPPER($text) }
+
+  # Using custom LOWER function
+  whisper = { LOWER($text) }
+
+  # Using custom REVERSE function
+  backwards = { REVERSE($text) }
+
+  # Combining with regular text
+  greeting = Hello, { UPPER($name) }! Welcome aboard.
+
+  # Still have access to default NUMBER function
+  price = Total: { NUMBER($amount, style: "currency", currency: "USD") }
+FTL
+
+bundle.add_resource(resource)
+
+puts "--- Custom Functions ---"
+
+puts bundle.format("shout", text: "Hello World")
+# => HELLO WORLD
+
+puts bundle.format("whisper", text: "QUIET PLEASE")
+# => quiet please
+
+puts bundle.format("backwards", text: "Foxtail")
+# => liatxoF
+
+puts bundle.format("greeting", name: "alice")
+# => Hello, ALICE! Welcome aboard.
+
+puts "\n--- Default Functions Still Work ---"
+puts bundle.format("price", amount: 99.99)
+# => Total: $99.99

--- a/examples/07_error_handling.rb
+++ b/examples/07_error_handling.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Example 07: Error Handling
+#
+# This example demonstrates:
+# - Missing variable handling
+# - Missing message handling
+# - Missing reference handling
+
+require "foxtail"
+
+bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("en-US"))
+
+resource = Foxtail::Resource.from_string(<<~FTL)
+  # Message with variable
+  welcome = Welcome, { $name }! You have { $count } messages.
+
+  # Message referencing another message
+  greet-user = { greeting }, { $name }!
+
+  # Valid greeting
+  greeting = Hello
+FTL
+bundle.add_resource(resource)
+
+puts "--- Missing Variables ---"
+# When a variable is missing, it renders as {$variable}
+puts bundle.format("welcome")
+# => Welcome, {$name}! You have {$count} messages.
+
+# Partial variables - only some provided
+puts bundle.format("welcome", name: "Alice")
+# => Welcome, Alice! You have {$count} messages.
+
+# All variables provided
+puts bundle.format("welcome", name: "Alice", count: 5)
+# => Welcome, Alice! You have 5 messages.
+
+puts "\n--- Message References ---"
+# Message referencing another message
+puts bundle.format("greet-user", name: "Bob")
+# => Hello, Bob!
+
+puts "\n--- Missing Messages ---"
+# When a message is not found, format returns the message ID
+puts bundle.format("nonexistent")
+# => nonexistent
+
+puts bundle.format("also-missing")
+# => also-missing
+
+puts "\n--- Checking Message Existence ---"
+# Use message? to check if a message exists before formatting
+%w[welcome greeting nonexistent].each do |id|
+  exists = bundle.message?(id)
+  puts "#{id}: #{exists ? "exists" : "not found"}"
+end

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,36 @@
+# Foxtail Examples
+
+Executable examples demonstrating Foxtail features.
+
+## Running Examples
+
+```bash
+# Simple examples
+bundle exec ruby examples/01_basic.rb
+
+# Practical scenarios
+bundle exec ruby examples/multilingual_app/main.rb
+```
+
+## Simple Examples
+
+| File | Feature | Description |
+|------|---------|-------------|
+| [01_basic.rb](01_basic.rb) | Basics | Messages, variables, Bundle creation |
+| [02_selectors.rb](02_selectors.rb) | Selectors | Plurals, gender, numeric matching |
+| [03_attributes_and_terms.rb](03_attributes_and_terms.rb) | Attributes & Terms | `.attribute` syntax, `-term` references |
+| [04_number_format.rb](04_number_format.rb) | NUMBER | Currency, percent, digit formatting |
+| [05_datetime_format.rb](05_datetime_format.rb) | DATETIME | Date/time formatting |
+| [06_custom_functions.rb](06_custom_functions.rb) | Custom Functions | Custom formatter injection |
+| [07_error_handling.rb](07_error_handling.rb) | Errors | Parse errors, missing variables |
+
+## Practical Scenarios
+
+| Directory | Scenario | Features |
+|-----------|----------|----------|
+| [multilingual_app/](multilingual_app/) | Multi-language app | Sequence, file loading, fallback |
+| [ecommerce/](ecommerce/) | E-commerce pricing | NUMBER, plurals, attributes |
+
+## Prerequisites
+
+Ensure `icu4x` is configured. Run `bin/setup` if needed.

--- a/examples/ecommerce/README.md
+++ b/examples/ecommerce/README.md
@@ -1,0 +1,76 @@
+# E-commerce Example
+
+Demonstrates e-commerce localization with currency, stock counts, and cart messages.
+
+## Features
+
+- Currency formatting with `NUMBER($price, style: "currency", currency: "...")`
+- Percent formatting for discounts with `NUMBER($percent, style: "percent")`
+- Plurals for stock counts and cart items
+- Loading FTL files from disk with `Resource.from_file`
+
+## Structure
+
+```
+ecommerce/
+  main.rb           # Main application code
+  locales/
+    en.ftl          # English translations (USD)
+    ja.ftl          # Japanese translations (JPY)
+```
+
+## Run
+
+```bash
+bundle exec ruby examples/ecommerce/main.rb
+```
+
+## Key Concepts
+
+### Currency Formatting
+
+Different currencies are formatted appropriately for each locale:
+
+```ftl
+# en.ftl - US Dollars
+product-price = { NUMBER($price, style: "currency", currency: "USD") }
+
+# ja.ftl - Japanese Yen
+product-price = { NUMBER($price, style: "currency", currency: "JPY") }
+```
+
+Output:
+- English: `$149.99`
+- Japanese: `¥22,000`
+
+### Plural Forms
+
+Stock and cart counts use locale-appropriate plural forms:
+
+```ftl
+# en.ftl - English has singular/plural distinction
+stock-status = { $count ->
+    [0] Out of stock
+    [one] Only { $count } left in stock!
+   *[other] { $count } items in stock
+}
+
+# ja.ftl - Japanese doesn't distinguish singular/plural
+stock-status = { $count ->
+    [0] 在庫切れ
+    [one] 残り{ $count }点のみ！
+   *[other] 在庫{ $count }点
+}
+```
+
+### Discount Percentages
+
+Percent formatting works across locales:
+
+```ftl
+product-discount = { NUMBER($percent, style: "percent") } off
+```
+
+With `percent: 0.2`:
+- English: `20% off`
+- Japanese: `20%オフ`

--- a/examples/ecommerce/locales/en.ftl
+++ b/examples/ecommerce/locales/en.ftl
@@ -1,0 +1,38 @@
+# E-commerce English translations
+
+# Product information
+product-name = { $name }
+product-price = { NUMBER($price, style: "currency", currency: "USD") }
+product-discount = { NUMBER($percent, style: "percent") } off
+
+# Stock status with plurals
+stock-status = { $count ->
+    [0] Out of stock
+    [one] Only { $count } left in stock!
+   *[other] { $count } items in stock
+}
+
+# Cart messages
+cart-items = { $count ->
+    [0] Your cart is empty
+    [one] { $count } item in cart
+   *[other] { $count } items in cart
+}
+
+cart-total = Total: { NUMBER($total, style: "currency", currency: "USD") }
+
+# Shipping
+shipping-free = Free shipping on orders over { NUMBER($threshold, style: "currency", currency: "USD") }
+shipping-cost = Shipping: { NUMBER($cost, style: "currency", currency: "USD") }
+
+# Reviews
+reviews-count = { $count ->
+    [0] No reviews yet
+    [one] { $count } customer review
+   *[other] { $count } customer reviews
+}
+
+reviews-rating = { NUMBER($rating, minimumFractionDigits: 1, maximumFractionDigits: 1) } out of 5 stars
+
+# Sale
+sale-banner = SALE! Save up to { NUMBER($maxDiscount, style: "percent") }

--- a/examples/ecommerce/locales/ja.ftl
+++ b/examples/ecommerce/locales/ja.ftl
@@ -1,0 +1,36 @@
+# E-commerce 日本語翻訳
+
+# 商品情報
+product-name = { $name }
+product-price = { NUMBER($price, style: "currency", currency: "JPY") }
+product-discount = { NUMBER($percent, style: "percent") }オフ
+
+# 在庫状況
+stock-status = { $count ->
+    [0] 在庫切れ
+    [one] 残り{ $count }点のみ！
+   *[other] 在庫{ $count }点
+}
+
+# カート
+cart-items = { $count ->
+    [0] カートは空です
+   *[other] カートに{ $count }点
+}
+
+cart-total = 合計：{ NUMBER($total, style: "currency", currency: "JPY") }
+
+# 配送
+shipping-free = { NUMBER($threshold, style: "currency", currency: "JPY") }以上で送料無料
+shipping-cost = 送料：{ NUMBER($cost, style: "currency", currency: "JPY") }
+
+# レビュー
+reviews-count = { $count ->
+    [0] レビューはまだありません
+   *[other] { $count }件のレビュー
+}
+
+reviews-rating = { NUMBER($rating, minimumFractionDigits: 1, maximumFractionDigits: 1) } / 5.0
+
+# セール
+sale-banner = セール中！最大{ NUMBER($maxDiscount, style: "percent") }オフ

--- a/examples/ecommerce/main.rb
+++ b/examples/ecommerce/main.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+# E-commerce Example
+#
+# This example demonstrates:
+# - Currency formatting with NUMBER function
+# - Percent formatting for discounts
+# - Plurals for stock counts and cart items
+# - Loading FTL files from disk
+
+require "foxtail"
+require "icu4x"
+require "pathname"
+
+# Directory containing locale files
+locales_dir = Pathname.new(__dir__).join("locales")
+
+# Load bundles for available locales
+en_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("en-US"))
+en_bundle.add_resource(Foxtail::Resource.from_file(locales_dir.join("en.ftl")))
+
+ja_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("ja"))
+ja_bundle.add_resource(Foxtail::Resource.from_file(locales_dir.join("ja.ftl")))
+
+# Sample product data
+product = {
+  name: "Wireless Headphones",
+  price_usd: 149.99,
+  price_jpy: 22_000,
+  discount: 0.2,
+  stock: 3,
+  rating: 4.7,
+  reviews: 128
+}
+
+puts "=== E-commerce Localization Demo ==="
+puts
+
+# English (US) display
+puts "--- English (US) ---"
+puts en_bundle.format("product-name", name: product[:name])
+puts en_bundle.format("product-price", price: product[:price_usd])
+puts en_bundle.format("product-discount", percent: product[:discount])
+puts en_bundle.format("stock-status", count: product[:stock])
+puts en_bundle.format("reviews-count", count: product[:reviews])
+puts en_bundle.format("reviews-rating", rating: product[:rating])
+puts
+
+# Japanese display
+puts "--- Japanese ---"
+puts ja_bundle.format("product-name", name: product[:name])
+puts ja_bundle.format("product-price", price: product[:price_jpy])
+puts ja_bundle.format("product-discount", percent: product[:discount])
+puts ja_bundle.format("stock-status", count: product[:stock])
+puts ja_bundle.format("reviews-count", count: product[:reviews])
+puts ja_bundle.format("reviews-rating", rating: product[:rating])
+puts
+
+# Cart examples
+puts "=== Shopping Cart ==="
+puts
+
+cart_items = 5
+cart_total_usd = 749.95
+cart_total_jpy = 110_000
+
+puts "English:"
+puts "  #{en_bundle.format("cart-items", count: cart_items)}"
+puts "  #{en_bundle.format("cart-total", total: cart_total_usd)}"
+puts "  #{en_bundle.format("shipping-free", threshold: 100)}"
+puts
+
+puts "Japanese:"
+puts "  #{ja_bundle.format("cart-items", count: cart_items)}"
+puts "  #{ja_bundle.format("cart-total", total: cart_total_jpy)}"
+puts "  #{ja_bundle.format("shipping-free", threshold: 10_000)}"
+puts
+
+# Empty cart
+puts "=== Empty Cart ==="
+puts "English: #{en_bundle.format("cart-items", count: 0)}"
+puts "Japanese: #{ja_bundle.format("cart-items", count: 0)}"
+puts
+
+# Sale banner
+puts "=== Sale Banner ==="
+puts "English: #{en_bundle.format("sale-banner", maxDiscount: 0.5)}"
+puts "Japanese: #{ja_bundle.format("sale-banner", maxDiscount: 0.5)}"

--- a/examples/multilingual_app/README.md
+++ b/examples/multilingual_app/README.md
@@ -1,0 +1,51 @@
+# Multilingual App Example
+
+Demonstrates language fallback using `Foxtail::Sequence`.
+
+## Features
+
+- Loading FTL files from disk with `Resource.from_file`
+- Using `Sequence` to create fallback chains
+- Handling locale-specific messages
+
+## Structure
+
+```
+multilingual_app/
+  main.rb           # Main application code
+  locales/
+    en.ftl          # English translations
+    ja.ftl          # Japanese translations
+```
+
+## Run
+
+```bash
+bundle exec ruby examples/multilingual_app/main.rb
+```
+
+## Key Concepts
+
+### Language Fallback
+
+When a message is missing in the primary locale, `Sequence` automatically falls back to the next bundle:
+
+```ruby
+# Japanese primary, English fallback
+sequence = Foxtail::Sequence.new(ja_bundle, en_bundle)
+
+# Found in Japanese bundle
+sequence.format("hello", name: "太郎")  # => こんにちは、太郎さん！
+
+# Not in Japanese, falls back to English
+sequence.format("english-only")  # => This message is only available in English.
+```
+
+### Finding Bundles
+
+Use `find` to determine which bundle contains a message:
+
+```ruby
+bundle = sequence.find("hello")
+puts bundle.locale  # => "ja"
+```

--- a/examples/multilingual_app/locales/en.ftl
+++ b/examples/multilingual_app/locales/en.ftl
@@ -1,0 +1,22 @@
+# English translations
+
+hello = Hello, { $name }!
+goodbye = Goodbye!
+
+notifications = You have { $count ->
+    [0] no notifications
+    [one] one notification
+   *[other] { $count } notifications
+}.
+
+menu-file = File
+menu-edit = Edit
+menu-view = View
+menu-help = Help
+
+btn-save = Save
+btn-cancel = Cancel
+btn-ok = OK
+
+# English-only message (not in Japanese)
+english-only = This message is only available in English.

--- a/examples/multilingual_app/locales/ja.ftl
+++ b/examples/multilingual_app/locales/ja.ftl
@@ -1,0 +1,18 @@
+# 日本語の翻訳
+
+hello = こんにちは、{ $name }さん！
+goodbye = さようなら！
+
+notifications = { $count }件の通知があります。
+
+menu-file = ファイル
+menu-edit = 編集
+menu-view = 表示
+menu-help = ヘルプ
+
+btn-save = 保存
+btn-cancel = キャンセル
+btn-ok = OK
+
+# Japanese-only message (not in English)
+japanese-only = このメッセージは日本語のみです。

--- a/examples/multilingual_app/main.rb
+++ b/examples/multilingual_app/main.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# Multilingual App Example
+#
+# This example demonstrates:
+# - Loading FTL files from disk
+# - Using Sequence for language fallback
+# - Handling locale-specific messages
+
+require "foxtail"
+require "icu4x"
+require "pathname"
+
+# Directory containing locale files
+locales_dir = Pathname.new(__dir__).join("locales")
+
+# Load bundles for available locales
+en_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("en"))
+en_bundle.add_resource(Foxtail::Resource.from_file(locales_dir.join("en.ftl")))
+
+ja_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("ja"))
+ja_bundle.add_resource(Foxtail::Resource.from_file(locales_dir.join("ja.ftl")))
+
+puts "=== Using Sequence for Fallback ==="
+puts
+
+# Create sequence with Japanese as primary, English as fallback
+puts "--- Japanese primary (with English fallback) ---"
+ja_sequence = Foxtail::Sequence.new(ja_bundle, en_bundle)
+
+puts ja_sequence.format("hello", name: "太郎")
+# => こんにちは、太郎さん！
+
+puts ja_sequence.format("notifications", count: 3)
+# => 3件の通知があります。
+
+# Message only in English - falls back
+puts ja_sequence.format("english-only")
+# => This message is only available in English.
+
+puts
+
+# Create sequence with English as primary, Japanese as fallback
+puts "--- English primary (with Japanese fallback) ---"
+en_sequence = Foxtail::Sequence.new(en_bundle, ja_bundle)
+
+puts en_sequence.format("hello", name: "Alice")
+# => Hello, Alice!
+
+puts en_sequence.format("notifications", count: 1)
+# => You have one notification.
+
+# Message only in Japanese - falls back
+puts en_sequence.format("japanese-only")
+# => このメッセージは日本語のみです。
+
+puts
+puts "=== Finding Which Bundle Has a Message ==="
+puts
+
+# Use find to determine which bundle contains a message
+bundle = ja_sequence.find("english-only")
+puts "Found 'english-only' in locale: #{bundle.locale}" if bundle
+
+bundle = ja_sequence.find("japanese-only")
+puts "Found 'japanese-only' in locale: #{bundle.locale}" if bundle
+
+puts
+puts "=== Menu Localization ==="
+puts
+
+puts "English:"
+%w[menu-file menu-edit menu-view menu-help].each do |id|
+  puts "  #{en_sequence.format(id)}"
+end
+
+puts
+puts "Japanese:"
+%w[menu-file menu-edit menu-view menu-help].each do |id|
+  puts "  #{ja_sequence.format(id)}"
+end


### PR DESCRIPTION
## Summary

Add examples/ directory with executable Ruby scripts demonstrating Foxtail features, making it easier for users to learn and explore the library.

## Changes

- Add 7 simple examples: basics, selectors, terms/attributes, NUMBER, DATETIME, custom functions, error handling
- Add 2 practical scenarios: multilingual_app (Sequence/fallback), ecommerce (currency/plurals)
- Simplify README Quick Start section with reference to examples/
- Add example reference to doc/sequence.md

## Test Plan

```bash
bundle exec ruby examples/01_basic.rb
bundle exec ruby examples/multilingual_app/main.rb
bundle exec ruby examples/ecommerce/main.rb
```

Closes #126
