### PR TITLE
:sparkles: Add locale-aware number formatting in custom functions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,6 +48,11 @@ Metrics/BlockNesting:
   Exclude:
     - 'lib/foxtail/syntax/parser.rb'
 
+# Example code may have complex function signatures for demonstration purposes
+Metrics/ParameterLists:
+  Exclude:
+    - 'examples/dungeon_game/functions/*.rb'
+
 # Allow common short parameter names in parser contexts
 Naming/MethodParameterName:
   AllowedNames:

--- a/examples/dungeon_game/expected.txt
+++ b/examples/dungeon_game/expected.txt
@@ -4,289 +4,465 @@
 found-item:
   You found a dagger.
   You found 3 daggers.
+  You found 1,000 daggers.
   You found an axe.
   You found 3 axes.
+  You found 1,000 axes.
   You found a sword.
   You found 3 swords.
+  You found 1,000 swords.
   You found a hammer.
   You found 3 hammers.
+  You found 1,000 hammers.
   You found a herb.
   You found 3 herbs.
+  You found 1,000 herbs.
+  You found a gold coin.
+  You found 3 gold coins.
+  You found 1,000 gold coins.
   You found a pair of gauntlets.
   You found 3 pairs of gauntlets.
+  You found 1,000 pairs of gauntlets.
   You found a flask of healing potion.
   You found 3 flasks of healing potion.
+  You found 1,000 flasks of healing potion.
   You found a flask of elixir.
   You found 3 flasks of elixir.
+  You found 1,000 flasks of elixir.
 attack-with-item:
   You attack with the sword.
 item-is-here:
   The dagger is here.
   3 daggers are here.
+  1,000 daggers are here.
   The axe is here.
   3 axes are here.
+  1,000 axes are here.
   The sword is here.
   3 swords are here.
+  1,000 swords are here.
   The hammer is here.
   3 hammers are here.
+  1,000 hammers are here.
   The herb is here.
   3 herbs are here.
+  1,000 herbs are here.
+  The gold coin is here.
+  3 gold coins are here.
+  1,000 gold coins are here.
   The pair of gauntlets is here.
   3 pairs of gauntlets are here.
+  1,000 pairs of gauntlets are here.
   The flask of healing potion is here.
   3 flasks of healing potion are here.
+  1,000 flasks of healing potion are here.
   The flask of elixir is here.
   3 flasks of elixir are here.
+  1,000 flasks of elixir are here.
 drop-item:
   You dropped a dagger.
   You dropped 3 daggers.
+  You dropped 1,000 daggers.
   You dropped an axe.
   You dropped 3 axes.
+  You dropped 1,000 axes.
   You dropped a sword.
   You dropped 3 swords.
+  You dropped 1,000 swords.
   You dropped a hammer.
   You dropped 3 hammers.
+  You dropped 1,000 hammers.
   You dropped a herb.
   You dropped 3 herbs.
+  You dropped 1,000 herbs.
+  You dropped a gold coin.
+  You dropped 3 gold coins.
+  You dropped 1,000 gold coins.
   You dropped a pair of gauntlets.
   You dropped 3 pairs of gauntlets.
+  You dropped 1,000 pairs of gauntlets.
   You dropped a flask of healing potion.
   You dropped 3 flasks of healing potion.
+  You dropped 1,000 flasks of healing potion.
   You dropped a flask of elixir.
   You dropped 3 flasks of elixir.
+  You dropped 1,000 flasks of elixir.
 inventory-item:
   a dagger
   3 daggers
+  1,000 daggers
   an axe
   3 axes
+  1,000 axes
   a sword
   3 swords
+  1,000 swords
   a hammer
   3 hammers
+  1,000 hammers
   a herb
   3 herbs
+  1,000 herbs
+  a gold coin
+  3 gold coins
+  1,000 gold coins
   a pair of gauntlets
   3 pairs of gauntlets
+  1,000 pairs of gauntlets
   a flask of healing potion
   3 flasks of healing potion
