### PR TITLE
:recycle: Rename dungeon game custom functions for consistency

### DIFF
--- a/examples/dungeon_game/README.md
+++ b/examples/dungeon_game/README.md
@@ -6,7 +6,7 @@ Demonstrates advanced localization for game items with grammatical gender, numbe
 
 - **Two-layer Bundle architecture**: Separate bundles for items (Terms) and messages
 - **Custom functions**: Language-specific functions for dynamic item embedding
-  - English/German/French: `ARTICLE_ITEM`, `COUNT_ITEM`
+  - English/German/French: `ITEM`, `ITEM_WITH_COUNT`
   - Japanese: `ITEM`, `COUNT`
 - **German grammatical cases**: nominative, accusative, dative, genitive
 - **German grammatical gender**: masculine, feminine, neuter
@@ -91,11 +91,11 @@ Each language provides different functions based on its needs:
 
 **English/German/French:**
 ```ftl
-# ARTICLE_ITEM: Item with article
-{ ARTICLE_ITEM($item, $count, type: "indefinite", case: "nominative", cap: "false") }
+# ITEM: Item with article
+{ ITEM($item, $count, type: "indefinite", case: "nominative", cap: "false") }
 
-# COUNT_ITEM: Count with item (uses counter if defined)
-{ COUNT_ITEM($item, $count, type: "none", case: "nominative", cap: "false") }
+# ITEM_WITH_COUNT: Count with item (uses counter if defined)
+{ ITEM_WITH_COUNT($item, $count, type: "none", case: "nominative", cap: "false") }
 ```
 
 **Japanese:**

--- a/examples/dungeon_game/functions/base.rb
+++ b/examples/dungeon_game/functions/base.rb
@@ -19,10 +19,13 @@ module ItemFunctions
     end
 
     # Returns the custom Fluent functions provided by this handler.
-    # Subclasses must override this method.
+    # Subclasses may override this method to provide different functions.
     # @return [Hash{String => #call}] function name to callable mapping
     def functions
-      raise NotImplementedError, "Subclasses must implement #functions"
+      {
+        "ITEM" => method(:fluent_item),
+        "ITEM_WITH_COUNT" => method(:fluent_item_with_count)
+      }
     end
 
     # Fluent function: ITEM(item_id, count = 1, type: "indefinite", case: "nominative", cap: "false")

--- a/examples/dungeon_game/functions/base.rb
+++ b/examples/dungeon_game/functions/base.rb
@@ -10,7 +10,7 @@ module ItemFunctions
   # Note on the `cap` parameter:
   # Capitalization at sentence start is technically a message-layer concern,
   # not an item-layer concern. However, Fluent does not support function nesting
-  # (e.g., CAPITALIZE(COUNT_ITEM(...))), so we use the `cap` parameter as a
+  # (e.g., CAPITALIZE(ITEM_WITH_COUNT(...))), so we use the `cap` parameter as a
   # pragmatic workaround. The message layer passes `cap: "true"` as a hint
   # when the result will appear at sentence start.
   class Base

--- a/examples/dungeon_game/functions/base.rb
+++ b/examples/dungeon_game/functions/base.rb
@@ -4,7 +4,7 @@
 module ItemFunctions
   # Base class for language-specific item localization functions.
   #
-  # Provides common fluent functions (ARTICLE_ITEM, COUNT_ITEM) and template methods
+  # Provides common fluent functions (ITEM, ITEM_WITH_COUNT) and template methods
   # for subclasses to override language-specific behavior.
   #
   # Note on the `cap` parameter:
@@ -25,8 +25,8 @@ module ItemFunctions
       raise NotImplementedError, "Subclasses must implement #functions"
     end
 
