### PR TITLE
:sparkles: Add CLI with lint command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Ruby implementation of [Project Fluent](https://projectfluent.org/) - a modern
 - **Runtime message formatting** - Bundle system with `icu4x`-based formatting
 - **FTL syntax parser** - Syntax support with error recovery
 - **Multi-language support** - Number, date, and pluralization formatting
+- **CLI tools** - Lint and validate FTL files
 - **Ruby implementation** - API following Ruby conventions
 
 ## Installation
@@ -110,6 +111,26 @@ $ bundle exec rake
 - **[Sequence](doc/sequence.md)** - Language fallback chains
 
 See [doc/architecture.md](doc/architecture.md) for detailed design documentation.
+
+## CLI
+
+Foxtail provides command-line tools for working with FTL files.
+
+### Lint
+
+Check FTL files for syntax errors:
+
+```bash
+foxtail lint messages.ftl
+foxtail lint locales/**/*.ftl
+```
+
+Options:
+- `-q, --quiet` - Only show errors, no summary
+
+Exit codes:
+- `0` - No errors found
+- `1` - Errors found or no files matched
 
 ## Compatibility
 

--- a/exe/foxtail
+++ b/exe/foxtail
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/foxtail"
+require "dry/cli"
+
+begin
+  Dry::CLI.new(Foxtail::CLI).call
+rescue Foxtail::CLI::LintError
+  exit 1
+end

--- a/foxtail.gemspec
+++ b/foxtail.gemspec
@@ -24,15 +24,17 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir[
     "lib/**/*.rb",
+    "exe/*",
     "CHANGELOG.md",
     "LICENSE.txt",
     "README.md"
   ]
   spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{\Aexe/}) {|f| File.basename(f) }
+  spec.executables = ["foxtail"]
   spec.require_paths = ["lib"]
 
   # Dependencies
+  spec.add_dependency "dry-cli", "~> 1.0"
   spec.add_dependency "icu4x", "~> 0.6"
   spec.add_dependency "zeitwerk", "~> 2.6"
 end

--- a/lib/foxtail.rb
+++ b/lib/foxtail.rb
@@ -14,7 +14,8 @@ module Foxtail
   # Configure inflections for acronyms
   loader.inflector.inflect(
     "ast" => "AST",
-    "ast_converter" => "ASTConverter"
+    "ast_converter" => "ASTConverter",
+    "cli" => "CLI"
   )
 
   loader.setup

--- a/lib/foxtail/cli.rb
+++ b/lib/foxtail/cli.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "dry/cli"
+
+module Foxtail
+  # Command-line interface for Foxtail
+  module CLI
+    extend Dry::CLI::Registry
+
+    register "lint", Commands::Lint
+  end
+end

--- a/lib/foxtail/cli/commands/lint.rb
+++ b/lib/foxtail/cli/commands/lint.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Foxtail
+  # Command-line interface for Foxtail
+  module CLI
+    module Commands
+      # Lint FTL files for syntax errors and junk entries
+      class Lint < Dry::CLI::Command
+        desc "Check FTL files for syntax errors"
+
+        argument :files, type: :array, required: true, desc: "FTL files to lint"
+
+        option :quiet, type: :boolean, default: false, aliases: ["-q"], desc: "Only show errors, no summary"
+
+        # Execute the lint command
+        def call(files:, quiet:, **)
+          total_errors = 0
+          total_files = 0
+
+          files.each do |file|
+            errors = lint_file(file)
+            total_files += 1
+            total_errors += errors.size
+
+            errors.each do |error|
+              puts error
+            end
+          end
+
+          unless quiet
+            puts
+            puts "#{total_files} file(s) checked, #{total_errors} error(s) found"
+          end
+
+          raise Foxtail::CLI::LintError, total_errors if total_errors > 0
+        end
+
+        private def lint_file(path)
+          errors = []
+          content = File.read(path)
+          parser = Foxtail::Parser.new
+          resource = parser.parse(content)
+
+          resource.body.each do |entry|
+            case entry
+            when Foxtail::Parser::AST::Junk
+              errors << format_junk_error(path, entry)
+            end
+          end
+
+          errors
+        end
+
+        private def format_junk_error(path, junk)
+          first_line = junk.content.lines.first&.chomp || ""
+          "#{path}: syntax error: #{first_line}"
+        end
+      end
+    end
+
+    register "lint", Commands::Lint
+  end
+end