+  1,000 flasks of healing potion
   a flask of elixir
   3 flasks of elixir
+  1,000 flasks of elixir
 
 --- German ---
 found-item:
   Du hast einen Dolch gefunden.
   Du hast 3 Dolche gefunden.
+  Du hast 1.000 Dolche gefunden.
   Du hast eine Axt gefunden.
   Du hast 3 Äxte gefunden.
+  Du hast 1.000 Äxte gefunden.
   Du hast ein Schwert gefunden.
   Du hast 3 Schwerter gefunden.
+  Du hast 1.000 Schwerter gefunden.
   Du hast einen Hammer gefunden.
   Du hast 3 Hämmer gefunden.
+  Du hast 1.000 Hämmer gefunden.
   Du hast ein Kraut gefunden.
   Du hast 3 Kräuter gefunden.
+  Du hast 1.000 Kräuter gefunden.
+  Du hast eine Goldmünze gefunden.
+  Du hast 3 Goldmünzen gefunden.
+  Du hast 1.000 Goldmünzen gefunden.
   Du hast ein Paar Panzerhandschuhe gefunden.
   Du hast 3 Paar Panzerhandschuhe gefunden.
+  Du hast 1.000 Paar Panzerhandschuhe gefunden.
   Du hast eine Flasche Heiltrank gefunden.
   Du hast 3 Flaschen Heiltrank gefunden.
+  Du hast 1.000 Flaschen Heiltrank gefunden.
   Du hast eine Flasche Elixier gefunden.
   Du hast 3 Flaschen Elixier gefunden.
+  Du hast 1.000 Flaschen Elixier gefunden.
 attack-with-item:
   Du greifst mit dem Schwert an.
 item-is-here:
   Der Dolch ist hier.
   3 Dolche sind hier.
+  1.000 Dolche sind hier.
   Die Axt ist hier.
   3 Äxte sind hier.
+  1.000 Äxte sind hier.
   Das Schwert ist hier.
   3 Schwerter sind hier.
+  1.000 Schwerter sind hier.
   Der Hammer ist hier.
   3 Hämmer sind hier.
+  1.000 Hämmer sind hier.
   Das Kraut ist hier.
   3 Kräuter sind hier.
+  1.000 Kräuter sind hier.
+  Die Goldmünze ist hier.
+  3 Goldmünzen sind hier.
+  1.000 Goldmünzen sind hier.
   Das Paar Panzerhandschuhe ist hier.
   3 Paar Panzerhandschuhe sind hier.
+  1.000 Paar Panzerhandschuhe sind hier.
   Die Flasche Heiltrank ist hier.
   3 Flaschen Heiltrank sind hier.
+  1.000 Flaschen Heiltrank sind hier.
   Die Flasche Elixier ist hier.
   3 Flaschen Elixier sind hier.
+  1.000 Flaschen Elixier sind hier.
 drop-item:
   Du hast einen Dolch fallen gelassen.
   Du hast 3 Dolche fallen gelassen.
+  Du hast 1.000 Dolche fallen gelassen.
   Du hast eine Axt fallen gelassen.
   Du hast 3 Äxte fallen gelassen.
+  Du hast 1.000 Äxte fallen gelassen.
   Du hast ein Schwert fallen gelassen.
   Du hast 3 Schwerter fallen gelassen.
+  Du hast 1.000 Schwerter fallen gelassen.
   Du hast einen Hammer fallen gelassen.
   Du hast 3 Hämmer fallen gelassen.
+  Du hast 1.000 Hämmer fallen gelassen.
   Du hast ein Kraut fallen gelassen.
   Du hast 3 Kräuter fallen gelassen.
+  Du hast 1.000 Kräuter fallen gelassen.
+  Du hast eine Goldmünze fallen gelassen.
+  Du hast 3 Goldmünzen fallen gelassen.
+  Du hast 1.000 Goldmünzen fallen gelassen.
   Du hast ein Paar Panzerhandschuhe fallen gelassen.
   Du hast 3 Paar Panzerhandschuhe fallen gelassen.
