### PR TITLE
:sparkles: Add dungeon game localization example

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,3 +92,7 @@ Style/DoubleNegation:
 # or when unhandled cases should be ignored intentionally
 Style/MissingElse:
   Enabled: false
+
+Style/TopLevelMethodDefinition:
+  Exclude:
+    - 'examples/**/*.rb'

--- a/examples/dungeon_game/README.md
+++ b/examples/dungeon_game/README.md
@@ -1,0 +1,263 @@
+# Dungeon Game Example
+
+Demonstrates advanced localization for game items with grammatical gender, number, case, articles, and counter words.
+
+## Features
+
+- **Two-layer Bundle architecture**: Separate bundles for items (Terms) and messages
+- **Custom functions**: Language-specific functions for dynamic item embedding
+  - English/German/French: `ARTICLE_ITEM`, `COUNT_ITEM`
+  - Japanese: `ITEM`, `COUNT`
+- **German grammatical cases**: nominative, accusative, dative, genitive
+- **German grammatical gender**: masculine, feminine, neuter
+- **French elision**: Automatic article contraction (le/la → l' before vowels)
+- **Counter words**: Japanese 助数詞 (振, 本, 組, 瓶), English/German/French counters (pair, flask, Paar, Flasche, paire, fiole)
+- **FTL-based article definitions**: Articles defined in FTL, not hardcoded in Ruby
+
+## Structure
+
+```
+dungeon_game/
+  main.rb                    # Main application
+  functions/
+    base.rb                  # Base class for item functions
+    de.rb                    # German-specific (case declension)
+    en.rb                    # English-specific (a/an selection)
+    fr.rb                    # French-specific (elision handling)
+    ja.rb                    # Japanese-specific (counter words)
+  locales/
+    en/
+      articles.ftl           # English article terms (-def-article, -indef-article)
+      counters.ftl           # English counter terms (-pair, -flask)
+      items.ftl              # English item terms (singular/plural, counter refs)
+      messages.ftl           # English messages
+    de/
+      articles.ftl           # German article terms (gender × case × number)
+      counters.ftl           # German counter terms (Paar, Flasche)
+      items.ftl              # German item terms (gender, case, number)
+      messages.ftl           # German messages with case usage
+    fr/
+      articles.ftl           # French article terms with elision patterns
+      counters.ftl           # French counter terms (paire, fiole)
+      items.ftl              # French item terms (gender, elision flags)
+      messages.ftl           # French messages
+    ja/
+      items.ftl              # Japanese item terms with counters
+      messages.ftl           # Japanese messages
+```
+
+## Run
+
+```bash
+bundle exec ruby examples/dungeon_game/main.rb
+```
+
+## Architecture
+
+### Two-layer Bundle Design
+
+```
+┌─────────────────────────────────────────────────┐
+│  Items Bundle (per language)                    │
+│  - Terms: items, articles, counters             │
+│  - All linguistic data in FTL                   │
+└─────────────────────────────────────────────────┘
+                      ↓ Captured via closure
+┌─────────────────────────────────────────────────┐
+│  Custom Functions (ItemFunctions module)        │
+│  - Language-specific subclasses                 │
+│  - Resolves terms and formats output            │
+└─────────────────────────────────────────────────┘
+                      ↓ Injected into functions:
+┌─────────────────────────────────────────────────┐
+│  Messages Bundle (per language)                 │
+│  - Messages only                                │
+│  - Uses custom functions to embed item names    │
+└─────────────────────────────────────────────────┘
+```
+
+### Why Two Bundles?
+
+1. **Separation of concerns**: Item vocabulary vs. game messages
+2. **Translator efficiency**: Edit item declensions directly in FTL
+3. **No circular references**: Items Bundle created first, then used by functions
+4. **Reusability**: Items Bundle can be shared across multiple Messages Bundles
+
+## Key Concepts
+
+### Function Signatures
+
+Each language provides different functions based on its needs:
+
+**English/German/French:**
+```ftl
+# ARTICLE_ITEM: Item with article
+{ ARTICLE_ITEM($item, $count, type: "indefinite", case: "nominative", cap: "false") }
+
+# COUNT_ITEM: Count with item (uses counter if defined)
+{ COUNT_ITEM($item, $count, type: "none", case: "nominative", cap: "false") }
+```
+
+**Japanese:**
+```ftl
+# ITEM: Just the item name
+{ ITEM($item) }
+
+# COUNT: Count with counter word
+{ COUNT($item, $count) }
+```
+
+### German Article Declension (FTL-based)
+
+Articles are defined as FTL terms with gender, count, and case selectors:
+
+```ftl
+-def-article =
+    { $gender ->
+        [masculine]
+            { $count ->
+                [one]
+                    { $case ->
+                       *[nominative] der
+                        [accusative] den
+                        [dative] dem
+                        [genitive] des
+                    }
+               *[other]
+                    { $case ->
+                       *[nominative] die
+                        ...
+                    }
+            }
+        ...
+    }
+```
+
+### German Items with Cases
+
+```ftl
+-dagger =
+    { $count ->
+        [one]
+            { $case ->
+               *[nominative] Dolch
+                [accusative] Dolch
+                [dative] Dolch
+                [genitive] Dolches
+            }
+       *[other]
+            { $case ->
+               *[nominative] Dolche
+                [accusative] Dolche
+                [dative] Dolchen
+                [genitive] Dolche
+            }
+    }
+    .gender = masculine
+```
+
+### French Elision
+
+French handles elision (l'épée instead of la épée) via:
+
+1. **Automatic detection**: NFD normalization to detect vowels (é → e)
+2. **Explicit override**: `.elision = false` for h aspiré words (la hache)
+3. **FTL format patterns**: Conditional spacing based on elision
+
+```ftl
+# Format pattern for article + item
+-fmt-article-item =
+    { $elision ->
+        [true] {$article}{$item}
+       *[false] {$article} {$item}
+    }
+
+# Item with h aspiré (no elision)
+-axe = hache
+    .gender = feminine
+    .elision = false
+```
+
+### Japanese Counter Words
+
+Items can specify a counter term:
+
+```ftl
+-sword = 剣
+    .counter = -counter-furi
+
+-counter-furi =
+    { $count ->
+        [1] 1振り
+        [2] 2振り
+        [3] 3振り
+       *[other] { $count }振り
+    }
+```
+
+## Output Examples
+
+### English
+
+```
+You found a dagger.
+You found 3 daggers.
+You found a pair of gauntlets.
+You found 3 pairs of gauntlets.
+You found a flask of elixir.
+You attack with the sword.
+```
+
+### German
+
+```
+Du hast einen Dolch gefunden.      # accusative, indefinite, masculine
+Du hast 3 Dolche gefunden.         # accusative, plural
+Du hast ein Paar Panzerhandschuhe gefunden.  # counter: Paar
+Du greifst mit dem Schwert an.     # dative, definite, neuter
+```
+
+### French
+
+```
+Tu as trouvé un poignard.          # masculine, indefinite
+Tu as trouvé une épée.             # feminine, indefinite
+L'épée est ici.                    # elision: l' before vowel
+La hache est ici.                  # h aspiré: no elision
+Tu as trouvé une fiole d'élixir.   # counter elision: d' before vowel
+```
+
+### Japanese
+
+```
+短剣を1本見つけた。                 # counter: 本
+剣を3振り見つけた。                 # counter: 振り
+籠手を1組見つけた。                 # counter: 組
+```
+
+## Adding New Items
+
+1. Add a term to each language's `items.ftl`
+2. Include required attributes (.gender, .counter, .elision as needed)
+
+```ftl
+# de/items.ftl
+-spear =
+    { $count ->
+        [one]
+            { $case ->
+               *[nominative] Speer
+                [accusative] Speer
+                [dative] Speer
+                [genitive] Speers
+            }
+       *[other]
+            { $case ->
+               *[nominative] Speere
+                ...
+            }
+    }
+    .gender = masculine
+```
+
+No changes needed to Ruby code or message FTL files.

--- a/examples/dungeon_game/expected.txt
+++ b/examples/dungeon_game/expected.txt
@@ -1,0 +1,280 @@
+=== Dungeon Game Localization Demo ===
+
+--- English ---
+found-item:
+  You found a dagger.
+  You found 3 daggers.
+  You found an axe.
+  You found 3 axes.
+  You found a sword.
+  You found 3 swords.
+  You found a hammer.
+  You found 3 hammers.
+  You found a pair of gauntlets.
+  You found 3 pairs of gauntlets.
+  You found a flask of healing potion.
+  You found 3 flasks of healing potion.
+  You found a flask of elixir.
+  You found 3 flasks of elixir.
+attack-with-item:
+  You attack with the sword.
+item-is-here:
+  The dagger is here.
+  3 daggers are here.
+  The axe is here.
+  3 axes are here.
+  The sword is here.
+  3 swords are here.
+  The hammer is here.
+  3 hammers are here.
+  The pair of gauntlets is here.
+  3 pairs of gauntlets are here.
+  The flask of healing potion is here.
+  3 flasks of healing potion are here.
+  The flask of elixir is here.
+  3 flasks of elixir are here.
+drop-item:
+  You dropped a dagger.
+  You dropped 3 daggers.
+  You dropped an axe.
+  You dropped 3 axes.
+  You dropped a sword.
+  You dropped 3 swords.
+  You dropped a hammer.
+  You dropped 3 hammers.
+  You dropped a pair of gauntlets.
+  You dropped 3 pairs of gauntlets.
+  You dropped a flask of healing potion.
+  You dropped 3 flasks of healing potion.
+  You dropped a flask of elixir.
+  You dropped 3 flasks of elixir.
+inventory-item:
+  a dagger
+  3 daggers
+  an axe
+  3 axes
+  a sword
+  3 swords
+  a hammer
+  3 hammers
+  a pair of gauntlets
+  3 pairs of gauntlets
+  a flask of healing potion
+  3 flasks of healing potion
+  a flask of elixir
+  3 flasks of elixir
+
+--- German ---
+found-item:
+  Du hast einen Dolch gefunden.
+  Du hast 3 Dolche gefunden.
+  Du hast eine Axt gefunden.
+  Du hast 3 Äxte gefunden.
+  Du hast ein Schwert gefunden.
+  Du hast 3 Schwerter gefunden.
+  Du hast einen Hammer gefunden.
+  Du hast 3 Hämmer gefunden.
+  Du hast ein Paar Panzerhandschuhe gefunden.
+  Du hast 3 Paar Panzerhandschuhe gefunden.
+  Du hast eine Flasche Heiltrank gefunden.
+  Du hast 3 Flaschen Heiltrank gefunden.
+  Du hast eine Flasche Elixier gefunden.
+  Du hast 3 Flaschen Elixier gefunden.
+attack-with-item:
+  Du greifst mit dem Schwert an.
+item-is-here:
+  Der Dolch ist hier.
+  3 Dolche sind hier.
+  Die Axt ist hier.
+  3 Äxte sind hier.
+  Das Schwert ist hier.
+  3 Schwerter sind hier.
+  Der Hammer ist hier.
+  3 Hämmer sind hier.
+  Das Paar Panzerhandschuhe ist hier.
+  3 Paar Panzerhandschuhe sind hier.
+  Die Flasche Heiltrank ist hier.
+  3 Flaschen Heiltrank sind hier.
+  Die Flasche Elixier ist hier.
+  3 Flaschen Elixier sind hier.
+drop-item:
+  Du hast einen Dolch fallen gelassen.
+  Du hast 3 Dolche fallen gelassen.
+  Du hast eine Axt fallen gelassen.
+  Du hast 3 Äxte fallen gelassen.
+  Du hast ein Schwert fallen gelassen.
+  Du hast 3 Schwerter fallen gelassen.
+  Du hast einen Hammer fallen gelassen.
+  Du hast 3 Hämmer fallen gelassen.
+  Du hast ein Paar Panzerhandschuhe fallen gelassen.
+  Du hast 3 Paar Panzerhandschuhe fallen gelassen.
+  Du hast eine Flasche Heiltrank fallen gelassen.
+  Du hast 3 Flaschen Heiltrank fallen gelassen.
+  Du hast eine Flasche Elixier fallen gelassen.
+  Du hast 3 Flaschen Elixier fallen gelassen.
+inventory-item:
+  ein Dolch
+  3 Dolche
+  eine Axt
+  3 Äxte
+  ein Schwert
+  3 Schwerter
+  ein Hammer
+  3 Hämmer
+  ein Paar Panzerhandschuhe
+  3 Paar Panzerhandschuhe
+  eine Flasche Heiltrank
+  3 Flaschen Heiltrank
+  eine Flasche Elixier
+  3 Flaschen Elixier
+
+--- French ---
+found-item:
+  Tu as trouvé un poignard.
+  Tu as trouvé 3 poignards.
+  Tu as trouvé une hache.
+  Tu as trouvé 3 haches.
+  Tu as trouvé une épée.
+  Tu as trouvé 3 épées.
+  Tu as trouvé un marteau.
+  Tu as trouvé 3 marteaux.
+  Tu as trouvé une paire de gantelets.
+  Tu as trouvé 3 paires de gantelets.
+  Tu as trouvé une fiole de potion de soin.
+  Tu as trouvé 3 fioles de potion de soin.
+  Tu as trouvé une fiole d'élixir.
+  Tu as trouvé 3 fioles d'élixir.
+attack-with-item:
+  Tu attaques avec l'épée.
+item-is-here:
+  Le poignard est ici.
+  3 poignards sont ici.
+  La hache est ici.
+  3 haches sont ici.
+  L'épée est ici.
+  3 épées sont ici.
+  Le marteau est ici.
+  3 marteaux sont ici.
+  La paire de gantelets est ici.
+  3 paires de gantelets sont ici.
+  La fiole de potion de soin est ici.
+  3 fioles de potion de soin sont ici.
+  La fiole d'élixir est ici.
+  3 fioles d'élixir sont ici.
+drop-item:
+  Tu as laissé tomber un poignard.
+  Tu as laissé tomber 3 poignards.
+  Tu as laissé tomber une hache.
+  Tu as laissé tomber 3 haches.
+  Tu as laissé tomber une épée.
+  Tu as laissé tomber 3 épées.
+  Tu as laissé tomber un marteau.
+  Tu as laissé tomber 3 marteaux.
+  Tu as laissé tomber une paire de gantelets.
+  Tu as laissé tomber 3 paires de gantelets.
+  Tu as laissé tomber une fiole de potion de soin.
+  Tu as laissé tomber 3 fioles de potion de soin.
+  Tu as laissé tomber une fiole d'élixir.
+  Tu as laissé tomber 3 fioles d'élixir.
+inventory-item:
+  un poignard
+  3 poignards
+  une hache
+  3 haches
+  une épée
+  3 épées
+  un marteau
+  3 marteaux
+  une paire de gantelets
+  3 paires de gantelets
+  une fiole de potion de soin
+  3 fioles de potion de soin
+  une fiole d'élixir
+  3 fioles d'élixir
+
+--- Japanese ---
+found-item:
+  短剣を1振見つけた。
+  短剣を3振見つけた。
+  斧を1振見つけた。
+  斧を3振見つけた。
+  剣を1振見つけた。
+  剣を3振見つけた。
+  槌を1振見つけた。
+  槌を3振見つけた。
+  籠手を1組見つけた。
+  籠手を3組見つけた。
+  回復薬を1瓶見つけた。
+  回復薬を3瓶見つけた。
+  霊薬を1瓶見つけた。
+  霊薬を3瓶見つけた。
+attack-with-item:
+  剣で攻撃した。
+item-is-here:
+  短剣が1振ある。
+  短剣が3振ある。
+  斧が1振ある。
+  斧が3振ある。
+  剣が1振ある。
+  剣が3振ある。
+  槌が1振ある。
+  槌が3振ある。
+  籠手が1組ある。
+  籠手が3組ある。
+  回復薬が1瓶ある。
+  回復薬が3瓶ある。
+  霊薬が1瓶ある。
+  霊薬が3瓶ある。
+drop-item:
+  短剣を1振捨てた。
+  短剣を3振捨てた。
+  斧を1振捨てた。
+  斧を3振捨てた。
+  剣を1振捨てた。
+  剣を3振捨てた。
+  槌を1振捨てた。
+  槌を3振捨てた。
+  籠手を1組捨てた。
+  籠手を3組捨てた。
+  回復薬を1瓶捨てた。
+  回復薬を3瓶捨てた。
+  霊薬を1瓶捨てた。
+  霊薬を3瓶捨てた。
+inventory-item:
+  短剣 x 1振
+  短剣 x 3振
+  斧 x 1振
+  斧 x 3振
+  剣 x 1振
+  剣 x 3振
+  槌 x 1振
+  槌 x 3振
+  籠手 x 1組
+  籠手 x 3組
+  回復薬 x 1瓶
+  回復薬 x 3瓶
+  霊薬 x 1瓶
+  霊薬 x 3瓶
+
+=== German Grammatical Cases ===
+
+Nominative (subject): Das Schwert ist hier.
+Accusative (direct object): Du hast ein Schwert gefunden.
+Dative (with preposition): Du greifst mit dem Schwert an.
+
+=== German Grammatical Gender ===
+
+Masculine (der Dolch): Du hast einen Dolch gefunden.
+Feminine (die Axt): Du hast eine Axt gefunden.
+Neuter (das Schwert): Du hast ein Schwert gefunden.
+
+=== French Elision ===
+
+With elision (l'épée): L'épée est ici.
+Without elision - h aspiré (la hache): La hache est ici.
+Masculine (le poignard): Le poignard est ici.
+
+=== French Counter Elision ===
+
+Counter + consonant (fiole de potion): Tu as trouvé une fiole de potion de soin.
+Counter + vowel (fiole d'élixir): Tu as trouvé une fiole d'élixir.

--- a/examples/dungeon_game/functions/base.rb
+++ b/examples/dungeon_game/functions/base.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+# Namespace for item localization function handlers
+module ItemFunctions
+  # Base class for language-specific item localization functions.
+  #
+  # Provides common fluent functions (ARTICLE_ITEM, COUNT_ITEM) and template methods
+  # for subclasses to override language-specific behavior.
+  #
+  # Note on the `cap` parameter:
+  # Capitalization at sentence start is technically a message-layer concern,
+  # not an item-layer concern. However, Fluent does not support function nesting
+  # (e.g., CAPITALIZE(COUNT_ITEM(...))), so we use the `cap` parameter as a
+  # pragmatic workaround. The message layer passes `cap: "true"` as a hint
+  # when the result will appear at sentence start.
+  class Base
+    def initialize(items_bundle)
+      @items_bundle = items_bundle
+    end
+
+    # Returns the custom Fluent functions provided by this handler.
+    # Subclasses must override this method.
+    # @return [Hash{String => #call}] function name to callable mapping
+    def functions
+      raise NotImplementedError, "Subclasses must implement #functions"
+    end
+
+    # Fluent function: ARTICLE_ITEM(item_id, count = 1, type: "indefinite", case: "nominative", cap: "false")
+    def fluent_article_item(item_id, count=1, **options)
+      type = options.fetch(:type, "indefinite")
+      grammatical_case = options.fetch(:case, "nominative")
+      cap = options.fetch(:cap, "false")
+
+      item = resolve_item(item_id, count, grammatical_case)
+      article = resolve_article(item_id, count, type, grammatical_case)
+      result = format_article_item(article, item)
+      cap == "true" ? capitalize_first(result) : result
+    end
+
+    # Fluent function: COUNT_ITEM(item_id, count, type: "none", case: "nominative", cap: "false")
+    def fluent_count_item(item_id, count, **options)
+      type = options.fetch(:type, "none")
+      grammatical_case = options.fetch(:case, "nominative")
+      cap = options.fetch(:cap, "false")
+
+      counter_term = resolve_counter_term(item_id)
+
+      result = if counter_term
+                 format_count_item_with_counter(counter_term, item_id, count, type, grammatical_case)
+               elsif count == 1 && type != "none"
+                 item = resolve_item(item_id, count, grammatical_case)
+                 article = resolve_article(item_id, count, type, grammatical_case)
+                 format_article_item(article, item)
+               else
+                 "#{count} #{resolve_item(item_id, count, grammatical_case)}"
+               end
+
+      cap == "true" ? capitalize_first(result) : result
+    end
+
+    private def capitalize_first(str) = str.sub(/\A\p{Ll}/, &:upcase)
+
+    private def format_article_counter_item(article, counter, item)
+      return [counter, item].compact.join(" ") unless article
+
+      term = @items_bundle.term("-fmt-article-counter-item")
+      if term
+        @items_bundle.format_pattern(term.value, article:, counter:, item:)
+      else
+        "#{article} #{counter} #{item}"
+      end
+    end
+
+    private def format_article_item(article, item)
+      return item unless article
+
+      term = @items_bundle.term("-fmt-article-item")
+      if term
+        @items_bundle.format_pattern(term.value, article:, item:)
+      else
+        "#{article} #{item}"
+      end
+    end
+
+    private def format_count_item_with_counter(counter_term, item_id, count, type, grammatical_case)
+      item = resolve_item(item_id, 1, grammatical_case)
+      counter = @items_bundle.format_pattern(counter_term.value, count:, case: grammatical_case)
+
+      if count == 1 && type != "none"
+        counter_gender = counter_term.attributes&.dig("gender")
+        article = resolve_article_for_counter(counter_term, counter_gender, count, type, grammatical_case)
+        format_article_counter_item(article, counter, item)
+      else
+        format_count_counter_item(count, counter, item)
+      end
+    end
+
+    private def format_count_counter_item(count, counter, item)
+      term = @items_bundle.term("-fmt-count-counter-item")
+      if term
+        @items_bundle.format_pattern(term.value, count:, counter:, item:)
+      else
+        "#{count} #{counter} #{item}"
+      end
+    end
+
+    private def resolve_article(_item_id, _count, _type, _grammatical_case) = nil
+
+    private def resolve_article_for_counter(_counter_term, gender, count, type, grammatical_case)
+      return nil unless gender
+
+      resolve_article_for_gender(gender, count, type, grammatical_case)
+    end
+
+    private def resolve_article_for_gender(_gender, _count, _type, _grammatical_case) = nil
+
+    private def resolve_counter_term(item_id)
+      term = @items_bundle.term("-#{item_id}")
+      return nil unless term&.attributes&.dig("counter")
+
+      counter_attr = term.attributes["counter"]
+      counter_str = counter_attr.is_a?(String) ? counter_attr : @items_bundle.format_pattern(counter_attr)
+      return nil unless counter_str.start_with?("-")
+
+      @items_bundle.term(counter_str)
+    end
+
+    private def resolve_item(item_id, count, grammatical_case)
+      term = @items_bundle.term("-#{item_id}")
+      return "{#{item_id}}" unless term
+
+      @items_bundle.format_pattern(term.value, count:, case: grammatical_case)
+    end
+  end
+end

--- a/examples/dungeon_game/functions/de.rb
+++ b/examples/dungeon_game/functions/de.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# German-specific item localization functions
+module ItemFunctions
+  # German item localization handler.
+  #
+  # Provides article declension based on grammatical gender (masculine, feminine, neuter),
+  # number (singular, plural), and case (nominative, accusative, dative, genitive).
+  class De < Base
+    # @return [Hash{String => #call}] ARTICLE_ITEM and COUNT_ITEM functions
+    def functions
+      {
+        "ARTICLE_ITEM" => method(:fluent_article_item),
+        "COUNT_ITEM" => method(:fluent_count_item)
+      }
+    end
+
+    # L1: entry points from Base (alphabetical)
+    private def resolve_article(item_id, count, type, grammatical_case)
+      return nil if type == "none"
+      # Indefinite only for singular
+      return nil if type == "indefinite" && count != 1
+
+      gender = resolve_gender(item_id)
+      return nil unless gender
+
+      term_name = type == "definite" ? "-def-article" : "-indef-article"
+      term = @items_bundle.term(term_name)
+      return nil unless term
+
+      @items_bundle.format_pattern(
+        term.value,
+        gender:,
+        count:,
+        case: grammatical_case
+      )
+    end
+
+    private def resolve_article_for_gender(gender, count, type, grammatical_case)
+      return nil if type == "none"
+      return nil if type == "indefinite" && count != 1
+
+      term_name = type == "definite" ? "-def-article" : "-indef-article"
+      term = @items_bundle.term(term_name)
+      return nil unless term
+
+      @items_bundle.format_pattern(
+        term.value,
+        gender:,
+        count:,
+        case: grammatical_case
+      )
+    end
+
+    # L2: called by L1
+    private def resolve_gender(item_id)
+      term = @items_bundle.term("-#{item_id}")
+      term&.attributes&.dig("gender")
+    end
+  end
+end

--- a/examples/dungeon_game/functions/en.rb
+++ b/examples/dungeon_game/functions/en.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# English-specific item localization functions
+module ItemFunctions
+  # English item localization handler.
+  #
+  # Provides indefinite article selection (a/an) based on first letter,
+  # with support for explicit overrides via .indef attribute.
+  class En < Base
+    # @return [Hash{String => #call}] ARTICLE_ITEM and COUNT_ITEM functions
+    def functions
+      {
+        "ARTICLE_ITEM" => method(:fluent_article_item),
+        "COUNT_ITEM" => method(:fluent_count_item)
+      }
+    end
+
+    # L1: entry points from Base (alphabetical)
+    private def resolve_article(item_id, count, type, _grammatical_case=nil)
+      return nil if type == "none"
+      # Indefinite only for singular
+      return nil if type == "indefinite" && count != 1
+
+      if type == "definite"
+        resolve_definite_article
+      else
+        resolve_indefinite_article(item_id, count)
+      end
+    end
+
+    private def resolve_article_for_counter(counter_term, _gender, count, type, _grammatical_case)
+      if type == "definite"
+        resolve_definite_article
+      else
+        resolve_indefinite_article_for_counter(counter_term, count)
+      end
+    end
+
+    # L2: called by L1 (alphabetical)
+    private def resolve_definite_article
+      term = @items_bundle.term("-def-article")
+      return "the" unless term
+
+      @items_bundle.format_pattern(term.value)
+    end
+
+    private def resolve_indefinite_article(item_id, count)
+      # Check explicit .indef attribute first
+      item_term = @items_bundle.term("-#{item_id}")
+      return item_term.attributes["indef"] if item_term&.attributes&.key?("indef")
+
+      # Use FTL term with first_letter selector
+      term = @items_bundle.term("-indef-article")
+      return "a" unless term
+
+      item = resolve_item(item_id, count, "nominative")
+      first_letter = extract_first_letter(item)
+      @items_bundle.format_pattern(term.value, first_letter:)
+    end
+
+    private def resolve_indefinite_article_for_counter(counter_term, count)
+      # Check explicit .indef attribute first
+      return counter_term.attributes["indef"] if counter_term.attributes&.key?("indef")
+
+      # Use FTL term with first_letter selector
+      term = @items_bundle.term("-indef-article")
+      return "a" unless term
+
+      counter = @items_bundle.format_pattern(counter_term.value, count:)
+      first_letter = extract_first_letter(counter)
+      @items_bundle.format_pattern(term.value, first_letter:)
+    end
+
+    # L3: utility
+    # Extract first letter, handling accented characters via NFD normalization
+    # e.g., "élixir" → NFD → "e" + combining accent → first char "e"
+    private def extract_first_letter(str)
+      str.unicode_normalize(:nfd)[0]&.downcase || ""
+    end
+  end
+end

--- a/examples/dungeon_game/functions/fr.rb
+++ b/examples/dungeon_game/functions/fr.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+# French-specific item localization functions
+module ItemFunctions
+  # French item localization handler.
+  #
+  # Provides article selection with elision handling (le/la → l' before vowels),
+  # with support for h aspiré exceptions via .elision attribute.
+  class Fr < Base
+    # @return [Hash{String => #call}] ARTICLE_ITEM and COUNT_ITEM functions
+    def functions
+      {
+        "ARTICLE_ITEM" => method(:fluent_article_item),
+        "COUNT_ITEM" => method(:fluent_count_item)
+      }
+    end
+
+    # L1: entry points from Base (alphabetical)
+    private def format_article_counter_item(article, counter, item, counter_elision: false)
+      unless article
+        term = @items_bundle.term("-fmt-counter-item")
+        return @items_bundle.format_pattern(term.value, counter:, item:, elision: counter_elision.to_s)
+      end
+
+      article_elision = article.end_with?("'")
+      term = @items_bundle.term("-fmt-article-counter-item")
+      @items_bundle.format_pattern(
+        term.value,
+        article:,
+        counter:,
+        item:,
+        article_elision: article_elision.to_s,
+        counter_elision: counter_elision.to_s
+      )
+    end
+
+    private def format_article_item(article, item)
+      return item unless article
+
+      elision = article.end_with?("'")
+      term = @items_bundle.term("-fmt-article-item")
+      @items_bundle.format_pattern(term.value, article:, item:, elision: elision.to_s)
+    end
+
+    private def format_count_item_with_counter(counter_term, item_id, count, type, grammatical_case)
+      item = resolve_item(item_id, 1, grammatical_case)
+      item_elision = should_elide_for_item?(item_id)
+      counter = @items_bundle.format_pattern(counter_term.value, count:, elision: item_elision.to_s)
+
+      if count == 1 && type != "none"
+        counter_gender = counter_term.attributes&.dig("gender") || "feminine"
+        article = resolve_article_for_counter(counter_term, counter_gender, count, type, grammatical_case)
+        format_article_counter_item(article, counter, item, counter_elision: item_elision)
+      else
+        format_count_counter_item(count, counter, item, item_elision)
+      end
+    end
+
+    private def format_count_counter_item(count, counter, item, elision)
+      term = @items_bundle.term("-fmt-count-counter-item")
+      @items_bundle.format_pattern(term.value, count:, counter:, item:, elision: elision.to_s)
+    end
+
+    private def resolve_article(item_id, count, type, _grammatical_case=nil)
+      return nil if type == "none"
+
+      term = @items_bundle.term("-#{item_id}")
+      gender = term&.attributes&.dig("gender") || "masculine"
+      elision = should_elide?(term, item_id, count)
+
+      if type == "definite"
+        resolve_definite_article(gender, count, elision)
+      else
+        resolve_indefinite_article(gender, count)
+      end
+    end
+
+    # L2: called by L1 (alphabetical)
+    private def resolve_article_for_counter(counter_term, gender, count, type, _grammatical_case)
+      elision = should_elide_counter?(counter_term, count)
+
+      if type == "definite"
+        resolve_definite_article(gender, count, elision)
+      else
+        resolve_indefinite_article(gender, count)
+      end
+    end
+
+    private def resolve_definite_article(gender, count, elision)
+      term = @items_bundle.term("-def-article")
+      return nil unless term
+
+      @items_bundle.format_pattern(
+        term.value,
+        gender:,
+        count:,
+        elision: elision.to_s
+      )
+    end
+
+    private def resolve_indefinite_article(gender, count)
+      term = @items_bundle.term("-indef-article")
+      return nil unless term
+
+      @items_bundle.format_pattern(
+        term.value,
+        gender:,
+        count:
+      )
+    end
+
+    private def should_elide?(term, item_id, count)
+      # Check explicit .elision attribute first
+      if term&.attributes&.key?("elision")
+        return term.attributes["elision"] != "false"
+      end
+
+      # Default: elide before vowels
+      item = resolve_item(item_id, count, "nominative")
+      starts_with_vowel?(item)
+    end
+
+    private def should_elide_for_item?(item_id)
+      term = @items_bundle.term("-#{item_id}")
+
+      # Check explicit .elision attribute first
+      if term&.attributes&.key?("elision")
+        return term.attributes["elision"] != "false"
+      end
+
+      # Default: elide before vowels
+      item = resolve_item(item_id, 1, "nominative")
+      starts_with_vowel?(item)
+    end
+
+    # L3: called by L2 (alphabetical)
+    private def should_elide_counter?(counter_term, count)
+      if counter_term.attributes&.key?("elision")
+        return counter_term.attributes["elision"] != "false"
+      end
+
+      counter = @items_bundle.format_pattern(counter_term.value, count:)
+      starts_with_vowel?(counter)
+    end
+
+    # Check if string starts with a vowel, using NFD normalization
+    # e.g., "épée" → NFD → "e" + combining accent → first char "e" (vowel)
+    private def starts_with_vowel?(str)
+      first_letter = str.unicode_normalize(:nfd)[0]&.downcase || ""
+      first_letter.match?(/[aeiou]/)
+    end
+  end
+end

--- a/examples/dungeon_game/functions/ja.rb
+++ b/examples/dungeon_game/functions/ja.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Japanese-specific item localization functions
+module ItemFunctions
+  # Japanese item localization handler.
+  #
+  # Provides counter word (助数詞) support for items. Each item can have a
+  # counter defined via .counter attribute (e.g., 振 for swords, 瓶 for bottles).
+  class Ja < Base
+    # @return [Hash{String => #call}] ITEM and COUNT functions
+    def functions
+      {
+        "COUNT" => method(:fluent_count),
+        "ITEM" => method(:fluent_item)
+      }
+    end
+
+    # Fluent function: ITEM(item_id)
+    def fluent_item(item_id, **)
+      resolve_item(item_id, 1, "nominative")
+    end
+
+    # Fluent function: COUNT(item_id, count)
+    def fluent_count(item_id, count, **)
+      format_count(item_id, count)
+    end
+
+    # "3組", "1瓶"
+    def format_count(item_id, count)
+      counter = resolve_counter(item_id, count)
+      "#{count}#{counter || "個"}"
+    end
+
+    private def resolve_counter(item_id, count)
+      counter_info = resolve_counter_attr(item_id)
+      return nil unless counter_info
+
+      counter_value, is_term = counter_info
+      if is_term
+        counter_term = @items_bundle.term(counter_value)
+        return nil unless counter_term
+
+        @items_bundle.format_pattern(counter_term.value, count:)
+      else
+        counter_value
+      end
+    end
+
+    private def resolve_counter_attr(item_id)
+      term = @items_bundle.term("-#{item_id}")
+      return nil unless term&.attributes&.dig("counter")
+
+      counter_attr = term.attributes["counter"]
+      counter_str = counter_attr.is_a?(String) ? counter_attr : @items_bundle.format_pattern(counter_attr)
+      [counter_str, counter_str.start_with?("-")]
+    end
+  end
+end

--- a/examples/dungeon_game/locales/de/articles.ftl
+++ b/examples/dungeon_game/locales/de/articles.ftl
@@ -1,0 +1,98 @@
+### German article definitions
+
+## Gender specification
+#
+# Each item must have a .gender attribute (masculine/feminine/neuter):
+#
+#   -sword = Schwert
+#       .gender = neuter
+#
+#   -axe = Axt
+#       .gender = feminine
+#
+# The article is selected based on gender, count, and grammatical case.
+
+## Article terms
+
+# Definite article (der/die/das)
+# Uses $count for plural selection via PluralRules
+-def-article =
+    { $gender ->
+        [masculine]
+            { $count ->
+                [one]
+                    { $case ->
+                       *[nominative] der
+                        [accusative] den
+                        [dative] dem
+                        [genitive] des
+                    }
+               *[other]
+                    { $case ->
+                       *[nominative] die
+                        [accusative] die
+                        [dative] den
+                        [genitive] der
+                    }
+            }
+        [feminine]
+            { $count ->
+                [one]
+                    { $case ->
+                       *[nominative] die
+                        [accusative] die
+                        [dative] der
+                        [genitive] der
+                    }
+               *[other]
+                    { $case ->
+                       *[nominative] die
+                        [accusative] die
+                        [dative] den
+                        [genitive] der
+                    }
+            }
+       *[neuter]
+            { $count ->
+                [one]
+                    { $case ->
+                       *[nominative] das
+                        [accusative] das
+                        [dative] dem
+                        [genitive] des
+                    }
+               *[other]
+                    { $case ->
+                       *[nominative] die
+                        [accusative] die
+                        [dative] den
+                        [genitive] der
+                    }
+            }
+    }
+
+# Indefinite article (ein/eine) - singular only
+-indef-article =
+    { $gender ->
+        [masculine]
+            { $case ->
+               *[nominative] ein
+                [accusative] einen
+                [dative] einem
+                [genitive] eines
+            }
+        [feminine]
+            { $case ->
+               *[nominative] eine
+                [accusative] eine
+                [dative] einer
+                [genitive] einer
+            }
+       *[neuter]
+            { $case ->
+               *[nominative] ein
+                [accusative] ein
+                [dative] einem
+                [genitive] eines
+            }
+    }

--- a/examples/dungeon_game/locales/de/counters.ftl
+++ b/examples/dungeon_game/locales/de/counters.ftl
@@ -1,0 +1,27 @@
+### German counter definitions
+
+## Counter terms
+
+# Paar (neuter) - invariant in plural after numbers
+-paar = Paar
+    .gender = neuter
+
+# Flasche (feminine)
+-flasche =
+    { $count ->
+        [one]
+            { $case ->
+                [nominative] Flasche
+                [accusative] Flasche
+                [dative] Flasche
+               *[genitive] Flasche
+            }
+       *[other]
+            { $case ->
+                [nominative] Flaschen
+                [accusative] Flaschen
+                [dative] Flaschen
+               *[genitive] Flaschen
+            }
+    }
+    .gender = feminine

--- a/examples/dungeon_game/locales/de/items.ftl
+++ b/examples/dungeon_game/locales/de/items.ftl
@@ -1,0 +1,136 @@
+### German item definitions
+
+## Items
+
+# Dolch (masculine)
+-dagger =
+    { $count ->
+        [one]
+            { $case ->
+               *[nominative] Dolch
+                [accusative] Dolch
+                [dative] Dolch
+                [genitive] Dolches
+            }
+       *[other]
+            { $case ->
+               *[nominative] Dolche
+                [accusative] Dolche
+                [dative] Dolchen
+                [genitive] Dolche
+            }
+    }
+    .gender = masculine
+
+# Axt (feminine)
+-axe =
+    { $count ->
+        [one]
+            { $case ->
+               *[nominative] Axt
+                [accusative] Axt
+                [dative] Axt
+                [genitive] Axt
+            }
+       *[other]
+            { $case ->
+               *[nominative] Äxte
+                [accusative] Äxte
+                [dative] Äxten
+                [genitive] Äxte
+            }
+    }
+    .gender = feminine
+
+# Schwert (neuter)
+-sword =
+    { $count ->
+        [one]
+            { $case ->
+               *[nominative] Schwert
+                [accusative] Schwert
+                [dative] Schwert
+                [genitive] Schwertes
+            }
+       *[other]
+            { $case ->
+               *[nominative] Schwerter
+                [accusative] Schwerter
+                [dative] Schwertern
+                [genitive] Schwerter
+            }
+    }
+    .gender = neuter
+
+# Hammer (masculine)
+-hammer =
+    { $count ->
+        [one]
+            { $case ->
+               *[nominative] Hammer
+                [accusative] Hammer
+                [dative] Hammer
+                [genitive] Hammers
+            }
+       *[other]
+            { $case ->
+               *[nominative] Hämmer
+                [accusative] Hämmer
+                [dative] Hämmern
+                [genitive] Hämmer
+            }
+    }
+    .gender = masculine
+
+## Items with counters
+
+# Panzerhandschuhe (plurale tantum) - counted with Paar
+-gauntlet =
+    { $case ->
+        [dative] Panzerhandschuhen
+       *[other] Panzerhandschuhe
+    }
+    .gender = masculine
+    .counter = -paar
+
+# Heiltrank (masculine) - counted with Flasche
+-healing-potion =
+    { $count ->
+        [one]
+            { $case ->
+               *[nominative] Heiltrank
+                [accusative] Heiltrank
+                [dative] Heiltrank
+                [genitive] Heiltrankes
+            }
+       *[other]
+            { $case ->
+               *[nominative] Heiltränke
+                [accusative] Heiltränke
+                [dative] Heiltränken
+                [genitive] Heiltränke
+            }
+    }
+    .gender = masculine
+    .counter = -flasche
+
+# Elixier (neuter) - counted with Flasche
+-elixir =
+    { $count ->
+        [one]
+            { $case ->
+               *[nominative] Elixier
+                [accusative] Elixier
+                [dative] Elixier
+                [genitive] Elixiers
+            }
+       *[other]
+            { $case ->
+               *[nominative] Elixiere
+                [accusative] Elixiere
+                [dative] Elixieren
+                [genitive] Elixiere
+            }
+    }
+    .gender = neuter
+    .counter = -flasche

--- a/examples/dungeon_game/locales/de/messages.ftl
+++ b/examples/dungeon_game/locales/de/messages.ftl
@@ -1,0 +1,55 @@
+### Game messages for German
+
+## Custom Functions
+#
+# ARTICLE_ITEM($item, $count, type, case, cap)
+#   Returns article + item name with gender/case agreement.
+#   - type: "indefinite" (ein/eine), "definite" (der/die/das), "none" (default: "indefinite")
+#   Example: { ARTICLE_ITEM("sword", type: "definite", case: "dative") } → "dem Schwert"
+#   Example: { ARTICLE_ITEM("axe", type: "indefinite", case: "accusative") } → "eine Axt"
+#
+# COUNT_ITEM($item, $count, type, case, cap)
+#   Returns count + item, using counters when available.
+#   - type: "indefinite", "definite", or "none" (default: "none")
+#   Example: { COUNT_ITEM("sword", 3, case: "accusative") } → "3 Schwerter"
+#   Example: { COUNT_ITEM("gauntlet", 1, type: "indefinite") } → "ein Paar Panzerhandschuhe"
+#
+# German grammatical cases:
+#   - nominative: Subject of the sentence (Der Dolch ist hier.)
+#   - accusative: Direct object (Du hast einen Dolch gefunden.)
+#   - dative: Indirect object / with prepositions (Du greifst mit dem Schwert an.)
+#   - genitive: Possession (rarely used in this example)
+
+## Messages
+
+# Finding items (accusative case - direct object, counter-aware)
+found-item =
+    { $count ->
+        [one] Du hast { COUNT_ITEM($item, $count, type: "indefinite", case: "accusative") } gefunden.
+       *[other] Du hast { COUNT_ITEM($item, $count, case: "accusative") } gefunden.
+    }
+
+# Item is here (nominative case - subject, sentence start - capitalize, counter-aware)
+item-is-here =
+    { $count ->
+        [one] { COUNT_ITEM($item, $count, type: "definite", case: "nominative", cap: "true") } ist hier.
+       *[other] { COUNT_ITEM($item, $count, case: "nominative", cap: "true") } sind hier.
+    }
+
+# Attack with item (dative case - with preposition "mit", count defaults to 1)
+attack-with-item = Du greifst mit { ARTICLE_ITEM($item, type: "definite", case: "dative") } an.
+
+# Drop item (accusative case - direct object, counter-aware)
+drop-item =
+    { $count ->
+        [one] Du hast { COUNT_ITEM($item, $count, type: "indefinite", case: "accusative") } fallen gelassen.
+       *[other] Du hast { COUNT_ITEM($item, $count, case: "accusative") } fallen gelassen.
+    }
+
+# Inventory (nominative case, counter-aware)
+inventory-item =
+    { $count ->
+        [one] { COUNT_ITEM($item, $count, type: "indefinite", case: "nominative") }
+       *[other] { COUNT_ITEM($item, $count, case: "nominative") }
+    }
+

--- a/examples/dungeon_game/locales/en/articles.ftl
+++ b/examples/dungeon_game/locales/en/articles.ftl
@@ -1,0 +1,31 @@
+### English article definitions
+
+## Exception handling
+#
+# By default, indefinite article is "a" before consonants and "an" before vowels.
+# For exceptions, add .indef attribute to the item term:
+#
+#   # "an hour" - silent h, use "an"
+#   -hour = hour
+#       .indef = an
+#
+#   # "a unicorn" - sounds like "yoo", use "a"
+#   -unicorn = unicorn
+#       .indef = a
+
+## Article terms
+
+# Definite article (always "the")
+-def-article = the
+
+# Indefinite article (a/an based on first letter)
+# Pass $first_letter as lowercase first character of the following word
+-indef-article =
+    { $first_letter ->
+        [a] an
+        [e] an
+        [i] an
+        [o] an
+        [u] an
+       *[other] a
+    }

--- a/examples/dungeon_game/locales/en/counters.ftl
+++ b/examples/dungeon_game/locales/en/counters.ftl
@@ -1,0 +1,15 @@
+### English counter definitions
+
+## Counter terms
+
+-pair =
+    { $count ->
+        [one] pair of
+       *[other] pairs of
+    }
+
+-flask =
+    { $count ->
+        [one] flask of
+       *[other] flasks of
+    }

--- a/examples/dungeon_game/locales/en/items.ftl
+++ b/examples/dungeon_game/locales/en/items.ftl
@@ -1,0 +1,41 @@
+### English item definitions
+
+## Items
+
+-dagger =
+    { $count ->
+        [one] dagger
+       *[other] daggers
+    }
+
+-axe =
+    { $count ->
+        [one] axe
+       *[other] axes
+    }
+
+-sword =
+    { $count ->
+        [one] sword
+       *[other] swords
+    }
+
+-hammer =
+    { $count ->
+        [one] hammer
+       *[other] hammers
+    }
+
+## Items with counters
+
+# Gauntlets are counted in pairs
+-gauntlet = gauntlets
+    .counter = -pair
+
+# Healing potions are counted in flasks
+-healing-potion = healing potion
+    .counter = -flask
+
+# Elixirs are counted in flasks
+-elixir = elixir
+    .counter = -flask

--- a/examples/dungeon_game/locales/en/messages.ftl
+++ b/examples/dungeon_game/locales/en/messages.ftl
@@ -1,0 +1,55 @@
+### Game messages for English
+
+## Custom Functions
+#
+# ARTICLE_ITEM($item, $count, type, cap)
+#   Returns article + item name.
+#   - type: "indefinite" (a/an), "definite" (the), or "none" (default: "indefinite")
+#   Example: { ARTICLE_ITEM("axe", type: "indefinite") } → "an axe"
+#   Example: { ARTICLE_ITEM("sword", type: "definite") } → "the sword"
+#
+# COUNT_ITEM($item, $count, type, cap)
+#   Returns count + item, using counters when available.
+#   For items with counters (e.g., gauntlet → pair), uses counter-based format.
+#   - type: "indefinite", "definite", or "none" (default: "none")
+#   Example: { COUNT_ITEM("sword", 3) } → "3 swords"
+#   Example: { COUNT_ITEM("gauntlet", 1, type: "indefinite") } → "a pair of gauntlets"
+#   Example: { COUNT_ITEM("healing-potion", 3) } → "3 flasks of healing potion"
+#
+# Note: The `cap: "true"` parameter is used when the function result appears
+# at sentence start. This is a pragmatic workaround since Fluent does not
+# support function nesting like CAPITALIZE(COUNT_ITEM(...)).
+
+## Messages
+
+# Finding items (counter-aware)
+found-item =
+    { $count ->
+        [one] You found { COUNT_ITEM($item, $count, type: "indefinite") }.
+       *[other] You found { COUNT_ITEM($item, $count) }.
+    }
+
+# Item is here (sentence start - capitalize, counter-aware)
+item-is-here =
+    { $count ->
+        [one] { COUNT_ITEM($item, $count, type: "definite", cap: "true") } is here.
+       *[other] { COUNT_ITEM($item, $count, cap: "true") } are here.
+    }
+
+# Attack with item (count defaults to 1)
+attack-with-item = You attack with { ARTICLE_ITEM($item, type: "definite") }.
+
+# Drop item (counter-aware)
+drop-item =
+    { $count ->
+        [one] You dropped { COUNT_ITEM($item, $count, type: "indefinite") }.
+       *[other] You dropped { COUNT_ITEM($item, $count) }.
+    }
+
+# Inventory (counter-aware)
+inventory-item =
+    { $count ->
+        [one] { COUNT_ITEM($item, $count, type: "indefinite") }
+       *[other] { COUNT_ITEM($item, $count) }
+    }
+

--- a/examples/dungeon_game/locales/fr/articles.ftl
+++ b/examples/dungeon_game/locales/fr/articles.ftl
@@ -1,0 +1,85 @@
+### French article definitions
+
+## Elision control
+#
+# By default, elision occurs before vowels (l'épée, l'arme).
+# For h aspiré words (no elision), add .elision = false to the item term:
+#
+#   # "la hache" - h aspiré, no elision
+#   -axe = hache
+#       .gender = feminine
+#       .elision = false
+#
+#   # "le hibou" - h aspiré, no elision
+#   -owl = hibou
+#       .gender = masculine
+#       .elision = false
+#
+# For words that should always elide (rare), use .elision = true
+
+## Format patterns
+#
+# Patterns for joining article with item/counter.
+# Uses $elision selector to handle l'/d' (no space after apostrophe).
+
+-fmt-article-item =
+    { $elision ->
+        [true] {$article}{$item}
+       *[false] {$article} {$item}
+    }
+
+-fmt-article-counter-item =
+    { $article_elision ->
+        [true]
+            { $counter_elision ->
+                [true] {$article}{$counter}{$item}
+               *[false] {$article}{$counter} {$item}
+            }
+       *[false]
+            { $counter_elision ->
+                [true] {$article} {$counter}{$item}
+               *[false] {$article} {$counter} {$item}
+            }
+    }
+
+-fmt-counter-item =
+    { $elision ->
+        [true] {$counter}{$item}
+       *[false] {$counter} {$item}
+    }
+
+-fmt-count-counter-item =
+    { $elision ->
+        [true] {$count} {$counter}{$item}
+       *[false] {$count} {$counter} {$item}
+    }
+
+## Article terms
+
+# Definite article (le/la/l'/les)
+# Uses $count for plural selection via PluralRules
+-def-article =
+    { $elision ->
+        [true] l'
+       *[false]
+            { $count ->
+                [one]
+                    { $gender ->
+                        [feminine] la
+                       *[masculine] le
+                    }
+               *[other] les
+            }
+    }
+
+# Indefinite article (un/une/des)
+# Uses $count for plural selection via PluralRules
+-indef-article =
+    { $count ->
+        [one]
+            { $gender ->
+                [feminine] une
+               *[masculine] un
+            }
+       *[other] des
+    }

--- a/examples/dungeon_game/locales/fr/counters.ftl
+++ b/examples/dungeon_game/locales/fr/counters.ftl
@@ -1,0 +1,42 @@
+### French counter definitions
+
+## Counter elision
+#
+# Counters use $elision selector for "de" vs "d'" based on the following item.
+# The elision is determined by whether the item starts with a vowel.
+#
+# Example: "fiole de potion" vs "fiole d'élixir"
+
+## Counter terms
+
+# Paire (feminine) - uses elision selector for "de" vs "d'"
+-paire =
+    { $elision ->
+        [true]
+            { $count ->
+                [one] paire d'
+               *[other] paires d'
+            }
+       *[false]
+            { $count ->
+                [one] paire de
+               *[other] paires de
+            }
+    }
+    .gender = feminine
+
+# Fiole (feminine) - uses elision selector for "de" vs "d'"
+-fiole =
+    { $elision ->
+        [true]
+            { $count ->
+                [one] fiole d'
+               *[other] fioles d'
+            }
+       *[false]
+            { $count ->
+                [one] fiole de
+               *[other] fioles de
+            }
+    }
+    .gender = feminine

--- a/examples/dungeon_game/locales/fr/items.ftl
+++ b/examples/dungeon_game/locales/fr/items.ftl
@@ -1,0 +1,61 @@
+### French item definitions
+
+## Items
+
+# Poignard (masculine)
+-dagger =
+    { $count ->
+        [one] poignard
+       *[other] poignards
+    }
+    .gender = masculine
+
+# Hache (feminine, h aspiré - no elision)
+-axe =
+    { $count ->
+        [one] hache
+       *[other] haches
+    }
+    .gender = feminine
+    .elision = false
+
+# Épée (feminine, starts with vowel - elision)
+-sword =
+    { $count ->
+        [one] épée
+       *[other] épées
+    }
+    .gender = feminine
+
+# Marteau (masculine)
+-hammer =
+    { $count ->
+        [one] marteau
+       *[other] marteaux
+    }
+    .gender = masculine
+
+## Items with counters
+
+# Gantelets (masculine, plural) - counted with paire
+-gauntlet = gantelets
+    .gender = masculine
+    .counter = -paire
+
+# Potion de soin (feminine) - counted with fiole
+-healing-potion =
+    { $count ->
+        [one] potion de soin
+       *[other] potions de soin
+    }
+    .gender = feminine
+    .counter = -fiole
+
+# Élixir (masculine) - counted with fiole, starts with vowel (tests elision)
+-elixir =
+    { $count ->
+        [one] élixir
+       *[other] élixirs
+    }
+    .gender = masculine
+    .counter = -fiole

--- a/examples/dungeon_game/locales/fr/messages.ftl
+++ b/examples/dungeon_game/locales/fr/messages.ftl
@@ -1,0 +1,56 @@
+### Game messages for French
+
+## Custom Functions
+#
+# ARTICLE_ITEM($item, $count, type, cap)
+#   Returns article + item name with gender agreement and elision.
+#   - type: "indefinite" (un/une), "definite" (le/la/l'), "none" (default: "indefinite")
+#   Example: { ARTICLE_ITEM("sword", type: "definite") } → "l'épée" (elision)
+#   Example: { ARTICLE_ITEM("axe", type: "definite") } → "la hache" (h aspiré, no elision)
+#   Example: { ARTICLE_ITEM("dagger", type: "indefinite") } → "un poignard"
+#
+# COUNT_ITEM($item, $count, type, cap)
+#   Returns count + item, using counters when available.
+#   Counter elision is handled automatically (fiole de potion vs fiole d'élixir).
+#   - type: "indefinite", "definite", or "none" (default: "none")
+#   Example: { COUNT_ITEM("sword", 3) } → "3 épées"
+#   Example: { COUNT_ITEM("healing-potion", 1, type: "indefinite") } → "une fiole de potion de soin"
+#   Example: { COUNT_ITEM("elixir", 1, type: "indefinite") } → "une fiole d'élixir"
+#
+# French elision notes:
+#   - Definite articles le/la become l' before vowels (l'épée)
+#   - Exception: h aspiré words keep la/le (la hache)
+#   - Counter "de" becomes "d'" before vowels (fiole d'élixir)
+
+## Messages
+
+# Finding items (counter-aware)
+found-item =
+    { $count ->
+        [one] Tu as trouvé { COUNT_ITEM($item, $count, type: "indefinite") }.
+       *[other] Tu as trouvé { COUNT_ITEM($item, $count) }.
+    }
+
+# Item is here (sentence start - capitalize, counter-aware)
+item-is-here =
+    { $count ->
+        [one] { COUNT_ITEM($item, $count, type: "definite", cap: "true") } est ici.
+       *[other] { COUNT_ITEM($item, $count, cap: "true") } sont ici.
+    }
+
+# Attack with item (count defaults to 1)
+attack-with-item = Tu attaques avec { ARTICLE_ITEM($item, type: "definite") }.
+
+# Drop item (counter-aware)
+drop-item =
+    { $count ->
+        [one] Tu as laissé tomber { COUNT_ITEM($item, $count, type: "indefinite") }.
+       *[other] Tu as laissé tomber { COUNT_ITEM($item, $count) }.
+    }
+
+# Inventory (counter-aware)
+inventory-item =
+    { $count ->
+        [one] { COUNT_ITEM($item, $count, type: "indefinite") }
+       *[other] { COUNT_ITEM($item, $count) }
+    }

--- a/examples/dungeon_game/locales/ja/items.ftl
+++ b/examples/dungeon_game/locales/ja/items.ftl
@@ -1,0 +1,29 @@
+### Japanese item definitions
+
+## Items
+#
+# Japanese has no grammatical articles or gender.
+# The .counter attribute specifies the counter word (助数詞).
+
+-dagger = 短剣
+    .counter = 振
+
+-axe = 斧
+    .counter = 振
+
+-sword = 剣
+    .counter = 振
+
+-hammer = 槌
+    .counter = 振
+
+## Items with counters
+
+-gauntlet = 籠手
+    .counter = 組
+
+-healing-potion = 回復薬
+    .counter = 瓶
+
+-elixir = 霊薬
+    .counter = 瓶

--- a/examples/dungeon_game/locales/ja/messages.ftl
+++ b/examples/dungeon_game/locales/ja/messages.ftl
@@ -1,0 +1,42 @@
+### Game messages for Japanese
+
+## Custom Functions
+#
+# ITEM($item, $count, cap)
+#   Returns the item name.
+#   - $item: Item ID (e.g., "sword", "healing-potion")
+#   - $count: Number of items (default: 1, not used for Japanese)
+#   Example: { ITEM("sword") } → "剣"
+#
+# COUNT($item, $count)
+#   Returns count with the appropriate counter (助数詞).
+#   Each item has a counter defined in items.ftl (.counter attribute).
+#   - $item: Item ID
+#   - $count: Number of items
+#   Example: { COUNT("sword", 3) } → "3振"
+#   Example: { COUNT("gauntlet", 2) } → "2組"
+#   Example: { COUNT("healing-potion", 1) } → "1瓶"
+#
+# Japanese counters (助数詞) used in this example:
+#   - 振 (ふり): For bladed weapons (sword, dagger, axe, hammer)
+#   - 組 (くみ): For pairs/sets (gauntlets)
+#   - 瓶 (びん): For bottled items (potions, elixir)
+#   - 個 (こ): Default counter when none specified
+
+## Messages
+
+# Finding items (counter-aware)
+found-item = { ITEM($item) }を{ COUNT($item, $count) }見つけた。
+
+# Item is here
+item-is-here = { ITEM($item) }が{ COUNT($item, $count) }ある。
+
+# Attack with item (count defaults to 1)
+attack-with-item = { ITEM($item) }で攻撃した。
+
+# Drop item
+drop-item = { ITEM($item) }を{ COUNT($item, $count) }捨てた。
+
+# Inventory
+inventory-item = { ITEM($item) } x { COUNT($item, $count) }
+

--- a/examples/dungeon_game/main.rb
+++ b/examples/dungeon_game/main.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+# Dungeon Game Example
+#
+# This example demonstrates:
+# - Two-layer bundle architecture (Items Bundle + Messages Bundle)
+# - Custom functions (ITEM, ARTICLE, ARTICLE_ITEM) for dynamic item localization
+# - German grammatical cases (nominative, accusative, dative, genitive)
+# - German grammatical gender (masculine, feminine, neuter)
+# - French elision (l'épée vs la hache)
+# - Proper article declension based on gender, number, and case
+
+require "foxtail"
+require "icu4x"
+require "pathname"
+
+require_relative "functions/base"
+require_relative "functions/de"
+require_relative "functions/en"
+require_relative "functions/fr"
+require_relative "functions/ja"
+
+# Language class registry for item localization
+module ItemFunctions
+  LANGUAGE_CLASSES = {
+    "de" => De,
+    "en" => En,
+    "fr" => Fr,
+    "ja" => Ja
+  }.freeze
+
+  private_constant :LANGUAGE_CLASSES
+
+  # Create language-specific function handler
+  # @param locale [ICU4X::Locale] The locale
+  # @param items_bundle [Foxtail::Bundle] The bundle containing item terms
+  # @return [Base] Language-specific handler instance
+  def self.for_locale(locale, items_bundle)
+    klass = LANGUAGE_CLASSES.fetch(locale.language, Base)
+    klass.new(items_bundle)
+  end
+end
+
+# Create a messages bundle for the specified locale
+# @param locale_tag [String] Locale identifier (e.g., "en", "de", "fr", "ja")
+# @param locales_dir [Pathname] Directory containing locale subdirectories
+# @return [Foxtail::Bundle] Configured messages bundle with custom functions
+def create_bundle(locale_tag, locales_dir)
+  locale = ICU4X::Locale.parse(locale_tag)
+  locale_dir = locales_dir.join(locale_tag)
+
+  # Items bundle loads: articles, counters, items
+  items_bundle = Foxtail::Bundle.new(locale, use_isolating: false)
+  %w[articles counters items].each do |name|
+    path = locale_dir.join("#{name}.ftl")
+    items_bundle.add_resource(Foxtail::Resource.from_file(path)) if path.exist?
+  end
+
+  handler = ItemFunctions.for_locale(locale, items_bundle)
+  custom_functions = Foxtail::Function.defaults.merge(handler.functions)
+
+  # Messages bundle loads: messages
+  messages_bundle = Foxtail::Bundle.new(locale, functions: custom_functions, use_isolating: false)
+  messages_bundle.add_resource(
+    Foxtail::Resource.from_file(locale_dir.join("messages.ftl"))
+  )
+
+  messages_bundle
+end
+
+# Directory containing locale files
+locales_dir = Pathname.new(__dir__).join("locales")
+
+# Create bundles
+en_bundle = create_bundle("en", locales_dir)
+de_bundle = create_bundle("de", locales_dir)
+fr_bundle = create_bundle("fr", locales_dir)
+ja_bundle = create_bundle("ja", locales_dir)
+
+puts "=== Dungeon Game Localization Demo ==="
+puts
+
+# Test items (including counter items)
+items = %w[dagger axe sword hammer gauntlet healing-potion elixir]
+counts = [1, 3]
+
+# English
+puts "--- English ---"
+puts "found-item:"
+items.each do |item|
+  counts.each do |count|
+    puts "  #{en_bundle.format("found-item", item:, count:)}"
+  end
+end
+puts "attack-with-item:"
+puts "  #{en_bundle.format("attack-with-item", item: "sword")}"
+puts "item-is-here:"
+items.each do |item|
+  counts.each do |count|
+    puts "  #{en_bundle.format("item-is-here", item:, count:)}"
+  end
+end
+puts "drop-item:"
+items.each do |item|
+  counts.each do |count|
+    puts "  #{en_bundle.format("drop-item", item:, count:)}"
+  end
+end
+puts "inventory-item:"
+items.each do |item|
+  counts.each do |count|
+    puts "  #{en_bundle.format("inventory-item", item:, count:)}"
+  end
+end
+puts
+
+# German
+puts "--- German ---"
+puts "found-item:"
+items.each do |item|
+  counts.each do |count|
+    puts "  #{de_bundle.format("found-item", item:, count:)}"
+  end
+end
+puts "attack-with-item:"
+puts "  #{de_bundle.format("attack-with-item", item: "sword")}"
+puts "item-is-here:"
+items.each do |item|
+  counts.each do |count|
+    puts "  #{de_bundle.format("item-is-here", item:, count:)}"
+  end
+end
+puts "drop-item:"
+items.each do |item|
+  counts.each do |count|
+    puts "  #{de_bundle.format("drop-item", item:, count:)}"
+  end
+end
+puts "inventory-item:"
+items.each do |item|
+  counts.each do |count|
+    puts "  #{de_bundle.format("inventory-item", item:, count:)}"
+  end
+end
+puts
+
+# French
+puts "--- French ---"
+puts "found-item:"
+items.each do |item|
+  counts.each do |count|
+    puts "  #{fr_bundle.format("found-item", item:, count:)}"
+  end
+end
+puts "attack-with-item:"
+puts "  #{fr_bundle.format("attack-with-item", item: "sword")}"
+puts "item-is-here:"
+items.each do |item|
+  counts.each do |count|
+    puts "  #{fr_bundle.format("item-is-here", item:, count:)}"
+  end
+end
+puts "drop-item:"
+items.each do |item|
+  counts.each do |count|
+    puts "  #{fr_bundle.format("drop-item", item:, count:)}"
+  end
+end
+puts "inventory-item:"
+items.each do |item|
+  counts.each do |count|
+    puts "  #{fr_bundle.format("inventory-item", item:, count:)}"
+  end
+end
+puts
+
+# Japanese
+puts "--- Japanese ---"
+puts "found-item:"
+items.each do |item|
+  counts.each do |count|
+    puts "  #{ja_bundle.format("found-item", item:, count:)}"
+  end
+end
+puts "attack-with-item:"
+puts "  #{ja_bundle.format("attack-with-item", item: "sword")}"
+puts "item-is-here:"
+items.each do |item|
+  counts.each do |count|
+    puts "  #{ja_bundle.format("item-is-here", item:, count:)}"
+  end
+end
+puts "drop-item:"
+items.each do |item|
+  counts.each do |count|
+    puts "  #{ja_bundle.format("drop-item", item:, count:)}"
+  end
+end
+puts "inventory-item:"
+items.each do |item|
+  counts.each do |count|
+    puts "  #{ja_bundle.format("inventory-item", item:, count:)}"
+  end
+end
+puts
+
+# Demonstrate case differences in German
+puts "=== German Grammatical Cases ==="
+puts
+puts "Nominative (subject): #{de_bundle.format("item-is-here", item: "sword", count: 1)}"
+puts "Accusative (direct object): #{de_bundle.format("found-item", item: "sword", count: 1)}"
+puts "Dative (with preposition): #{de_bundle.format("attack-with-item", item: "sword")}"
+puts
+
+# Demonstrate gender differences in German
+puts "=== German Grammatical Gender ==="
+puts
+puts "Masculine (der Dolch): #{de_bundle.format("found-item", item: "dagger", count: 1)}"
+puts "Feminine (die Axt): #{de_bundle.format("found-item", item: "axe", count: 1)}"
+puts "Neuter (das Schwert): #{de_bundle.format("found-item", item: "sword", count: 1)}"
+puts
+
+# Demonstrate French elision
+puts "=== French Elision ==="
+puts
+puts "With elision (l'épée): #{fr_bundle.format("item-is-here", item: "sword", count: 1)}"
+puts "Without elision - h aspiré (la hache): #{fr_bundle.format("item-is-here", item: "axe", count: 1)}"
+puts "Masculine (le poignard): #{fr_bundle.format("item-is-here", item: "dagger", count: 1)}"
+puts
+puts "=== French Counter Elision ==="
+puts
+puts "Counter + consonant (fiole de potion): #{fr_bundle.format("found-item", item: "healing-potion", count: 1)}"
+puts "Counter + vowel (fiole d'élixir): #{fr_bundle.format("found-item", item: "elixir", count: 1)}"


### PR DESCRIPTION
## Summary

Add a comprehensive dungeon game localization example demonstrating advanced Fluent features with multi-language support.

## Changes

- Implement two-layer bundle architecture (Items Bundle + Messages Bundle)
- Add language-specific function handlers (En, De, Fr, Ja) with Base class
- Support German grammatical gender/case declension via FTL terms
- Implement French article elision with FTL format patterns
- Add Japanese counter word (助数詞) support
- Include counter terms for items (pair/Paar/paire, flask/Flasche/fiole)

## Features Demonstrated

- **German**: Grammatical cases (nominative, accusative, dative, genitive) and gender (masculine, feminine, neuter)
- **French**: Elision handling (l'épée vs la hache) with h aspiré support
- **Japanese**: Counter words (振, 本, 組, 瓶)
- **English**: a/an selection with counter support

## Test Plan

```bash
bundle exec ruby examples/dungeon_game/main.rb
```

Output is verified against `expected.txt`.
