### PR TITLE
:sparkles: Add CLI tidy command for formatting FTL files

### DIFF
--- a/exe/foxtail
+++ b/exe/foxtail
@@ -6,6 +6,7 @@ require "dry/cli"
 
 begin
   Dry::CLI.new(Foxtail::CLI).call
-rescue Foxtail::CLI::LintError
+rescue Foxtail::CLI::Error => e
+  warn e.message
   exit 1
 end

--- a/lib/foxtail/cli.rb
+++ b/lib/foxtail/cli.rb
@@ -8,5 +8,6 @@ module Foxtail
     extend Dry::CLI::Registry
 
     register "lint", Commands::Lint
+    register "tidy", Commands::Tidy
   end
 end

--- a/lib/foxtail/cli/commands/tidy.rb
+++ b/lib/foxtail/cli/commands/tidy.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module Foxtail
+  # Command-line interface for Foxtail
+  module CLI
+    module Commands
+      # Format FTL files with consistent style
+      class Tidy < Dry::CLI::Command
+        desc "Format FTL files with consistent style"
+
+        argument :files, type: :array, required: true, desc: "FTL files to format"
+
+        option :write, type: :flag, default: false, aliases: ["-w"], desc: "Write result back to source file"
+        option :check, type: :flag, default: false, aliases: ["-c"], desc: "Check if files are formatted (for CI)"
+        option :diff, type: :flag, default: false, aliases: ["-d"], desc: "Show diff instead of formatted output"
+        option :with_junk, type: :flag, default: false, desc: "Allow formatting files with syntax errors"
+
+        # Execute the tidy command
+        def call(files:, write:, check:, diff:, with_junk:, **)
+          files_with_errors = []
+          files_needing_format = []
+          multiple_files = files.size > 1
+
+          files.each do |file|
+            result = process_file(file, write:, check:, diff:, with_junk:, multiple_files:)
+            case result
+            when :has_errors
+              files_with_errors << file
+            when :needs_format
+              files_needing_format << file
+            end
+          end
+
+          raise Foxtail::CLI::TidyError, files_with_errors unless files_with_errors.empty?
+          raise Foxtail::CLI::TidyCheckError, files_needing_format if check && !files_needing_format.empty?
+        end
+
+        private
+
+        private def process_file(path, write:, check:, diff:, with_junk:, multiple_files:)
+          content = File.read(path)
+          parser = Foxtail::Parser.new
+          resource = parser.parse(content)
+
+          # Check for Junk entries (syntax errors)
+          has_junk = resource.body.any?(Parser::AST::Junk)
+          return :has_errors if has_junk && !with_junk
+
+          serializer = Foxtail::Serializer.new(with_junk:)
+          formatted = serializer.serialize(resource)
+
+          if check
+            return :needs_format if content != formatted
+
+            return :ok
+          end
+
+          if diff
+            output_diff(path, content, formatted)
+            return :ok
+          end
+
+          if write
+            File.write(path, formatted) if content != formatted
+            return :ok
+          end
+
+          # Default: output to stdout
+          output_formatted(path, formatted, multiple_files)
+          :ok
+        end
+
+        private def output_formatted(path, formatted, multiple_files)
+          if multiple_files
+            puts "==> #{path} <=="
+            puts formatted
+          else
+            print formatted
+          end
+        end
+
+        private def output_diff(path, original, formatted)
+          return if original == formatted
+
+          require "tempfile"
+
+          Tempfile.create(["original", ".ftl"]) do |orig_file|
+            Tempfile.create(["formatted", ".ftl"]) do |fmt_file|
+              orig_file.write(original)
+              orig_file.flush
+              fmt_file.write(formatted)
+              fmt_file.flush
+
+              # Use diff command with file path labels
+              system("diff", "-u", "--label", path, orig_file.path, "--label", "#{path} (formatted)", fmt_file.path)
+            end
+          end
+        end
+      end
+    end
+
+    register "tidy", Commands::Tidy
+  end
+end

--- a/lib/foxtail/cli/tidy_check_error.rb
+++ b/lib/foxtail/cli/tidy_check_error.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Foxtail
+  module CLI
+    # Raised when tidy --check finds files that need formatting
+    class TidyCheckError < Error
+      attr_reader :files_needing_format
+
+      def initialize(files_needing_format)
+        @files_needing_format = files_needing_format
+        super("Files need formatting: #{files_needing_format.join(", ")}")
+      end
+    end
+  end
+end