+  Du hast 1.000 Paar Panzerhandschuhe fallen gelassen.
   Du hast eine Flasche Heiltrank fallen gelassen.
   Du hast 3 Flaschen Heiltrank fallen gelassen.
+  Du hast 1.000 Flaschen Heiltrank fallen gelassen.
   Du hast eine Flasche Elixier fallen gelassen.
   Du hast 3 Flaschen Elixier fallen gelassen.
+  Du hast 1.000 Flaschen Elixier fallen gelassen.
 inventory-item:
   ein Dolch
   3 Dolche
+  1.000 Dolche
   eine Axt
   3 Äxte
+  1.000 Äxte
   ein Schwert
   3 Schwerter
+  1.000 Schwerter
   ein Hammer
   3 Hämmer
+  1.000 Hämmer
   ein Kraut
   3 Kräuter
+  1.000 Kräuter
+  eine Goldmünze
+  3 Goldmünzen
+  1.000 Goldmünzen
   ein Paar Panzerhandschuhe
   3 Paar Panzerhandschuhe
+  1.000 Paar Panzerhandschuhe
   eine Flasche Heiltrank
   3 Flaschen Heiltrank
+  1.000 Flaschen Heiltrank
   eine Flasche Elixier
   3 Flaschen Elixier
+  1.000 Flaschen Elixier
 
 --- French ---
 found-item:
   Tu as trouvé un poignard.
   Tu as trouvé 3 poignards.
+  Tu as trouvé 1 000 poignards.
   Tu as trouvé une hache.
   Tu as trouvé 3 haches.
+  Tu as trouvé 1 000 haches.
   Tu as trouvé une épée.
   Tu as trouvé 3 épées.
+  Tu as trouvé 1 000 épées.
   Tu as trouvé un marteau.
   Tu as trouvé 3 marteaux.
+  Tu as trouvé 1 000 marteaux.
   Tu as trouvé une herbe.
   Tu as trouvé 3 herbes.
+  Tu as trouvé 1 000 herbes.
+  Tu as trouvé une pièce d'or.
+  Tu as trouvé 3 pièces d'or.
+  Tu as trouvé 1 000 pièces d'or.
   Tu as trouvé une paire de gantelets.
   Tu as trouvé 3 paires de gantelets.
+  Tu as trouvé 1 000 paires de gantelets.
   Tu as trouvé une fiole de potion de soin.
   Tu as trouvé 3 fioles de potion de soin.
+  Tu as trouvé 1 000 fioles de potion de soin.
   Tu as trouvé une fiole d'élixir.
   Tu as trouvé 3 fioles d'élixir.
+  Tu as trouvé 1 000 fioles d'élixir.
 attack-with-item:
   Tu attaques avec l'épée.
 item-is-here:
   Le poignard est ici.
   3 poignards sont ici.
+  1 000 poignards sont ici.
   La hache est ici.
   3 haches sont ici.
+  1 000 haches sont ici.
   L'épée est ici.
   3 épées sont ici.
+  1 000 épées sont ici.
   Le marteau est ici.
   3 marteaux sont ici.
+  1 000 marteaux sont ici.
   L'herbe est ici.
   3 herbes sont ici.
+  1 000 herbes sont ici.
+  La pièce d'or est ici.
+  3 pièces d'or sont ici.
+  1 000 pièces d'or sont ici.
   La paire de gantelets est ici.
   3 paires de gantelets sont ici.
+  1 000 paires de gantelets sont ici.
   La fiole de potion de soin est ici.
   3 fioles de potion de soin sont ici.
+  1 000 fioles de potion de soin sont ici.
   La fiole d'élixir est ici.
   3 fioles d'élixir sont ici.
+  1 000 fioles d'élixir sont ici.
 drop-item:
   Tu as laissé tomber un poignard.
   Tu as laissé tomber 3 poignards.
+  Tu as laissé tomber 1 000 poignards.
   Tu as laissé tomber une hache.
   Tu as laissé tomber 3 haches.
