### PR TITLE
:zap: Add ICU4XCache singleton for formatter/rules caching

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -65,6 +65,11 @@ Naming/PredicateMethod:
     - 'lib/foxtail/bundle/scope.rb'           # track() - tracks IDs for circular reference detection
     - 'lib/foxtail/bundle/parser.rb'          # consume_char/consume_token - consume and return success
 
+# Match Zeitwerk inflection: icu4x_cache => ICU4XCache
+RSpec/SpecFilePathFormat:
+  CustomTransform:
+    ICU4XCache: icu4x_cache
+
 # These specs test cross-cutting concerns rather than specific classes
 RSpec/DescribeClass:
   Exclude:

--- a/examples/dungeon_game/functions/base.rb
+++ b/examples/dungeon_game/functions/base.rb
@@ -83,7 +83,7 @@ module ItemFunctions
 
     private def capitalize_first(str) = str.sub(/\A\p{Ll}/, &:upcase)
 
-    private def format_count(count, locale) = ICU4X::NumberFormat.new(locale).format(count)
+    private def format_count(count, locale) = Foxtail::ICU4XCache.instance.number_formatter(locale).format(count)
 
     private def format_article_counter_item(article, counter, item)
       return [counter, item].compact.join(" ") unless article

--- a/lib/foxtail.rb
+++ b/lib/foxtail.rb
@@ -14,7 +14,8 @@ module Foxtail
   # Configure inflections for acronyms
   loader.inflector.inflect(
     "ast" => "AST",
-    "cli" => "CLI"
+    "cli" => "CLI",
+    "icu4x_cache" => "ICU4XCache"
   )
 
   loader.setup

--- a/lib/foxtail/bundle/resolver.rb
+++ b/lib/foxtail/bundle/resolver.rb
@@ -358,7 +358,7 @@ module Foxtail
           end
 
         # Use bundle's locale for plural rules
-        plural_rules = ICU4X::PluralRules.new(@bundle.locale)
+        plural_rules = ICU4XCache.instance.plural_rules(@bundle.locale)
         plural_category = plural_rules.select(numeric_value).to_s
         key_str.to_s == plural_category
       rescue => e

--- a/lib/foxtail/function.rb
+++ b/lib/foxtail/function.rb
@@ -22,7 +22,7 @@ module Foxtail
     # @return [String] Formatted number
     private_class_method def self.format_number(value, locale:, **options)
       icu_options = convert_number_options(options)
-      ICU4X::NumberFormat.new(locale, **icu_options).format(value)
+      ICU4XCache.instance.number_formatter(locale, **icu_options).format(value)
     end
 
     # Format datetime using ICU4X
@@ -35,7 +35,7 @@ module Foxtail
       # ICU4X requires at least one of date_style or time_style
       # Default to :medium for date if neither specified
       icu_options[:date_style] ||= :medium unless icu_options[:time_style]
-      ICU4X::DateTimeFormat.new(locale, **icu_options).format(value)
+      ICU4XCache.instance.datetime_formatter(locale, **icu_options).format(value)
     end
 
     # Convert FTL/JS style number options to ICU4X options

--- a/lib/foxtail/function.rb
+++ b/lib/foxtail/function.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "icu4x"
-
 module Foxtail
   # Built-in formatting functions for FTL
   # Uses ICU4X for number and datetime formatting

--- a/lib/foxtail/icu4x_cache.rb
+++ b/lib/foxtail/icu4x_cache.rb
@@ -21,6 +21,9 @@ module Foxtail
       @number_formatters = {}
       @datetime_formatters = {}
       @plural_rules = {}
+      @number_formatters_mutex = Mutex.new
+      @datetime_formatters_mutex = Mutex.new
+      @plural_rules_mutex = Mutex.new
     end
 
     # Returns a cached ICU4X::NumberFormat instance.
@@ -30,7 +33,9 @@ module Foxtail
     # @return [ICU4X::NumberFormat] Cached formatter instance
     def number_formatter(locale, **options)
       key = [locale.to_s, options]