--- a/lib/foxtail/cli/tidy_error.rb
+++ b/lib/foxtail/cli/tidy_error.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Foxtail
+  module CLI
+    # Raised when tidy command encounters syntax errors without --with-junk
+    class TidyError < Error
+      attr_reader :files_with_errors
+
+      def initialize(files_with_errors)
+        @files_with_errors = files_with_errors
+        super("Files contain syntax errors: #{files_with_errors.join(", ")}")
+      end
+    end
+  end
+end

--- a/lib/foxtail/serializer.rb
+++ b/lib/foxtail/serializer.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+module Foxtail
+  # Serializes AST nodes back to FTL format
+  class Serializer
+    attr_reader :with_junk
+
+    def initialize(with_junk: false)
+      @with_junk = with_junk
+    end
+
+    # Serialize a Resource AST to FTL string
+    def serialize(resource)
+      has_entries = false
+      parts = []
+
+      resource.body.each do |entry|
+        next if entry.is_a?(Parser::AST::Junk) && !with_junk
+
+        parts << serialize_entry(entry, has_entries:)
+        has_entries = true
+      end
+
+      parts.join
+    end
+
+    # Serialize a single entry (Message, Term, Comment, or Junk)
+    def serialize_entry(entry, has_entries: false)
+      case entry
+      when Parser::AST::Message
+        serialize_message(entry)
+      when Parser::AST::Term
+        serialize_term(entry)
+      when Parser::AST::Comment
+        serialize_standalone_comment(entry, "#", has_entries)
+      when Parser::AST::GroupComment
+        serialize_standalone_comment(entry, "##", has_entries)
+      when Parser::AST::ResourceComment
+        serialize_standalone_comment(entry, "###", has_entries)
+      when Parser::AST::Junk
+        serialize_junk(entry)
+      else
+        raise ArgumentError, "Unknown entry type: #{entry.class}"
+      end
+    end
+
+    private
+
+    private def serialize_standalone_comment(comment, prefix, has_entries)
+      result = serialize_comment(comment, prefix)
+      if has_entries
+        "\n#{result}\n"
+      else
+        "#{result}\n"
+      end
+    end
+
+    private def serialize_comment(comment, prefix="#")
+      prefixed = comment.content.split("\n").map {|line|
+        line.empty? ? prefix : "#{prefix} #{line}"
+      }.join("\n")
+      "#{prefixed}\n"
+    end
+
+    private def serialize_junk(junk) = junk.content
+
+    private def serialize_message(message)
+      parts = []
+      parts << serialize_comment(message.comment) if message.comment
+      parts << "#{message.id.name} ="
+      parts << serialize_pattern(message.value) if message.value
+      message.attributes.each {|attr| parts << serialize_attribute(attr) }
+      parts << "\n"
+      parts.join
+    end
+
+    private def serialize_term(term)
+      parts = []
+      parts << serialize_comment(term.comment) if term.comment
+      parts << "-#{term.id.name} ="
+      parts << serialize_pattern(term.value)
+      term.attributes.each {|attr| parts << serialize_attribute(attr) }
+      parts << "\n"
+      parts.join
+    end
+
+    private def serialize_attribute(attribute)
+      value = indent_except_first_line(serialize_pattern(attribute.value))
+      "\n    .#{attribute.id.name} =#{value}"
+    end
+
+    private def serialize_pattern(pattern)
+      content = pattern.elements.map {|elem| serialize_element(elem) }.join
+
+      if should_start_on_new_line?(pattern)
+        "\n    #{indent_except_first_line(content)}"
+      else
+        " #{indent_except_first_line(content)}"
+      end
+    end
+
+    private def serialize_element(element)
+      case element
+      when Parser::AST::TextElement
+        element.value
+      when Parser::AST::Placeable
+        serialize_placeable(element)
+      else
+        raise ArgumentError, "Unknown element type: #{element.class}"
+      end
+    end
+
+    private def serialize_placeable(placeable)
+      expr = placeable.expression
+      case expr
+      when Parser::AST::Placeable
+        "{#{serialize_placeable(expr)}}"
+      when Parser::AST::SelectExpression
+        "{ #{serialize_expression(expr)}}"
+      else
+        "{ #{serialize_expression(expr)} }"
+      end
+    end
+
+    private def serialize_expression(expr)
+      case expr
+      when Parser::AST::StringLiteral
+        "\"#{expr.value}\""
+      when Parser::AST::NumberLiteral
+        expr.value
+      when Parser::AST::VariableReference
+        "$#{expr.id.name}"
+      when Parser::AST::TermReference
+        serialize_term_reference(expr)
+      when Parser::AST::MessageReference
+        serialize_message_reference(expr)
+      when Parser::AST::FunctionReference
+        "#{expr.id.name}#{serialize_call_arguments(expr.arguments)}"
+      when Parser::AST::SelectExpression
+        serialize_select_expression(expr)
+      when Parser::AST::Placeable
+        serialize_placeable(expr)
+      else
+        raise ArgumentError, "Unknown expression type: #{expr.class}"
+      end
+    end
+
+    private def serialize_term_reference(ref)
+      out = "-#{ref.id.name}"
+      out += ".#{ref.attribute.name}" if ref.attribute
+      out += serialize_call_arguments(ref.arguments) if ref.arguments
+      out
+    end
+
+    private def serialize_message_reference(ref)
+      out = ref.id.name
+      out += ".#{ref.attribute.name}" if ref.attribute
+      out
+    end
+
+    private def serialize_select_expression(expr)
+      out = "#{serialize_expression(expr.selector)} ->"
+      expr.variants.each {|variant| out += serialize_variant(variant) }
+      "#{out}\n"
+    end
+
+    private def serialize_variant(variant)
+      key = serialize_variant_key(variant.key)
+      value = indent_except_first_line(serialize_pattern(variant.value))
+
+      if variant.default
+        "\n   *[#{key}]#{value}"
+      else
+        "\n    [#{key}]#{value}"
+      end
+    end
+
+    private def serialize_variant_key(key)
+      case key
+      when Parser::AST::Identifier
+        key.name
+      when Parser::AST::NumberLiteral
+        key.value
+      else
+        raise ArgumentError, "Unknown variant key type: #{key.class}"
+      end
+    end
+
+    private def serialize_call_arguments(args)
+      return "()" if args.nil?
+
+      positional = args.positional.map {|arg| serialize_expression(arg) }.join(", ")
+      named = args.named.map {|arg| serialize_named_argument(arg) }.join(", ")
+
+      if !positional.empty? && !named.empty?
+        "(#{positional}, #{named})"
+      else
+        "(#{positional}#{named})"
+      end
+    end
+
+    private def serialize_named_argument(arg)
+      value = serialize_expression(arg.value)
+      "#{arg.name.name}: #{value}"
+    end
+
+    private def indent_except_first_line(content)
+      content.split("\n").join("\n    ")
+    end
+
+    private def should_start_on_new_line?(pattern)
+      is_multiline = pattern.elements.any? {|elem|
+        select_expr?(elem) || includes_newline?(elem)
+      }
+
+      return false unless is_multiline
+
+      first_element = pattern.elements.first
+      return true unless first_element.is_a?(Parser::AST::TextElement)
+
+      first_char = first_element.value[0]
+      # These characters may not appear as the first character on a new line
+      !["[", ".", "*"].include?(first_char)
+    end
+
+    private def select_expr?(elem)
+      elem.is_a?(Parser::AST::Placeable) && elem.expression.is_a?(Parser::AST::SelectExpression)
+    end
+
+    private def includes_newline?(elem)
+      elem.is_a?(Parser::AST::TextElement) && elem.value.include?("\n")
+    end
+  end
+end