--- a/lib/foxtail/cli/error.rb
+++ b/lib/foxtail/cli/error.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Foxtail
+  module CLI
+    # Base error class for CLI-specific exceptions
+    class Error < Foxtail::Error; end
+  end
+end

--- a/lib/foxtail/cli/lint_error.rb
+++ b/lib/foxtail/cli/lint_error.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Foxtail
+  module CLI
+    # Raised when lint command finds errors in FTL files
+    class LintError < Error
+      attr_reader :error_count
+
+      def initialize(error_count)
+        @error_count = error_count
+        super("Lint found #{error_count} error(s)")
+      end
+    end
+  end
+end

--- a/spec/foxtail/cli/commands/lint_spec.rb
+++ b/spec/foxtail/cli/commands/lint_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+RSpec.describe Foxtail::CLI::Commands::Lint do
+  subject(:command) { Foxtail::CLI::Commands::Lint.new }
+
+  describe "#call" do
+    context "with valid FTL files" do
+      it "reports no errors and does not raise" do
+        Tempfile.create(%w[valid .ftl]) do |f|
+          f.write("hello = Hello, world!\n")
+          f.flush
+
+          expect {
+            command.call(files: [f.path], quiet: true)
+          }.not_to raise_error
+        end
+      end
+    end
+
+    context "with invalid FTL files" do
+      it "raises LintError with error count" do
+        Tempfile.create(%w[invalid .ftl]) do |f|
+          f.write("hello = Hi\nbad entry\n")
+          f.flush
+
+          expect {
+            command.call(files: [f.path], quiet: true)
+          }.to output(String).to_stdout
+            .and raise_error(Foxtail::CLI::LintError) {|e| expect(e.error_count).to eq(1) }
+        end
+      end
+
+      it "outputs junk content with file path" do
+        Tempfile.create(%w[invalid .ftl]) do |f|
+          f.write("hello = Hi\nbad entry\n")
+          f.flush
+
+          expect {
+            command.call(files: [f.path], quiet: true)
+          }.to output(/#{Regexp.escape(f.path)}: syntax error: bad entry/).to_stdout
+            .and raise_error(Foxtail::CLI::LintError)
+        end
+      end
+    end
+
+    context "with multiple files" do
+      it "checks all files without raising when valid" do
+        Dir.mktmpdir do |dir|
+          en_path = File.join(dir, "en.ftl")
+          ja_path = File.join(dir, "ja.ftl")
+          File.write(en_path, "hello = Hello!\n")
+          File.write(ja_path, "hello = こんにちは！\n")
+
+          expect {
+            command.call(files: [en_path, ja_path], quiet: true)
+          }.not_to raise_error
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Add CLI framework using dry-cli and implement the first command: `foxtail lint` for checking FTL files for syntax errors.

## Changes
- Add dry-cli dependency for CLI framework
- Implement lint command that detects Junk entries (syntax errors) in FTL files
- Use LintError exception for proper exit code handling
- Add documentation in README.md

## Test Plan
```bash
# Run tests
bundle exec rspec spec/foxtail/cli/commands/lint_spec.rb

# Manual test with valid file
echo "hello = Hello!" > /tmp/valid.ftl
bundle exec exe/foxtail lint /tmp/valid.ftl

# Manual test with invalid file
echo -e "hello = Hi\nbad entry" > /tmp/invalid.ftl
bundle exec exe/foxtail lint /tmp/invalid.ftl
```

Closes #119