+  Tu as laissé tomber 1 000 haches.
   Tu as laissé tomber une épée.
   Tu as laissé tomber 3 épées.
+  Tu as laissé tomber 1 000 épées.
   Tu as laissé tomber un marteau.
   Tu as laissé tomber 3 marteaux.
+  Tu as laissé tomber 1 000 marteaux.
   Tu as laissé tomber une herbe.
   Tu as laissé tomber 3 herbes.
+  Tu as laissé tomber 1 000 herbes.
+  Tu as laissé tomber une pièce d'or.
+  Tu as laissé tomber 3 pièces d'or.
+  Tu as laissé tomber 1 000 pièces d'or.
   Tu as laissé tomber une paire de gantelets.
   Tu as laissé tomber 3 paires de gantelets.
+  Tu as laissé tomber 1 000 paires de gantelets.
   Tu as laissé tomber une fiole de potion de soin.
   Tu as laissé tomber 3 fioles de potion de soin.
+  Tu as laissé tomber 1 000 fioles de potion de soin.
   Tu as laissé tomber une fiole d'élixir.
   Tu as laissé tomber 3 fioles d'élixir.
+  Tu as laissé tomber 1 000 fioles d'élixir.
 inventory-item:
   un poignard
   3 poignards
+  1 000 poignards
   une hache
   3 haches
+  1 000 haches
   une épée
   3 épées
+  1 000 épées
   un marteau
   3 marteaux
+  1 000 marteaux
   une herbe
   3 herbes
+  1 000 herbes
+  une pièce d'or
+  3 pièces d'or
+  1 000 pièces d'or
   une paire de gantelets
   3 paires de gantelets
+  1 000 paires de gantelets
   une fiole de potion de soin
   3 fioles de potion de soin
+  1 000 fioles de potion de soin
   une fiole d'élixir
   3 fioles d'élixir
+  1 000 fioles d'élixir
 
 --- Japanese ---
 found-item:
   短剣を1振見つけた。
   短剣を3振見つけた。
+  短剣を1,000振見つけた。
   斧を1振見つけた。
   斧を3振見つけた。
+  斧を1,000振見つけた。
   剣を1振見つけた。
   剣を3振見つけた。
+  剣を1,000振見つけた。
   槌を1振見つけた。
   槌を3振見つけた。
+  槌を1,000振見つけた。
   薬草を1束見つけた。
   薬草を3束見つけた。
+  薬草を1,000束見つけた。
+  金貨を1枚見つけた。
+  金貨を3枚見つけた。
+  金貨を1,000枚見つけた。
   籠手を1組見つけた。
   籠手を3組見つけた。
+  籠手を1,000組見つけた。
   回復薬を1瓶見つけた。
   回復薬を3瓶見つけた。
+  回復薬を1,000瓶見つけた。
   霊薬を1瓶見つけた。
   霊薬を3瓶見つけた。
+  霊薬を1,000瓶見つけた。
 attack-with-item:
   剣で攻撃した。
 item-is-here:
   短剣が1振ある。
   短剣が3振ある。
+  短剣が1,000振ある。
   斧が1振ある。
   斧が3振ある。
+  斧が1,000振ある。
   剣が1振ある。
   剣が3振ある。
+  剣が1,000振ある。
   槌が1振ある。
   槌が3振ある。
+  槌が1,000振ある。
   薬草が1束ある。
   薬草が3束ある。
+  薬草が1,000束ある。
+  金貨が1枚ある。
+  金貨が3枚ある。
+  金貨が1,000枚ある。
   籠手が1組ある。
   籠手が3組ある。
+  籠手が1,000組ある。
   回復薬が1瓶ある。
   回復薬が3瓶ある。
+  回復薬が1,000瓶ある。
   霊薬が1瓶ある。
   霊薬が3瓶ある。
+  霊薬が1,000瓶ある。
 drop-item:
   短剣を1振捨てた。
   短剣を3振捨てた。