-    # Fluent function: ARTICLE_ITEM(item_id, count = 1, type: "indefinite", case: "nominative", cap: "false")
-    def fluent_article_item(item_id, count=1, **options)
+    # Fluent function: ITEM(item_id, count = 1, type: "indefinite", case: "nominative", cap: "false")
+    def fluent_item(item_id, count=1, **options)
       type = options.fetch(:type, "indefinite")
       grammatical_case = options.fetch(:case, "nominative")
       cap = options.fetch(:cap, "false")
@@ -37,8 +37,8 @@ module ItemFunctions
       cap == "true" ? capitalize_first(result) : result
     end
 
-    # Fluent function: COUNT_ITEM(item_id, count, type: "none", case: "nominative", cap: "false")
-    def fluent_count_item(item_id, count, **options)
+    # Fluent function: ITEM_WITH_COUNT(item_id, count, type: "none", case: "nominative", cap: "false")
+    def fluent_item_with_count(item_id, count, **options)
       type = options.fetch(:type, "none")
       grammatical_case = options.fetch(:case, "nominative")
       cap = options.fetch(:cap, "false")

--- a/examples/dungeon_game/functions/de.rb
+++ b/examples/dungeon_game/functions/de.rb
@@ -7,11 +7,11 @@ module ItemFunctions
   # Provides article declension based on grammatical gender (masculine, feminine, neuter),
   # number (singular, plural), and case (nominative, accusative, dative, genitive).
   class De < Base
-    # @return [Hash{String => #call}] ARTICLE_ITEM and COUNT_ITEM functions
+    # @return [Hash{String => #call}] ITEM and ITEM_WITH_COUNT functions
     def functions
       {
-        "ARTICLE_ITEM" => method(:fluent_article_item),
-        "COUNT_ITEM" => method(:fluent_count_item)
+        "ITEM" => method(:fluent_item),
+        "ITEM_WITH_COUNT" => method(:fluent_item_with_count)
       }
     end
 

--- a/examples/dungeon_game/functions/de.rb
+++ b/examples/dungeon_game/functions/de.rb
@@ -7,14 +7,6 @@ module ItemFunctions
   # Provides article declension based on grammatical gender (masculine, feminine, neuter),
   # number (singular, plural), and case (nominative, accusative, dative, genitive).
   class De < Base
-    # @return [Hash{String => #call}] ITEM and ITEM_WITH_COUNT functions
-    def functions
-      {
-        "ITEM" => method(:fluent_item),
-        "ITEM_WITH_COUNT" => method(:fluent_item_with_count)
-      }
-    end
-
     # L1: entry points from Base (alphabetical)
     private def resolve_article(item_id, count, type, grammatical_case)
       return nil if type == "none"

--- a/examples/dungeon_game/functions/en.rb
+++ b/examples/dungeon_game/functions/en.rb
@@ -7,14 +7,6 @@ module ItemFunctions
   # Provides indefinite article selection (a/an) based on first letter,
   # with support for explicit overrides via .indef attribute.
   class En < Base
-    # @return [Hash{String => #call}] ITEM and ITEM_WITH_COUNT functions
-    def functions
-      {
-        "ITEM" => method(:fluent_item),
-        "ITEM_WITH_COUNT" => method(:fluent_item_with_count)
-      }
-    end
-
     # L1: entry points from Base (alphabetical)
     private def resolve_article(item_id, count, type, _grammatical_case=nil)
       return nil if type == "none"

--- a/examples/dungeon_game/functions/en.rb
+++ b/examples/dungeon_game/functions/en.rb
@@ -7,11 +7,11 @@ module ItemFunctions
   # Provides indefinite article selection (a/an) based on first letter,
   # with support for explicit overrides via .indef attribute.
   class En < Base
-    # @return [Hash{String => #call}] ARTICLE_ITEM and COUNT_ITEM functions
+    # @return [Hash{String => #call}] ITEM and ITEM_WITH_COUNT functions
     def functions
       {
-        "ARTICLE_ITEM" => method(:fluent_article_item),
-        "COUNT_ITEM" => method(:fluent_count_item)
+        "ITEM" => method(:fluent_item),
+        "ITEM_WITH_COUNT" => method(:fluent_item_with_count)
       }
     end
 

