### PR TITLE
:memo: Add CLI documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ A Ruby implementation of [Project Fluent](https://projectfluent.org/) - a modern
 | Bundle system details | [doc/bundle-system.md](doc/bundle-system.md) |
 | Language fallback | [doc/sequence.md](doc/sequence.md) |
 | `icu4x` integration | [doc/icu4x-integration.md](doc/icu4x-integration.md) |
+| CLI reference | [doc/cli.md](doc/cli.md) |
 | Testing strategy | [doc/testing.md](doc/testing.md) |
 
 ## Core Principles

--- a/README.md
+++ b/README.md
@@ -114,23 +114,13 @@ See [doc/architecture.md](doc/architecture.md) for detailed design documentation
 
 ## CLI
 
-Foxtail provides command-line tools for working with FTL files.
+Foxtail provides command-line tools for working with FTL files:
 
-### Lint
+- `foxtail lint` - Check FTL files for syntax errors
+- `foxtail tidy` - Format FTL files with consistent style
+- `foxtail ids` - Extract message and term IDs
 
-Check FTL files for syntax errors:
-
-```bash
-foxtail lint messages.ftl
-foxtail lint locales/**/*.ftl
-```
-
-Options:
-- `-q, --quiet` - Only show errors, no summary
-
-Exit codes:
-- `0` - No errors found
-- `1` - Errors found or no files matched
+See [doc/cli.md](doc/cli.md) for full documentation.
 
 ## Compatibility
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -1,0 +1,127 @@
+# CLI Reference
+
+Foxtail provides command-line tools for working with FTL files.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `foxtail lint` | Check FTL files for syntax errors |
+| `foxtail tidy` | Format FTL files with consistent style |
+| `foxtail ids` | Extract message and term IDs from FTL files |
+
+## lint
+
+Check FTL files for syntax errors.
+
+```bash
+foxtail lint FILES
+```
+
+### Options
+
+| Option | Alias | Description |
+|--------|-------|-------------|
+| `--quiet` | `-q` | Only show errors, no summary |
+
+### Examples
+
+```bash
+# Check a single file
+foxtail lint messages.ftl
+
+# Check multiple files
+foxtail lint en.ftl ja.ftl
+
+# Quiet mode (only errors)
+foxtail lint -q messages.ftl
+```
+
+## tidy
+
+Format FTL files with consistent style.
+
+```bash
+foxtail tidy FILES
+```
+
+### Options
+
+| Option | Alias | Description |
+|--------|-------|-------------|
+| `--write` | `-w` | Write result back to source file |
+| `--check` | `-c` | Check if files are formatted (for CI) |
+| `--diff` | `-d` | Show diff instead of formatted output |
+| `--with-junk` | | Allow formatting files with syntax errors |
+
+### Examples
+
+```bash
+# Preview formatted output
+foxtail tidy messages.ftl
+
+# Format in place
+foxtail tidy -w messages.ftl
+
+# Check formatting (for CI)
+foxtail tidy -c messages.ftl
+
+# Show diff
+foxtail tidy -d messages.ftl
+```
+
+## ids
+
+Extract message and term IDs from FTL files.
+
+```bash
+foxtail ids FILES
+```
+
+### Options
+
+| Option | Alias | Description |
+|--------|-------|-------------|
+| `--only-messages` | `-m` | Show only message IDs |
+| `--only-terms` | `-t` | Show only term IDs |
+| `--with-attributes` | `-a` | Include attribute names |
+| `--json` | `-j` | Output as JSON array |
+
+### Examples
+
+```bash
+# List all IDs
+foxtail ids messages.ftl
+
+# Only message IDs
+foxtail ids -m messages.ftl
+
+# Only term IDs
+foxtail ids -t messages.ftl
+
+# Include attributes
+foxtail ids -a messages.ftl
+# Output: greeting, greeting.placeholder, -brand, -brand.short
+
+# JSON output
+foxtail ids -j messages.ftl
+# Output: ["greeting", "-brand"]
+```
+
+### Output Format
+
+By default, IDs are output one per line:
+
+```
+greeting
+-brand
+```
+
+With `--json`, output is a JSON array:
+
+```json
+[
+  "greeting",
+  "-brand"
+]
+```


### PR DESCRIPTION
## Summary

Add comprehensive CLI documentation and update references.

## Changes

- Create `doc/cli.md` with full command reference for lint, tidy, and ids
- Update README CLI section to link to new documentation
- Add CLI reference to documentation map in CLAUDE.md