--- a/spec/foxtail/cli/commands/tidy_spec.rb
+++ b/spec/foxtail/cli/commands/tidy_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+RSpec.describe Foxtail::CLI::Commands::Tidy do
+  subject(:command) { Foxtail::CLI::Commands::Tidy.new }
+
+  describe "#call" do
+    context "with valid FTL files" do
+      it "outputs formatted content to stdout" do
+        Tempfile.create(%w[valid .ftl]) do |f|
+          f.write("hello=Hello\n")
+          f.flush
+
+          expect {
+            command.call(files: [f.path], write: false, check: false, diff: false, with_junk: false)
+          }.to output("hello = Hello\n").to_stdout
+        end
+      end
+
+      it "does not raise when file is already formatted" do
+        Tempfile.create(%w[valid .ftl]) do |f|
+          f.write("hello = Hello\n")
+          f.flush
+
+          expect {
+            command.call(files: [f.path], write: false, check: false, diff: false, with_junk: false)
+          }.to output("hello = Hello\n").to_stdout
+        end
+      end
+    end
+
+    context "with multiple files" do
+      it "outputs with file headers" do
+        Dir.mktmpdir do |dir|
+          a_path = File.join(dir, "a.ftl")
+          b_path = File.join(dir, "b.ftl")
+          File.write(a_path, "a = A\n")
+          File.write(b_path, "b = B\n")
+
+          expect {
+            command.call(files: [a_path, b_path], write: false, check: false, diff: false, with_junk: false)
+          }.to output(/==> .*a\.ftl <==.*==> .*b\.ftl <==/m).to_stdout
+        end
+      end
+    end
+
+    context "with --write option" do
+      it "writes formatted content back to file" do
+        Tempfile.create(%w[towrite .ftl]) do |f|
+          f.write("hello=Hello\n")
+          f.flush
+
+          expect {
+            command.call(files: [f.path], write: true, check: false, diff: false, with_junk: false)
+          }.not_to output.to_stdout
+
+          expect(File.read(f.path)).to eq("hello = Hello\n")
+        end
+      end
+    end
+
+    context "with --check option" do
+      it "does not raise when file is already formatted" do
+        Tempfile.create(%w[formatted .ftl]) do |f|
+          f.write("hello = Hello\n")
+          f.flush
+
+          expect {
+            command.call(files: [f.path], write: false, check: true, diff: false, with_junk: false)
+          }.not_to raise_error
+        end
+      end
+
+      it "raises TidyCheckError when file needs formatting" do
+        Tempfile.create(%w[unformatted .ftl]) do |f|
+          f.write("hello=Hello\n")
+          f.flush
+
+          expect {
+            command.call(files: [f.path], write: false, check: true, diff: false, with_junk: false)
+          }.to raise_error(Foxtail::CLI::TidyCheckError)
+        end
+      end
+    end
+
+    context "with --diff option" do
+      it "shows diff when file needs formatting" do
+        Tempfile.create(%w[unformatted .ftl]) do |f|
+          f.write("hello=Hello\n")
+          f.flush
+
+          # Capture stdout at OS level to suppress system("diff") output
+          Tempfile.create("stdout") do |stdout_capture|
+            original_stdout = $stdout.dup
+            $stdout.reopen(stdout_capture)
+
+            begin
+              command.call(files: [f.path], write: false, check: false, diff: true, with_junk: false)
+            ensure
+              $stdout.flush
+              $stdout.reopen(original_stdout)
+              original_stdout.close
+            end
+
+            stdout_capture.rewind
+            output = stdout_capture.read
+            expect(output).to include("-hello=Hello")
+            expect(output).to include("+hello = Hello")
+          end
+        end
+      end
+    end
+
+    context "with syntax errors (Junk)" do
+      it "raises TidyError by default" do
+        Tempfile.create(%w[broken .ftl]) do |f|
+          f.write("hello = Hi\nbad entry\n")
+          f.flush
+
+          expect {
+            command.call(files: [f.path], write: false, check: false, diff: false, with_junk: false)
+          }.to raise_error(Foxtail::CLI::TidyError)
+        end
+      end
+
+      it "includes Junk when --with-junk is specified" do
+        Tempfile.create(%w[broken .ftl]) do |f|
+          f.write("hello = Hi\nbad entry\n")
+          f.flush
+
+          expect {
+            command.call(files: [f.path], write: false, check: false, diff: false, with_junk: true)
+          }.to output(/hello = Hi.*bad entry/m).to_stdout
+        end
+      end
+    end
+  end
+end

