### PR TITLE
:sparkles: Add implicit NUMBER/DATETIME formatting for variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **Formatting Features**
   - `icu4x`-based number and date formatting
   - Built-in functions: NUMBER() and DATETIME()
+  - Implicit NUMBER/DATETIME function calling for numeric and time variables
 - **CLI Commands**
   - `foxtail check` - Check FTL files for syntax errors
   - `foxtail dump` - Dump FTL files as AST in JSON format

--- a/doc/icu4x-integration.md
+++ b/doc/icu4x-integration.md
@@ -165,6 +165,31 @@ bundle.format("meeting", time: Time.new(2026, 1, 4, 14, 30))
 # => "Meeting at 2:30 PM"
 ```
 
+### Implicit Function Calling
+
+Per the [Fluent specification](https://github.com/projectfluent/fluent/blob/main/guide/functions.md), numeric and time variables automatically receive locale-aware formatting when used in placeables:
+
+```ftl
+# Implicit NUMBER formatting - equivalent to { NUMBER($count) }
+emails = You have { $count } emails.
+
+# Implicit DATETIME formatting - equivalent to { DATETIME($date) }
+created = Created on { $date }.
+```
+
+```ruby
+bundle.format("emails", count: 1000)  # "You have 1,000 emails."
+
+time = Time.new(2025, 1, 4)
+bundle.format("created", date: time)  # "Created on Jan 4, 2025."
+```
+
+**Supported types for implicit formatting:**
+- NUMBER: `Integer`, `Float`, `BigDecimal`
+- DATETIME: `Time`, or any object responding to `#to_time` (e.g., `Date`)
+
+Use explicit function calls when you need specific formatting options (currency, percent, date/time styles, etc.).
+
 ## Plural Rules
 
 Foxtail uses ICU4X plural rules for select expressions with numeric selectors.

--- a/examples/04_number_format.expected.txt
+++ b/examples/04_number_format.expected.txt
@@ -1,5 +1,5 @@
 === English (US) ===
-Total: 42
+Total: 1,234
 Price: $1,234.5
 Save 25%!
 Value: 3.14

--- a/examples/04_number_format.rb
+++ b/examples/04_number_format.rb
@@ -3,45 +3,44 @@
 # Example 04: Number Formatting
 #
 # This example demonstrates:
-# - NUMBER function for locale-aware formatting
-# - Currency formatting
-# - Percentage formatting
-# - Decimal digit control
+# - Implicit NUMBER formatting for numeric variables
+# - Explicit NUMBER function for currency, percent, and precision options
+# - Locale-aware formatting
 
 require "foxtail"
 
 # English (US)
 en_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("en-US"), use_isolating: false)
 en_resource = Foxtail::Resource.from_string(<<~FTL)
-  # Basic number formatting
-  count = Total: { NUMBER($value) }
-  # Currency formatting
+  # Implicit NUMBER formatting (automatically applied to numeric variables)
+  count = Total: { $value }
+  # Currency formatting (requires explicit NUMBER with options)
   price = Price: { NUMBER($amount, style: "currency", currency: "USD") }
-  # Percentage
+  # Percentage (requires explicit NUMBER with options)
   discount = Save { NUMBER($rate, style: "percent") }!
-  # Controlling decimal places
+  # Controlling decimal places (requires explicit NUMBER with options)
   precise = Value: { NUMBER($num, minimumFractionDigits: 2, maximumFractionDigits: 2) }
-  # Large numbers with grouping
-  population = Population: { NUMBER($count) }
+  # Large numbers with implicit grouping
+  population = Population: { $count }
 FTL
 en_bundle.add_resource(en_resource)
 
 # Japanese
 ja_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("ja"), use_isolating: false)
 ja_resource = Foxtail::Resource.from_string(<<~FTL)
-  # Currency in Yen
+  # Currency in Yen (requires explicit NUMBER with options)
   price = 価格：{ NUMBER($amount, style: "currency", currency: "JPY") }
-  # Percentage
+  # Percentage (requires explicit NUMBER with options)
   discount = { NUMBER($rate, style: "percent") }オフ！
-  # Large numbers
-  population = 人口：{ NUMBER($count) }人
+  # Large numbers with implicit grouping
+  population = 人口：{ $count }人
 FTL
 ja_bundle.add_resource(ja_resource)
 
 puts "=== English (US) ==="
 
-puts en_bundle.format("count", value: 42)
-# => Total: 42
+puts en_bundle.format("count", value: 1234)
+# => Total: 1,234
 
 puts en_bundle.format("price", amount: 1234.50)
 # => Price: $1,234.50

--- a/examples/05_datetime_format.expected.txt
+++ b/examples/05_datetime_format.expected.txt
@@ -1,8 +1,9 @@
 === English (US) ===
-Full:   January 4, 2025
-Long:   January 4, 2025
-Medium: Jan 4, 2025
-Short:  1/4/25
+Implicit: Jan 4, 2025
+Full:     January 4, 2025
+Long:     January 4, 2025
+Medium:   Jan 4, 2025
+Short:    1/4/25
 
 Time (full):  5:30:00 AM
 Time (short): 5:30:00 AM
@@ -10,6 +11,7 @@ Time (short): 5:30:00 AM
 Combined: Jan 4, 2025, 5:30:00 AM
 
 === Japanese ===
-Full:   2025年1月4日
-Medium: 2025/01/04
+Implicit: 2025/01/04
+Full:     2025年1月4日
+Medium:   2025/01/04
 Combined: 2025/01/04 5:30:00

--- a/examples/05_datetime_format.rb
+++ b/examples/05_datetime_format.rb
@@ -3,25 +3,26 @@
 # Example 05: Date/Time Formatting
 #
 # This example demonstrates:
