### PR TITLE
:sparkles: Add CLI ids command for extracting message and term IDs

### DIFF
--- a/lib/foxtail/cli.rb
+++ b/lib/foxtail/cli.rb
@@ -7,6 +7,7 @@ module Foxtail
   module CLI
     extend Dry::CLI::Registry
 
+    register "ids", Commands::Ids
     register "lint", Commands::Lint
     register "tidy", Commands::Tidy
   end

--- a/lib/foxtail/cli/commands/ids.rb
+++ b/lib/foxtail/cli/commands/ids.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Foxtail
+  # Command-line interface for Foxtail
+  module CLI
+    module Commands
+      # Extract message and term IDs from FTL files
+      class Ids < Dry::CLI::Command
+        desc "Extract message and term IDs from FTL files"
+
+        argument :files, type: :array, required: true, desc: "FTL files to extract IDs from"
+
+        option :only_messages, type: :flag, default: false, aliases: ["-m"], desc: "Show only message IDs"
+        option :only_terms, type: :flag, default: false, aliases: ["-t"], desc: "Show only term IDs"
+        option :with_attributes, type: :flag, default: false, aliases: ["-a"], desc: "Include attribute names"
+        option :json, type: :flag, default: false, aliases: ["-j"], desc: "Output as JSON array"
+
+        # Execute the ids command
+        def call(files:, only_messages:, only_terms:, with_attributes:, json:, **)
+          ids = []
+
+          files.each do |file|
+            ids.concat(extract_ids(file, only_messages:, only_terms:, with_attributes:))
+          end
+
+          if json
+            puts JSON.pretty_generate(ids)
+          else
+            ids.each { puts _1 }
+          end
+        end
+
+        private def extract_ids(path, only_messages:, only_terms:, with_attributes:)
+          ids = []
+          content = File.read(path)
+          parser = Foxtail::Parser.new
+          resource = parser.parse(content)
+
+          resource.body.each do |entry|
+            case entry
+            when Foxtail::Parser::AST::Message
+              next if only_terms
+
+              ids << entry.id.name
+              ids.concat(attribute_ids(entry)) if with_attributes
+            when Foxtail::Parser::AST::Term
+              next if only_messages
+
+              ids << "-#{entry.id.name}"
+              ids.concat(attribute_ids(entry, prefix: "-")) if with_attributes
+            end
+          end
+
+          ids
+        end
+
+        private def attribute_ids(entry, prefix: "")
+          entry.attributes.map { "#{prefix}#{entry.id.name}.#{_1.id.name}" }
+        end
+      end
+    end
+
+    register "ids", Commands::Ids
+  end
+end

--- a/spec/foxtail/cli/commands/ids_spec.rb
+++ b/spec/foxtail/cli/commands/ids_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "json"
+require "tempfile"
+
+RSpec.describe Foxtail::CLI::Commands::Ids do
+  subject(:command) { Foxtail::CLI::Commands::Ids.new }
+
+  let(:ftl_content) do
+    <<~FTL
+      hello = Hello
+      greeting = Hello, { $name }!
+          .placeholder = Your name
+
+      -brand = Firefox
+          .short = Fx
+    FTL
+  end
+
+  describe "#call" do
+    context "with default options" do
+      it "outputs all message and term IDs" do
+        Tempfile.create(%w[test .ftl]) do |f|
+          f.write(ftl_content)
+          f.flush
+
+          expect {
+            command.call(files: [f.path], only_messages: false, only_terms: false, with_attributes: false, json: false)
+          }.to output("hello\ngreeting\n-brand\n").to_stdout
+        end
+      end
+    end
+
+    context "with --only-messages option" do
+      it "outputs only message IDs" do
+        Tempfile.create(%w[test .ftl]) do |f|
+          f.write(ftl_content)
+          f.flush
+
+          expect {
+            command.call(files: [f.path], only_messages: true, only_terms: false, with_attributes: false, json: false)
+          }.to output("hello\ngreeting\n").to_stdout
+        end
+      end
+    end
+
+    context "with --only-terms option" do
+      it "outputs only term IDs" do
+        Tempfile.create(%w[test .ftl]) do |f|
+          f.write(ftl_content)
+          f.flush
+
+          expect {
+            command.call(files: [f.path], only_messages: false, only_terms: true, with_attributes: false, json: false)
+          }.to output("-brand\n").to_stdout
+        end
+      end
+    end
+
+    context "with --with-attributes option" do
+      it "includes attribute names" do
+        Tempfile.create(%w[test .ftl]) do |f|
+          f.write(ftl_content)
+          f.flush
+
+          expect {
+            command.call(files: [f.path], only_messages: false, only_terms: false, with_attributes: true, json: false)
+          }.to output("hello\ngreeting\ngreeting.placeholder\n-brand\n-brand.short\n").to_stdout
+        end
+      end
+    end
+
+    context "with --json option" do
+      it "outputs as JSON array" do
+        Tempfile.create(%w[test .ftl]) do |f|
+          f.write(ftl_content)
+          f.flush
+
+          output = capture_stdout {
+            command.call(files: [f.path], only_messages: false, only_terms: false, with_attributes: false, json: true)
+          }
+
+          expect(JSON.parse(output)).to eq(%w[hello greeting -brand])
+        end
+      end
+    end
+
+    context "with multiple files" do
+      it "combines IDs from all files" do
+        Dir.mktmpdir do |dir|
+          a_path = File.join(dir, "a.ftl")
+          b_path = File.join(dir, "b.ftl")
+          File.write(a_path, "msg-a = A\n")
+          File.write(b_path, "msg-b = B\n")
+
+          expect {
+            command.call(files: [a_path, b_path], only_messages: false, only_terms: false, with_attributes: false, json: false)
+          }.to output("msg-a\nmsg-b\n").to_stdout
+        end
+      end
+    end
+  end
+end

--- a/spec/support/output_helpers.rb
+++ b/spec/support/output_helpers.rb
@@ -1,6 +1,21 @@
 # frozen_string_literal: true
 
+require "stringio"
+
 module OutputHelpers
+  # Capture stdout output from a block
+  #
+  # @yield the block to execute
+  # @return [String] the captured stdout
+  def capture_stdout
+    original_stdout = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original_stdout
+  end
+
   # Capture stdout from system calls (e.g., system("diff", ...))
   # Uses file descriptor reopen to capture subprocess output
   #


### PR DESCRIPTION
## Summary
Add `foxtail ids` command to extract message and term IDs from FTL files.

## Usage

```bash
# List all IDs (messages and terms)
foxtail ids messages.ftl

# List only messages
foxtail ids messages.ftl --only-messages

# List only terms
foxtail ids messages.ftl --only-terms

# Include attribute names
foxtail ids messages.ftl --with-attributes

# Output as JSON
foxtail ids messages.ftl --json
```

## Options

| Option | Short | Description |
|--------|-------|-------------|
| `--only-messages` | `-m` | Show only message IDs |
| `--only-terms` | `-t` | Show only term IDs |
| `--with-attributes` | `-a` | Include attribute names |
| `--json` | `-j` | Output as pretty JSON array |

## Test Plan

- [x] Default output lists all message and term IDs
- [x] `--only-messages` filters to messages only
- [x] `--only-terms` filters to terms only
- [x] `--with-attributes` includes attribute names
- [x] `--json` outputs as JSON array
- [x] Multiple files combine IDs

Fixes #123