-      @number_formatters[key] ||= ICU4X::NumberFormat.new(locale, **options)
+      @number_formatters_mutex.synchronize do
+        @number_formatters[key] ||= ICU4X::NumberFormat.new(locale, **options)
+      end
     end
 
     # Returns a cached ICU4X::DateTimeFormat instance.
@@ -40,7 +45,9 @@ module Foxtail
     # @return [ICU4X::DateTimeFormat] Cached formatter instance
     def datetime_formatter(locale, **options)
       key = [locale.to_s, options]
-      @datetime_formatters[key] ||= ICU4X::DateTimeFormat.new(locale, **options)
+      @datetime_formatters_mutex.synchronize do
+        @datetime_formatters[key] ||= ICU4X::DateTimeFormat.new(locale, **options)
+      end
     end
 
     # Returns a cached ICU4X::PluralRules instance.
@@ -50,7 +57,9 @@ module Foxtail
     # @return [ICU4X::PluralRules] Cached rules instance
     def plural_rules(locale, type: :cardinal)
       key = [locale.to_s, type]
-      @plural_rules[key] ||= ICU4X::PluralRules.new(locale, type:)
+      @plural_rules_mutex.synchronize do
+        @plural_rules[key] ||= ICU4X::PluralRules.new(locale, type:)
+      end
     end
   end
 end

--- a/lib/foxtail/icu4x_cache.rb
+++ b/lib/foxtail/icu4x_cache.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "icu4x"
+require "singleton"
+
+module Foxtail
+  # Singleton cache for ICU4X formatter and rules instances.
+  #
+  # ICU4X formatters and rules internally load and parse locale data,
+  # making instance creation non-trivial. This cache stores instances
+  # keyed by locale and options to avoid repeated instantiation.
+  #
+  # @example
+  #   cache = Foxtail::ICU4XCache.instance
+  #   formatter = cache.number_formatter(locale)
+  #   formatter.format(1234)  #=> "1,234"
+  class ICU4XCache
+    include Singleton
+
+    def initialize
+      @number_formatters = {}
+      @datetime_formatters = {}
+      @plural_rules = {}
+    end
+
+    # Returns a cached ICU4X::NumberFormat instance.
+    #
+    # @param locale [ICU4X::Locale] The locale for formatting
+    # @param options [Hash] Formatting options passed to ICU4X::NumberFormat.new
+    # @return [ICU4X::NumberFormat] Cached formatter instance
+    def number_formatter(locale, **options)
+      key = [locale.to_s, options]
+      @number_formatters[key] ||= ICU4X::NumberFormat.new(locale, **options)
+    end
+
+    # Returns a cached ICU4X::DateTimeFormat instance.
+    #
+    # @param locale [ICU4X::Locale] The locale for formatting
+    # @param options [Hash] Formatting options passed to ICU4X::DateTimeFormat.new
+    # @return [ICU4X::DateTimeFormat] Cached formatter instance
+    def datetime_formatter(locale, **options)
+      key = [locale.to_s, options]
+      @datetime_formatters[key] ||= ICU4X::DateTimeFormat.new(locale, **options)
+    end
+
+    # Returns a cached ICU4X::PluralRules instance.
+    #
+    # @param locale [ICU4X::Locale] The locale for plural rules
+    # @param type [Symbol] Plural rule type (:cardinal or :ordinal)
+    # @return [ICU4X::PluralRules] Cached rules instance
+    def plural_rules(locale, type: :cardinal)
+      key = [locale.to_s, type]
+      @plural_rules[key] ||= ICU4X::PluralRules.new(locale, type:)
+    end
+  end
+end

--- a/spec/foxtail/bundle/resolver_spec.rb
+++ b/spec/foxtail/bundle/resolver_spec.rb
@@ -321,7 +321,7 @@ RSpec.describe Foxtail::Bundle::Resolver do
     it "falls back to default when plural rules fail" do
       # Test with unsupported locale that might fail plural rule evaluation
       plural_rules_double = instance_double(ICU4X::PluralRules)
