### PR TITLE
:sparkles: Add foxtail parse command for AST output

### DIFF
--- a/doc/cli.md
+++ b/doc/cli.md
@@ -6,9 +6,10 @@ Foxtail provides command-line tools for working with FTL files.
 
 | Command | Description |
 |---------|-------------|
-| `foxtail lint` | Check FTL files for syntax errors |
-| `foxtail tidy` | Format FTL files with consistent style |
 | `foxtail ids` | Extract message and term IDs from FTL files |
+| `foxtail lint` | Check FTL files for syntax errors |
+| `foxtail parse` | Parse FTL files and output AST as JSON |
+| `foxtail tidy` | Format FTL files with consistent style |
 
 ## lint
 
@@ -35,6 +36,61 @@ foxtail lint en.ftl ja.ftl
 
 # Quiet mode (only errors)
 foxtail lint -q messages.ftl
+```
+
+## parse
+
+Parse FTL files and output the AST as JSON.
+
+```bash
+foxtail parse FILES
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--with-spans` | Include source position information in output |
+
+### Examples
+
+```bash
+# Parse a single file
+foxtail parse messages.ftl
+
+# Parse with span information
+foxtail parse messages.ftl --with-spans
+
+# Parse multiple files (outputs JSON array)
+foxtail parse en.ftl ja.ftl
+
+# Compare AST before and after tidy
+foxtail parse original.ftl > before.json
+foxtail tidy original.ftl > tidied.ftl
+foxtail parse tidied.ftl > after.json
+diff before.json after.json
+```
+
+### Output Format
+
+JSON output follows the fluent.js AST structure:
+
+```json
+{
+  "file": "messages.ftl",
+  "ast": {
+    "type": "Resource",
+    "body": [
+      {
+        "type": "Message",
+        "id": { "type": "Identifier", "name": "hello" },
+        "value": { "type": "Pattern", "elements": [...] },
+        "attributes": [],
+        "comment": null
+      }
+    ]
+  }
+}
 ```
 
 ## tidy

--- a/lib/foxtail/cli.rb
+++ b/lib/foxtail/cli.rb
@@ -53,6 +53,7 @@ module Foxtail
 
     register "ids", Commands::Ids
     register "lint", Commands::Lint
+    register "parse", Commands::Parse
     register "tidy", Commands::Tidy
   end
 end

--- a/lib/foxtail/cli/commands/parse.rb
+++ b/lib/foxtail/cli/commands/parse.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Foxtail
+  # Command-line interface for Foxtail
+  module CLI
+    module Commands
+      # Parse FTL files and output AST as JSON
+      class Parse < Dry::CLI::Command
+        desc "Parse FTL files and output AST as JSON"
+
+        argument :files, type: :array, required: true, desc: "FTL files to parse"
+
+        option :with_spans, type: :flag, default: false, desc: "Include span information in output"
+
+        # Execute the parse command
+        # @param files [Array<String>] FTL files to parse
+        # @param with_spans [Boolean] Include span information
+        # @return [void]
+        def call(files:, with_spans:, **)
+          raise Foxtail::CLI::NoFilesError if files.empty?
+
+          results = files.map {|file| parse_file(Pathname(file), with_spans:) }
+
+          output = files.size == 1 ? results.first : results
+          puts JSON.pretty_generate(output)
+        end
+
+        private def parse_file(path, with_spans:)
+          content = path.read
+          parser = Foxtail::Syntax::Parser.new(with_spans:)
+          resource = parser.parse(content)
+
+          {
+            "file" => path.to_s,
+            "ast" => resource.to_h
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/foxtail/cli/commands/parse_spec.rb
+++ b/spec/foxtail/cli/commands/parse_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "json"
+require "tempfile"
+
+RSpec.describe Foxtail::CLI::Commands::Parse do
+  subject(:command) { Foxtail::CLI::Commands::Parse.new }
+
+  describe "#call" do
+    context "with no files" do
+      it "raises NoFilesError" do
+        expect {
+          command.call(files: [], with_spans: false)
+        }.to raise_error(Foxtail::CLI::NoFilesError, "No files specified")
+      end
+    end
+
+    context "with valid FTL file" do
+      it "outputs JSON AST" do
+        Tempfile.create(%w[valid .ftl]) do |f|
+          f.write("hello = Hello, world!\n")
+          f.flush
+
+          output = capture_stdout { command.call(files: [f.path], with_spans: false) }
+          result = JSON.parse(output)
+
+          expect(result["file"]).to eq(f.path)
+          expect(result["ast"]["type"]).to eq("Resource")
+          expect(result["ast"]["body"].first["type"]).to eq("Message")
+          expect(result["ast"]["body"].first["id"]["name"]).to eq("hello")
+        end
+      end
+
+      it "excludes span information by default" do
+        Tempfile.create(%w[valid .ftl]) do |f|
+          f.write("hello = Hi\n")
+          f.flush
+
+          output = capture_stdout { command.call(files: [f.path], with_spans: false) }
+          result = JSON.parse(output)
+
+          expect(result["ast"]["body"].first).not_to have_key("span")
+        end
+      end
+
+      it "includes span information when --with-spans is specified" do
+        Tempfile.create(%w[valid .ftl]) do |f|
+          f.write("hello = Hi\n")
+          f.flush
+
+          output = capture_stdout { command.call(files: [f.path], with_spans: true) }
+          result = JSON.parse(output)
+
+          expect(result["ast"]["body"].first["span"]).to include("start", "end")
+        end
+      end
+    end
+
+    context "with multiple files" do
+      it "outputs array of ASTs" do
+        Dir.mktmpdir do |dir|
+          en_path = File.join(dir, "en.ftl")
+          ja_path = File.join(dir, "ja.ftl")
+          File.write(en_path, "hello = Hello!\n")
+          File.write(ja_path, "hello = こんにちは！\n")
+
+          output = capture_stdout { command.call(files: [en_path, ja_path], with_spans: false) }
+          result = JSON.parse(output)
+
+          expect(result).to be_an(Array)
+          expect(result.size).to eq(2)
+          expect(result[0]["file"]).to eq(en_path)
+          expect(result[1]["file"]).to eq(ja_path)
+        end
+      end
+    end
+
+    context "with file containing junk" do
+      it "includes junk entries in AST" do
+        Tempfile.create(%w[junk .ftl]) do |f|
+          f.write("hello = Hi\nbad entry\n")
+          f.flush
+
+          output = capture_stdout { command.call(files: [f.path], with_spans: false) }
+          result = JSON.parse(output)
+
+          types = result["ast"]["body"].map {|e| e["type"] }
+          expect(types).to include("Junk")
+        end
+      end
+    end
+  end
+
+  private def capture_stdout
+    original_stdout = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original_stdout
+  end
+end


### PR DESCRIPTION
## Summary

Add `foxtail parse` command that outputs the AST of FTL files as pretty JSON, useful for debugging and tooling.

## Changes

- Add `foxtail parse` command with `--with-spans` option
- Output AST in fluent.js compatible JSON format
- Add tests for the new command
- Update CLI documentation

## Test Plan

```bash
foxtail parse messages.ftl
foxtail parse messages.ftl --with-spans
```

Fixes #121