--- a/spec/foxtail/serializer_spec.rb
+++ b/spec/foxtail/serializer_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+RSpec.describe Foxtail::Serializer do
+  subject(:serializer) { Foxtail::Serializer.new(**options) }
+
+  let(:options) { {} }
+  let(:parser) { Foxtail::Parser.new }
+
+  def parse_and_serialize(ftl)
+    resource = parser.parse(ftl)
+    serializer.serialize(resource)
+  end
+
+  describe "#serialize" do
+    context "with simple messages" do
+      it "serializes a simple message" do
+        result = parse_and_serialize("hello = Hello, world!\n")
+        expect(result).to eq("hello = Hello, world!\n")
+      end
+
+      it "normalizes spacing around equals sign" do
+        result = parse_and_serialize("hello=Hello\n")
+        expect(result).to eq("hello = Hello\n")
+      end
+    end
+
+    context "with variables" do
+      it "serializes variable references" do
+        result = parse_and_serialize("greeting = Hello, { $name }!\n")
+        expect(result).to eq("greeting = Hello, { $name }!\n")
+      end
+    end
+
+    context "with select expressions" do
+      it "serializes select expressions on new line" do
+        ftl = <<~FTL
+          emails = { $count ->
+              [one] one email
+             *[other] { $count } emails
+          }
+        FTL
+        result = parse_and_serialize(ftl)
+        expect(result).to include("{ $count ->")
+        expect(result).to include("[one]")
+        expect(result).to include("*[other]")
+      end
+    end
+
+    context "with terms" do
+      it "serializes terms with dash prefix" do
+        result = parse_and_serialize("-brand = Firefox\n")
+        expect(result).to eq("-brand = Firefox\n")
+      end
+
+      it "serializes term references" do
+        ftl = <<~FTL
+          -brand = Firefox
+          welcome = Welcome to { -brand }
+        FTL
+        result = parse_and_serialize(ftl)
+        expect(result).to include("{ -brand }")
+      end
+    end
+
+    context "with attributes" do
+      it "serializes message attributes" do
+        ftl = <<~FTL
+          login =
+              .placeholder = Email
+              .title = Login form
+        FTL
+        result = parse_and_serialize(ftl)
+        expect(result).to include(".placeholder = Email")
+        expect(result).to include(".title = Login form")
+      end
+    end
+
+    context "with comments" do
+      it "serializes message comments" do
+        ftl = <<~FTL
+          # This is a comment
+          hello = Hello
+        FTL
+        result = parse_and_serialize(ftl)
+        expect(result).to include("# This is a comment")
+      end
+
+      it "serializes group comments with ##" do
+        ftl = <<~FTL
+          ## Group comment
+          hello = Hello
+        FTL
+        result = parse_and_serialize(ftl)
+        expect(result).to include("## Group comment")
+      end
+
+      it "serializes resource comments with ###" do
+        ftl = <<~FTL
+          ### Resource comment
+          hello = Hello
+        FTL
+        result = parse_and_serialize(ftl)
+        expect(result).to include("### Resource comment")
+      end
+    end
+
+    context "with functions" do
+      it "serializes function calls" do
+        ftl = "amount = { NUMBER($value, style: \"currency\") }\n"
+        result = parse_and_serialize(ftl)
+        expect(result).to include("NUMBER($value, style: \"currency\")")
+      end
+    end
+
+    context "with Junk entries" do
+      let(:ftl) { "hello = Hi\nbad entry\n" }
+
+      context "when with_junk is false (default)" do
+        it "excludes Junk from output" do
+          result = parse_and_serialize(ftl)
+          expect(result).to eq("hello = Hi\n")
+          expect(result).not_to include("bad entry")
+        end
+      end
+
+      context "when with_junk is true" do
+        let(:options) { {with_junk: true} }
+
+        it "includes Junk in output" do
+          result = parse_and_serialize(ftl)
+          expect(result).to include("hello = Hi")
+          expect(result).to include("bad entry")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Add `foxtail tidy` command for formatting FTL files with consistent style, following Unix conventions.

## Changes
- Add `Serializer` class for converting AST back to FTL format
- Add `tidy` command with options: `--write`, `--check`, `--diff`, `--with-junk`
- Improve error handling in CLI with proper exit codes

## Options
| Option | Description |
|--------|-------------|
| (default) | Output formatted content to stdout |
| `--write` / `-w` | Write result back to source file |
| `--check` / `-c` | Check if files are formatted (for CI) |
| `--diff` / `-d` | Show unified diff |
| `--with-junk` | Allow formatting files with syntax errors |

## Test Plan
```bash
# Format and output to stdout
bundle exec foxtail tidy file.ftl

# Check formatting (CI mode)
bundle exec foxtail tidy --check file.ftl

# Show diff
bundle exec foxtail tidy --diff file.ftl

# Format in-place
bundle exec foxtail tidy --write file.ftl
```

Fixes #120