--- a/examples/dungeon_game/functions/fr.rb
+++ b/examples/dungeon_game/functions/fr.rb
@@ -7,14 +7,6 @@ module ItemFunctions
   # Provides article selection with elision handling (le/la → l' before vowels),
   # with support for h aspiré exceptions via .elision attribute.
   class Fr < Base
-    # @return [Hash{String => #call}] ITEM and ITEM_WITH_COUNT functions
-    def functions
-      {
-        "ITEM" => method(:fluent_item),
-        "ITEM_WITH_COUNT" => method(:fluent_item_with_count)
-      }
-    end
-
     # L1: entry points from Base (alphabetical)
     private def format_article_counter_item(article, counter, item, counter_elision: false)
       unless article

--- a/examples/dungeon_game/functions/fr.rb
+++ b/examples/dungeon_game/functions/fr.rb
@@ -7,11 +7,11 @@ module ItemFunctions
   # Provides article selection with elision handling (le/la → l' before vowels),
   # with support for h aspiré exceptions via .elision attribute.
   class Fr < Base
-    # @return [Hash{String => #call}] ARTICLE_ITEM and COUNT_ITEM functions
+    # @return [Hash{String => #call}] ITEM and ITEM_WITH_COUNT functions
     def functions
       {
-        "ARTICLE_ITEM" => method(:fluent_article_item),
-        "COUNT_ITEM" => method(:fluent_count_item)
+        "ITEM" => method(:fluent_item),
+        "ITEM_WITH_COUNT" => method(:fluent_item_with_count)
       }
     end
 

--- a/examples/dungeon_game/locales/de/messages.ftl
+++ b/examples/dungeon_game/locales/de/messages.ftl
@@ -2,17 +2,17 @@
 
 ## Custom Functions
 #
-# ARTICLE_ITEM($item, $count, type, case, cap)
+# ITEM($item, $count, type, case, cap)
 #   Returns article + item name with gender/case agreement.
 #   - type: "indefinite" (ein/eine), "definite" (der/die/das), "none" (default: "indefinite")
-#   Example: { ARTICLE_ITEM("sword", type: "definite", case: "dative") } → "dem Schwert"
-#   Example: { ARTICLE_ITEM("axe", type: "indefinite", case: "accusative") } → "eine Axt"
+#   Example: { ITEM("sword", type: "definite", case: "dative") } → "dem Schwert"
+#   Example: { ITEM("axe", type: "indefinite", case: "accusative") } → "eine Axt"
 #
-# COUNT_ITEM($item, $count, type, case, cap)
+# ITEM_WITH_COUNT($item, $count, type, case, cap)
 #   Returns count + item, using counters when available.
 #   - type: "indefinite", "definite", or "none" (default: "none")
-#   Example: { COUNT_ITEM("sword", 3, case: "accusative") } → "3 Schwerter"
-#   Example: { COUNT_ITEM("gauntlet", 1, type: "indefinite") } → "ein Paar Panzerhandschuhe"
+#   Example: { ITEM_WITH_COUNT("sword", 3, case: "accusative") } → "3 Schwerter"
+#   Example: { ITEM_WITH_COUNT("gauntlet", 1, type: "indefinite") } → "ein Paar Panzerhandschuhe"
 #
 # German grammatical cases:
 #   - nominative: Subject of the sentence (Der Dolch ist hier.)