+  短剣を1,000振捨てた。
   斧を1振捨てた。
   斧を3振捨てた。
+  斧を1,000振捨てた。
   剣を1振捨てた。
   剣を3振捨てた。
+  剣を1,000振捨てた。
   槌を1振捨てた。
   槌を3振捨てた。
+  槌を1,000振捨てた。
   薬草を1束捨てた。
   薬草を3束捨てた。
+  薬草を1,000束捨てた。
+  金貨を1枚捨てた。
+  金貨を3枚捨てた。
+  金貨を1,000枚捨てた。
   籠手を1組捨てた。
   籠手を3組捨てた。
+  籠手を1,000組捨てた。
   回復薬を1瓶捨てた。
   回復薬を3瓶捨てた。
+  回復薬を1,000瓶捨てた。
   霊薬を1瓶捨てた。
   霊薬を3瓶捨てた。
+  霊薬を1,000瓶捨てた。
 inventory-item:
   短剣 x 1振
   短剣 x 3振
+  短剣 x 1,000振
   斧 x 1振
   斧 x 3振
+  斧 x 1,000振
   剣 x 1振
   剣 x 3振
+  剣 x 1,000振
   槌 x 1振
   槌 x 3振
+  槌 x 1,000振
   薬草 x 1束
   薬草 x 3束
+  薬草 x 1,000束
+  金貨 x 1枚
+  金貨 x 3枚
+  金貨 x 1,000枚
   籠手 x 1組
   籠手 x 3組
+  籠手 x 1,000組
   回復薬 x 1瓶
   回復薬 x 3瓶
+  回復薬 x 1,000瓶
   霊薬 x 1瓶
   霊薬 x 3瓶
+  霊薬 x 1,000瓶
 
 === German Grammatical Cases ===
 

--- a/examples/dungeon_game/functions/fr.rb
+++ b/examples/dungeon_game/functions/fr.rb
@@ -33,7 +33,7 @@ module ItemFunctions
       @items_bundle.format_pattern(term.value, article:, item:, elision: elision.to_s)
     end
 
-    private def format_count_item_with_counter(counter_term, item_id, count, type, grammatical_case)
+    private def format_count_item_with_counter(counter_term, item_id, count, type, grammatical_case, locale)
       item = resolve_item(item_id, 1, grammatical_case)
       item_elision = should_elide_for_item?(item_id)
       counter = @items_bundle.format_pattern(counter_term.value, count:, elision: item_elision.to_s)
@@ -43,13 +43,14 @@ module ItemFunctions
         article = resolve_article_for_counter(counter_term, counter_gender, count, type, grammatical_case)
         format_article_counter_item(article, counter, item, counter_elision: item_elision)
       else
-        format_count_counter_item(count, counter, item, item_elision)
+        format_count_counter_item(count, counter, item, item_elision, locale)
       end
     end
 
-    private def format_count_counter_item(count, counter, item, elision)
+    private def format_count_counter_item(count, counter, item, elision, locale)
       term = @items_bundle.term("-fmt-count-counter-item")
-      @items_bundle.format_pattern(term.value, count:, counter:, item:, elision: elision.to_s)
+      formatted_count = format_count(count, locale)
+      @items_bundle.format_pattern(term.value, count: formatted_count, counter:, item:, elision: elision.to_s)
     end
 
     private def resolve_article(item_id, count, type, _grammatical_case=nil)

--- a/examples/dungeon_game/functions/ja.rb
+++ b/examples/dungeon_game/functions/ja.rb
@@ -40,12 +40,11 @@ module ItemFunctions
     #
     # @param item_id [String] the item identifier used to determine the counter word
     # @param count [Integer] the quantity of items
+    # @param locale [ICU4X::Locale] the locale for number formatting
     # @return [String] the formatted count with counter word (e.g., "3振", "1瓶")