-# - DATETIME function for locale-aware formatting
-# - Date styles (full, long, medium, short)
-# - Time styles
-# - Combined date and time
+# - Implicit DATETIME formatting for Time variables
+# - Explicit DATETIME function for date/time style options
+# - Locale-aware formatting
 
 require "foxtail"
 
 # English (US)
 en_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("en-US"), use_isolating: false)
 en_resource = Foxtail::Resource.from_string(<<~FTL)
-  # Date only - various styles
+  # Implicit DATETIME formatting (automatically applied to Time variables)
+  date-implicit = { $date }
+  # Date only - various styles (requires explicit DATETIME with options)
   date-full = { DATETIME($date, dateStyle: "full") }
   date-long = { DATETIME($date, dateStyle: "long") }
   date-medium = { DATETIME($date, dateStyle: "medium") }
   date-short = { DATETIME($date, dateStyle: "short") }
-  # Time only
+  # Time only (requires explicit DATETIME with options)
   time-full = { DATETIME($time, timeStyle: "full") }
   time-short = { DATETIME($time, timeStyle: "short") }
-  # Combined
+  # Combined (requires explicit DATETIME with options)
   datetime = { DATETIME($dt, dateStyle: "medium", timeStyle: "short") }
 FTL
 en_bundle.add_resource(en_resource)
@@ -29,6 +30,8 @@ en_bundle.add_resource(en_resource)
 # Japanese
 ja_bundle = Foxtail::Bundle.new(ICU4X::Locale.parse("ja"), use_isolating: false)
 ja_resource = Foxtail::Resource.from_string(<<~FTL)
+  # Implicit DATETIME formatting
+  date-implicit = { $date }
   date-full = { DATETIME($date, dateStyle: "full") }
   date-medium = { DATETIME($date, dateStyle: "medium") }
   datetime = { DATETIME($dt, dateStyle: "medium", timeStyle: "short") }
@@ -39,10 +42,11 @@ ja_bundle.add_resource(ja_resource)
 sample_date = Time.new(2025, 1, 4, 14, 30, 0, "+09:00")
 
 puts "=== English (US) ==="
-puts "Full:   #{en_bundle.format("date-full", date: sample_date)}"
-puts "Long:   #{en_bundle.format("date-long", date: sample_date)}"
-puts "Medium: #{en_bundle.format("date-medium", date: sample_date)}"
-puts "Short:  #{en_bundle.format("date-short", date: sample_date)}"
+puts "Implicit: #{en_bundle.format("date-implicit", date: sample_date)}"
+puts "Full:     #{en_bundle.format("date-full", date: sample_date)}"
+puts "Long:     #{en_bundle.format("date-long", date: sample_date)}"
+puts "Medium:   #{en_bundle.format("date-medium", date: sample_date)}"
+puts "Short:    #{en_bundle.format("date-short", date: sample_date)}"
 puts
 puts "Time (full):  #{en_bundle.format("time-full", time: sample_date)}"
 puts "Time (short): #{en_bundle.format("time-short", time: sample_date)}"
@@ -50,6 +54,7 @@ puts
 puts "Combined: #{en_bundle.format("datetime", dt: sample_date)}"
 
 puts "\n=== Japanese ==="
-puts "Full:   #{ja_bundle.format("date-full", date: sample_date)}"
-puts "Medium: #{ja_bundle.format("date-medium", date: sample_date)}"
+puts "Implicit: #{ja_bundle.format("date-implicit", date: sample_date)}"
+puts "Full:     #{ja_bundle.format("date-full", date: sample_date)}"
+puts "Medium:   #{ja_bundle.format("date-medium", date: sample_date)}"
 puts "Combined: #{ja_bundle.format("datetime", dt: sample_date)}"

--- a/foxtail.gemspec
+++ b/foxtail.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Dependencies
+  spec.add_dependency "bigdecimal", ">= 3.1"
   spec.add_dependency "dry-cli", "~> 1.3"
   spec.add_dependency "icu4x", "~> 0.7"
   spec.add_dependency "zeitwerk", "~> 2.7"

--- a/lib/foxtail/function.rb
+++ b/lib/foxtail/function.rb
@@ -16,7 +16,7 @@ module Foxtail
     end
 
     # Format number using ICU4X
-    # @param value [Numeric] Number to format
+    # @param value [Integer, Float, BigDecimal] Number to format
     # @param locale [ICU4X::Locale] Locale for formatting
     # @param options [Hash] Formatting options (camelCase keys)
     # @return [String] Formatted number
@@ -26,7 +26,7 @@ module Foxtail
     end
 
     # Format datetime using ICU4X
-    # @param value [Time] Time to format
+    # @param value [Time, #to_time] Time or object responding to #to_time
     # @param locale [ICU4X::Locale] Locale for formatting
     # @param options [Hash] Formatting options (camelCase keys)
     # @return [String] Formatted datetime


### PR DESCRIPTION
## Summary

Implement implicit NUMBER/DATETIME function calling per the Fluent specification. Numeric and time variables now automatically receive locale-aware formatting when used in placeables.

## Changes

- Add implicit NUMBER formatting for Integer, Float, and BigDecimal variables
- Add implicit DATETIME formatting for Time and `#to_time` responders
- Update examples to demonstrate implicit formatting
- Add documentation for implicit function calling

## Example

```ftl
# Before: explicit function call required
emails = You have { NUMBER($count) } emails.

# After: implicit formatting applied automatically  
emails = You have { $count } emails.
```

Both produce locale-aware output: "You have 1,000 emails."

## Test Plan

- `bundle exec rake` passes (478 examples, 0 failures)
- Examples in `examples/04_number_format.rb` and `examples/05_datetime_format.rb` demonstrate implicit formatting

Closes #142