@@ -25,31 +25,31 @@
 # Finding items (accusative case - direct object, counter-aware)
 found-item =
     { $count ->
-        [one] Du hast { COUNT_ITEM($item, $count, type: "indefinite", case: "accusative") } gefunden.
-       *[other] Du hast { COUNT_ITEM($item, $count, case: "accusative") } gefunden.
+        [one] Du hast { ITEM_WITH_COUNT($item, $count, type: "indefinite", case: "accusative") } gefunden.
+       *[other] Du hast { ITEM_WITH_COUNT($item, $count, case: "accusative") } gefunden.
     }
 
 # Item is here (nominative case - subject, sentence start - capitalize, counter-aware)
 item-is-here =
     { $count ->
-        [one] { COUNT_ITEM($item, $count, type: "definite", case: "nominative", cap: "true") } ist hier.
-       *[other] { COUNT_ITEM($item, $count, case: "nominative", cap: "true") } sind hier.
+        [one] { ITEM_WITH_COUNT($item, $count, type: "definite", case: "nominative", cap: "true") } ist hier.
+       *[other] { ITEM_WITH_COUNT($item, $count, case: "nominative", cap: "true") } sind hier.
     }
 
 # Attack with item (dative case - with preposition "mit", count defaults to 1)
-attack-with-item = Du greifst mit { ARTICLE_ITEM($item, type: "definite", case: "dative") } an.
+attack-with-item = Du greifst mit { ITEM($item, type: "definite", case: "dative") } an.
 
 # Drop item (accusative case - direct object, counter-aware)
 drop-item =
     { $count ->
-        [one] Du hast { COUNT_ITEM($item, $count, type: "indefinite", case: "accusative") } fallen gelassen.
-       *[other] Du hast { COUNT_ITEM($item, $count, case: "accusative") } fallen gelassen.
+        [one] Du hast { ITEM_WITH_COUNT($item, $count, type: "indefinite", case: "accusative") } fallen gelassen.
+       *[other] Du hast { ITEM_WITH_COUNT($item, $count, case: "accusative") } fallen gelassen.
     }
 
 # Inventory (nominative case, counter-aware)
 inventory-item =
     { $count ->
-        [one] { COUNT_ITEM($item, $count, type: "indefinite", case: "nominative") }
-       *[other] { COUNT_ITEM($item, $count, case: "nominative") }
+        [one] { ITEM_WITH_COUNT($item, $count, type: "indefinite", case: "nominative") }
+       *[other] { ITEM_WITH_COUNT($item, $count, case: "nominative") }
     }
 

--- a/examples/dungeon_game/locales/en/messages.ftl
+++ b/examples/dungeon_game/locales/en/messages.ftl
@@ -2,54 +2,54 @@
 
 ## Custom Functions
 #
-# ARTICLE_ITEM($item, $count, type, cap)
+# ITEM($item, $count, type, cap)
 #   Returns article + item name.
 #   - type: "indefinite" (a/an), "definite" (the), or "none" (default: "indefinite")
-#   Example: { ARTICLE_ITEM("axe", type: "indefinite") } → "an axe"
-#   Example: { ARTICLE_ITEM("sword", type: "definite") } → "the sword"
+#   Example: { ITEM("axe", type: "indefinite") } → "an axe"
+#   Example: { ITEM("sword", type: "definite") } → "the sword"
 #
-# COUNT_ITEM($item, $count, type, cap)
+# ITEM_WITH_COUNT($item, $count, type, cap)
 #   Returns count + item, using counters when available.
 #   For items with counters (e.g., gauntlet → pair), uses counter-based format.
 #   - type: "indefinite", "definite", or "none" (default: "none")
-#   Example: { COUNT_ITEM("sword", 3) } → "3 swords"
-#   Example: { COUNT_ITEM("gauntlet", 1, type: "indefinite") } → "a pair of gauntlets"
-#   Example: { COUNT_ITEM("healing-potion", 3) } → "3 flasks of healing potion"
+#   Example: { ITEM_WITH_COUNT("sword", 3) } → "3 swords"
+#   Example: { ITEM_WITH_COUNT("gauntlet", 1, type: "indefinite") } → "a pair of gauntlets"
+#   Example: { ITEM_WITH_COUNT("healing-potion", 3) } → "3 flasks of healing potion"
 #
 # Note: The `cap: "true"` parameter is used when the function result appears
 # at sentence start. This is a pragmatic workaround since Fluent does not