-    # @note The trailing ** is required because Foxtail::Bundle passes additional
-    #   keyword arguments (e.g., locale:) that this function does not use.
-    def fluent_count(item_id, count, **)
+    def fluent_count(item_id, count, locale:, **)
       counter = resolve_counter(item_id, count)
-      "#{count}#{counter || "個"}"
+      "#{format_count(count, locale)}#{counter || "個"}"
     end
 
     private def resolve_counter(item_id, count)

--- a/examples/dungeon_game/locales/de/items.ftl
+++ b/examples/dungeon_game/locales/de/items.ftl
@@ -98,6 +98,25 @@
             }
     }
     .gender = neuter
+# Goldmünze (feminine)
+-gold-coin =
+    { $count ->
+        [one]
+            { $case ->
+               *[nominative] Goldmünze
+                [accusative] Goldmünze
+                [dative] Goldmünze
+                [genitive] Goldmünze
+            }
+       *[other]
+            { $case ->
+               *[nominative] Goldmünzen
+                [accusative] Goldmünzen
+                [dative] Goldmünzen
+                [genitive] Goldmünzen
+            }
+    }
+    .gender = feminine
 
 ## Items with counters
 

--- a/examples/dungeon_game/locales/en/items.ftl
+++ b/examples/dungeon_game/locales/en/items.ftl
@@ -28,6 +28,11 @@
         [one] herb
        *[other] herbs
     }
+-gold-coin =
+    { $count ->
+        [one] gold coin
+       *[other] gold coins
+    }
 
 ## Items with counters
 

--- a/examples/dungeon_game/locales/fr/items.ftl
+++ b/examples/dungeon_game/locales/fr/items.ftl
@@ -39,6 +39,13 @@
     }
     .gender = feminine
     .elision = true
+# Pièce d'or (feminine)
+-gold-coin =
+    { $count ->
+        [one] pièce d'or
+       *[other] pièces d'or
+    }
+    .gender = feminine
 
 ## Items with counters
 

--- a/examples/dungeon_game/locales/ja/items.ftl
+++ b/examples/dungeon_game/locales/ja/items.ftl
@@ -18,6 +18,8 @@
     .counter = 振
 -herb = 薬草
     .counter = 束
+-gold-coin = 金貨
+    .counter = 枚
 
 ## Items with counters
 

--- a/examples/dungeon_game/main.rb
+++ b/examples/dungeon_game/main.rb
@@ -5,6 +5,7 @@
 # This example demonstrates:
 # - Two-layer bundle architecture (Items Bundle + Messages Bundle)
 # - Custom functions (ITEM, ITEM_WITH_COUNT) for dynamic item localization
+# - Locale-aware number formatting using ICU4X (1,000 vs 1.000 vs 1 000)
 # - German grammatical cases (nominative, accusative, dative, genitive)
 # - German grammatical gender (masculine, feminine, neuter)
 # - French elision (l'épée vs la hache)
@@ -73,8 +74,8 @@ puts "=== Dungeon Game Localization Demo ==="
 puts
 
 # Test items (including counter items)
-items = %w[dagger axe sword hammer herb gauntlet healing-potion elixir]
-counts = [1, 3]
+items = %w[dagger axe sword hammer herb gold-coin gauntlet healing-potion elixir]
+counts = [1, 3, 1000]
 
 # Language bundles
 en = TARGET_LOCALES["en"]


### PR DESCRIPTION
## Summary

Add locale-aware number formatting in dungeon_game custom functions using ICU4X.

## Changes

- Add `format_count` helper method using `ICU4X::NumberFormat`
- Update custom functions to accept `locale:` and format numbers appropriately
- Add gold coin item to demonstrate large number formatting (1,000 vs 1.000 vs 1 000)
- Update documentation to describe locale-aware formatting

## Example Output

| Locale | Format |
|--------|--------|
| English | 1,000 gold coins |
| German | 1.000 Goldmünzen |
| French | 1 000 pièces d'or |
| Japanese | 金貨を1,000枚 |

## Test Plan

- `bundle exec rake` passes (478 examples, 0 failures)

Closes #143