-      allow(ICU4X::PluralRules).to receive(:new).and_return(plural_rules_double)
+      allow(Foxtail::ICU4XCache.instance).to receive(:plural_rules).and_return(plural_rules_double)
       allow(plural_rules_double).to receive(:select).and_raise("Error")
 
       expr = ast::SelectExpression[

--- a/spec/foxtail/function_spec.rb
+++ b/spec/foxtail/function_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "icu4x"
+
 RSpec.describe Foxtail::Function do
   describe ".defaults" do
     it "returns callable ICU4X-based functions" do

--- a/spec/foxtail/icu4x_cache_spec.rb
+++ b/spec/foxtail/icu4x_cache_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+RSpec.describe Foxtail::ICU4XCache do
+  let(:cache) { Foxtail::ICU4XCache.instance }
+  let(:locale) { ICU4X::Locale.parse("en") }
+
+  describe "#number_formatter" do
+    it "returns a NumberFormat instance" do
+      formatter = cache.number_formatter(locale)
+
+      expect(formatter).to be_a(ICU4X::NumberFormat)
+    end
+
+    it "returns the same instance for the same locale and options" do
+      formatter1 = cache.number_formatter(locale)
+      formatter2 = cache.number_formatter(locale)
+
+      expect(formatter1).to be(formatter2)
+    end
+
+    it "returns different instances for different options" do
+      formatter1 = cache.number_formatter(locale)
+      formatter2 = cache.number_formatter(locale, style: :percent)
+
+      expect(formatter1).not_to be(formatter2)
+    end
+
+    it "formats numbers correctly" do
+      formatter = cache.number_formatter(locale)
+
+      expect(formatter.format(1234)).to eq("1,234")
+    end
+  end
+
+  describe "#datetime_formatter" do
+    it "returns a DateTimeFormat instance" do
+      formatter = cache.datetime_formatter(locale, date_style: :medium)
+
+      expect(formatter).to be_a(ICU4X::DateTimeFormat)
+    end
+
+    it "returns the same instance for the same locale and options" do
+      formatter1 = cache.datetime_formatter(locale, date_style: :medium)
+      formatter2 = cache.datetime_formatter(locale, date_style: :medium)
+
+      expect(formatter1).to be(formatter2)
+    end
+
+    it "returns different instances for different options" do
+      formatter1 = cache.datetime_formatter(locale, date_style: :short)
+      formatter2 = cache.datetime_formatter(locale, date_style: :long)
+
+      expect(formatter1).not_to be(formatter2)
+    end
+  end
+
+  describe "#plural_rules" do
+    it "returns a PluralRules instance" do
+      rules = cache.plural_rules(locale)
+
+      expect(rules).to be_a(ICU4X::PluralRules)
+    end
+
+    it "returns the same instance for the same locale and type" do
+      rules1 = cache.plural_rules(locale)
+      rules2 = cache.plural_rules(locale)
+
+      expect(rules1).to be(rules2)
+    end
+
+    it "returns different instances for different types" do
+      rules1 = cache.plural_rules(locale, type: :cardinal)
+      rules2 = cache.plural_rules(locale, type: :ordinal)
+
+      expect(rules1).not_to be(rules2)
+    end
+
+    it "returns correct plural categories" do
+      rules = cache.plural_rules(locale)
+
+      expect(rules.select(1)).to eq(:one)
+      expect(rules.select(2)).to eq(:other)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Introduce `Foxtail::ICU4XCache` singleton to cache ICU4X formatter and rules instances, significantly reducing instantiation overhead.

## Changes

- Add `ICU4XCache` singleton class with thread-safe caching (Mutex per cache type)
- Update `Function` module to use cached formatters for NUMBER/DATETIME
- Update `Resolver` to use cached PluralRules
- Update dungeon game example to use cached NumberFormat
- Add Zeitwerk inflection for `ICU4XCache` naming

## Benchmark Results

| Class | Direct (1000 calls) | Cached | Speedup |
|-------|---------------------|--------|---------|
| NumberFormat | 13.0ms | 0.8ms | **16x** |
| DateTimeFormat | 7.1ms | 0.8ms | **9x** |
| PluralRules | 5.4ms | 0.5ms | **10x** |

Note: `ICU4X::Locale.parse` was not cached as it's already very fast (~0.17μs per call).

## Test Plan

- All existing tests pass
- New specs for `ICU4XCache` verify caching behavior and instance reuse

Fixes #146