-# support function nesting like CAPITALIZE(COUNT_ITEM(...)).
+# support function nesting like CAPITALIZE(ITEM_WITH_COUNT(...)).
 
 ## Messages
 
 # Finding items (counter-aware)
 found-item =
     { $count ->
-        [one] You found { COUNT_ITEM($item, $count, type: "indefinite") }.
-       *[other] You found { COUNT_ITEM($item, $count) }.
+        [one] You found { ITEM_WITH_COUNT($item, $count, type: "indefinite") }.
+       *[other] You found { ITEM_WITH_COUNT($item, $count) }.
     }
 
 # Item is here (sentence start - capitalize, counter-aware)
 item-is-here =
     { $count ->
-        [one] { COUNT_ITEM($item, $count, type: "definite", cap: "true") } is here.
-       *[other] { COUNT_ITEM($item, $count, cap: "true") } are here.
+        [one] { ITEM_WITH_COUNT($item, $count, type: "definite", cap: "true") } is here.
+       *[other] { ITEM_WITH_COUNT($item, $count, cap: "true") } are here.
     }
 
 # Attack with item (count defaults to 1)
-attack-with-item = You attack with { ARTICLE_ITEM($item, type: "definite") }.
+attack-with-item = You attack with { ITEM($item, type: "definite") }.
 
 # Drop item (counter-aware)
 drop-item =
     { $count ->
-        [one] You dropped { COUNT_ITEM($item, $count, type: "indefinite") }.
-       *[other] You dropped { COUNT_ITEM($item, $count) }.
+        [one] You dropped { ITEM_WITH_COUNT($item, $count, type: "indefinite") }.
+       *[other] You dropped { ITEM_WITH_COUNT($item, $count) }.
     }
 
 # Inventory (counter-aware)
 inventory-item =
     { $count ->
-        [one] { COUNT_ITEM($item, $count, type: "indefinite") }
-       *[other] { COUNT_ITEM($item, $count) }
+        [one] { ITEM_WITH_COUNT($item, $count, type: "indefinite") }
+       *[other] { ITEM_WITH_COUNT($item, $count) }
     }
 

--- a/examples/dungeon_game/locales/fr/messages.ftl
+++ b/examples/dungeon_game/locales/fr/messages.ftl
@@ -2,20 +2,20 @@
 
 ## Custom Functions
 #
-# ARTICLE_ITEM($item, $count, type, cap)
+# ITEM($item, $count, type, cap)
 #   Returns article + item name with gender agreement and elision.
 #   - type: "indefinite" (un/une), "definite" (le/la/l'), "none" (default: "indefinite")
-#   Example: { ARTICLE_ITEM("sword", type: "definite") } → "l'épée" (elision)
-#   Example: { ARTICLE_ITEM("axe", type: "definite") } → "la hache" (h aspiré, no elision)
-#   Example: { ARTICLE_ITEM("dagger", type: "indefinite") } → "un poignard"
+#   Example: { ITEM("sword", type: "definite") } → "l'épée" (elision)
+#   Example: { ITEM("axe", type: "definite") } → "la hache" (h aspiré, no elision)
+#   Example: { ITEM("dagger", type: "indefinite") } → "un poignard"
 #
-# COUNT_ITEM($item, $count, type, cap)
+# ITEM_WITH_COUNT($item, $count, type, cap)
 #   Returns count + item, using counters when available.
 #   Counter elision is handled automatically (fiole de potion vs fiole d'élixir).
 #   - type: "indefinite", "definite", or "none" (default: "none")
-#   Example: { COUNT_ITEM("sword", 3) } → "3 épées"
-#   Example: { COUNT_ITEM("healing-potion", 1, type: "indefinite") } → "une fiole de potion de soin"
-#   Example: { COUNT_ITEM("elixir", 1, type: "indefinite") } → "une fiole d'élixir"
+#   Example: { ITEM_WITH_COUNT("sword", 3) } → "3 épées"
+#   Example: { ITEM_WITH_COUNT("healing-potion", 1, type: "indefinite") } → "une fiole de potion de soin"
+#   Example: { ITEM_WITH_COUNT("elixir", 1, type: "indefinite") } → "une fiole d'élixir"
 #
 # French elision notes:
 #   - Definite articles le/la become l' before vowels (l'épée)
@@ -27,30 +27,30 @@
 # Finding items (counter-aware)
 found-item =
     { $count ->
-        [one] Tu as trouvé { COUNT_ITEM($item, $count, type: "indefinite") }.
-       *[other] Tu as trouvé { COUNT_ITEM($item, $count) }.
+        [one] Tu as trouvé { ITEM_WITH_COUNT($item, $count, type: "indefinite") }.
+       *[other] Tu as trouvé { ITEM_WITH_COUNT($item, $count) }.
     }
 
 # Item is here (sentence start - capitalize, counter-aware)
 item-is-here =
     { $count ->
-        [one] { COUNT_ITEM($item, $count, type: "definite", cap: "true") } est ici.
-       *[other] { COUNT_ITEM($item, $count, cap: "true") } sont ici.
+        [one] { ITEM_WITH_COUNT($item, $count, type: "definite", cap: "true") } est ici.
+       *[other] { ITEM_WITH_COUNT($item, $count, cap: "true") } sont ici.
     }
 
 # Attack with item (count defaults to 1)
-attack-with-item = Tu attaques avec { ARTICLE_ITEM($item, type: "definite") }.
+attack-with-item = Tu attaques avec { ITEM($item, type: "definite") }.
 
 # Drop item (counter-aware)
 drop-item =
     { $count ->
-        [one] Tu as laissé tomber { COUNT_ITEM($item, $count, type: "indefinite") }.
-       *[other] Tu as laissé tomber { COUNT_ITEM($item, $count) }.
+        [one] Tu as laissé tomber { ITEM_WITH_COUNT($item, $count, type: "indefinite") }.
+       *[other] Tu as laissé tomber { ITEM_WITH_COUNT($item, $count) }.
     }
 
 # Inventory (counter-aware)
 inventory-item =
     { $count ->
-        [one] { COUNT_ITEM($item, $count, type: "indefinite") }
-       *[other] { COUNT_ITEM($item, $count) }
+        [one] { ITEM_WITH_COUNT($item, $count, type: "indefinite") }
+       *[other] { ITEM_WITH_COUNT($item, $count) }
     }

--- a/examples/dungeon_game/main.rb
+++ b/examples/dungeon_game/main.rb
@@ -4,7 +4,7 @@
 #
 # This example demonstrates:
 # - Two-layer bundle architecture (Items Bundle + Messages Bundle)
-# - Custom functions (ITEM, ARTICLE, ARTICLE_ITEM) for dynamic item localization
+# - Custom functions (ITEM, ITEM_WITH_COUNT) for dynamic item localization
 # - German grammatical cases (nominative, accusative, dative, genitive)
 # - German grammatical gender (masculine, feminine, neuter)
 # - French elision (l'épée vs la hache)


### PR DESCRIPTION
## Summary

Rename custom Fluent functions in the dungeon game example for better naming consistency.

## Changes

- Rename `ARTICLE_ITEM` → `ITEM` and `COUNT_ITEM` → `ITEM_WITH_COUNT`
- Move common `functions` method to Base class (en/de/fr now inherit it)
- Japanese functions (`ITEM`, `COUNT`) remain unchanged

## Rationale

- `ITEM` as the base function is more natural
- Both functions control articles via `type` parameter, so `ARTICLE_` prefix was misleading
- `ITEM_WITH_COUNT` clearly indicates the count is included in output

Closes #140
