### PR TITLE
:sparkles: Add Visitor pattern support to AST

### DIFF
--- a/foxtail-tools/.rubocop.yml
+++ b/foxtail-tools/.rubocop.yml
@@ -70,10 +70,12 @@ RSpec/MultipleDescribes:
   Exclude:
     - 'spec/foxtail/syntax/parser/ast_spec.rb'  # Tests multiple AST node classes in logical groupings
 
-# Internal utility methods in stream processing don't require documentation
+# Internal utility methods don't require documentation
 Style/DocumentationMethod:
   Exclude:
     - 'lib/foxtail/syntax/parser/stream.rb'     # Internal stream processing utilities
+    - 'lib/foxtail/syntax/parser/ast/*.rb'      # children method overrides documented in base class
+    - 'lib/foxtail/syntax/visitor.rb'           # visit_* methods documented at module level
 
 # Case statements don't always need else clauses when all cases are handled
 # or when unhandled cases should be ignored intentionally

--- a/foxtail-tools/lib/foxtail/syntax/parser/ast/attribute.rb
+++ b/foxtail-tools/lib/foxtail/syntax/parser/ast/attribute.rb
@@ -14,6 +14,8 @@ module Foxtail
             @id = id
             @value = value
           end
+
+          def children = [id, value]
         end
       end
     end

--- a/foxtail-tools/lib/foxtail/syntax/parser/ast/base_node.rb
+++ b/foxtail-tools/lib/foxtail/syntax/parser/ast/base_node.rb
@@ -46,6 +46,16 @@ module Foxtail
             true
           end
 
+          # Accept a visitor and dispatch to the appropriate visit method
+          def accept(visitor)
+            method_name = "visit_#{self.class.name.split("::").last.gsub(/([a-z])([A-Z])/, '\1_\2').downcase}"
+            visitor.public_send(method_name, self)
+          end
+
+          # Returns an array of child nodes for traversal
+          # Subclasses with children should override this method
+          def children = []
+
           # Convert node to hash representation for JSON serialization
           def to_h
             result = {}

--- a/foxtail-tools/lib/foxtail/syntax/parser/ast/call_arguments.rb
+++ b/foxtail-tools/lib/foxtail/syntax/parser/ast/call_arguments.rb
@@ -14,6 +14,8 @@ module Foxtail
             @positional = positional
             @named = named
           end
+
+          def children = [*positional, *named]
         end
       end
     end

--- a/foxtail-tools/lib/foxtail/syntax/parser/ast/function_reference.rb
+++ b/foxtail-tools/lib/foxtail/syntax/parser/ast/function_reference.rb
@@ -14,6 +14,8 @@ module Foxtail
             @id = id
             @arguments = arguments
           end
+
+          def children = [id, arguments].compact
         end
       end
     end

--- a/foxtail-tools/lib/foxtail/syntax/parser/ast/junk.rb
+++ b/foxtail-tools/lib/foxtail/syntax/parser/ast/junk.rb
@@ -14,6 +14,8 @@ module Foxtail
             @content = content
             @annotations = annotations
           end
+
+          def children = annotations
         end
       end
     end

--- a/foxtail-tools/lib/foxtail/syntax/parser/ast/message.rb
+++ b/foxtail-tools/lib/foxtail/syntax/parser/ast/message.rb
@@ -19,6 +19,8 @@ module Foxtail
             @attributes = attributes
             @comment = comment
           end
+
+          def children = [id, value, *attributes, comment].compact
         end
       end
     end

--- a/foxtail-tools/lib/foxtail/syntax/parser/ast/message_reference.rb
+++ b/foxtail-tools/lib/foxtail/syntax/parser/ast/message_reference.rb
@@ -14,6 +14,8 @@ module Foxtail
             @id = id
             @attribute = attribute
           end
+
+          def children = [id, attribute].compact
         end
       end
     end

--- a/foxtail-tools/lib/foxtail/syntax/parser/ast/named_argument.rb
+++ b/foxtail-tools/lib/foxtail/syntax/parser/ast/named_argument.rb
@@ -14,6 +14,8 @@ module Foxtail
             @name = name
             @value = value
           end
+
+          def children = [name, value]
         end
       end
     end

--- a/foxtail-tools/lib/foxtail/syntax/parser/ast/pattern.rb
+++ b/foxtail-tools/lib/foxtail/syntax/parser/ast/pattern.rb
@@ -13,6 +13,8 @@ module Foxtail
             super()
             @elements = elements
           end
+
+          def children = elements
         end
       end
     end

--- a/foxtail-tools/lib/foxtail/syntax/parser/ast/placeable.rb
+++ b/foxtail-tools/lib/foxtail/syntax/parser/ast/placeable.rb
@@ -12,6 +12,8 @@ module Foxtail
             super()
             @expression = expression
           end
+
+          def children = [expression]
         end
       end
     end

--- a/foxtail-tools/lib/foxtail/syntax/parser/ast/resource.rb
+++ b/foxtail-tools/lib/foxtail/syntax/parser/ast/resource.rb
@@ -13,6 +13,8 @@ module Foxtail
             super()
             @body = body
           end
+
+          def children = body
         end
       end
     end

--- a/foxtail-tools/lib/foxtail/syntax/parser/ast/select_expression.rb
+++ b/foxtail-tools/lib/foxtail/syntax/parser/ast/select_expression.rb
@@ -14,6 +14,8 @@ module Foxtail
             @selector = selector
             @variants = variants
           end
+
+          def children = [selector, *variants]
         end
       end
     end

--- a/foxtail-tools/lib/foxtail/syntax/parser/ast/term.rb
+++ b/foxtail-tools/lib/foxtail/syntax/parser/ast/term.rb
@@ -19,6 +19,8 @@ module Foxtail
             @attributes = attributes
             @comment = comment
           end
+
+          def children = [id, value, *attributes, comment].compact
         end
       end
     end

--- a/foxtail-tools/lib/foxtail/syntax/parser/ast/term_reference.rb
+++ b/foxtail-tools/lib/foxtail/syntax/parser/ast/term_reference.rb
@@ -16,6 +16,8 @@ module Foxtail
             @attribute = attribute
             @arguments = arguments
           end
+
+          def children = [id, attribute, arguments].compact
         end
       end
     end

--- a/foxtail-tools/lib/foxtail/syntax/parser/ast/variable_reference.rb
+++ b/foxtail-tools/lib/foxtail/syntax/parser/ast/variable_reference.rb
@@ -12,6 +12,8 @@ module Foxtail
             super()
             @id = id
           end
+
+          def children = [id]
         end
       end
     end

--- a/foxtail-tools/lib/foxtail/syntax/parser/ast/variant.rb
+++ b/foxtail-tools/lib/foxtail/syntax/parser/ast/variant.rb
@@ -16,6 +16,8 @@ module Foxtail
             @value = value
             @default = default
           end
+
+          def children = [key, value]
         end
       end
     end

--- a/foxtail-tools/lib/foxtail/syntax/visitor.rb
+++ b/foxtail-tools/lib/foxtail/syntax/visitor.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Foxtail
+  module Syntax
+    # Visitor module for traversing AST nodes
+    #
+    # Include this module and override the visit_* methods you need.
+    # All visit_* methods return nil by default (no-op).
+    #
+    # @example Collecting message IDs
+    #   class MessageIdCollector
+    #     include Foxtail::Syntax::Visitor
+    #
+    #     def initialize
+    #       @ids = []
+    #     end
+    #
+    #     attr_reader :ids
+    #
+    #     def visit_message(node)
+    #       @ids << node.id.name
+    #       visit_children(node)
+    #     end
+    #   end
+    #
+    #   collector = MessageIdCollector.new
+    #   resource.accept(collector)
+    #   collector.ids # => ["hello", "goodbye", ...]
+    module Visitor
+      # Container nodes
+      def visit_resource(_node) = nil
+      def visit_message(_node) = nil
+      def visit_term(_node) = nil
+      def visit_attribute(_node) = nil
+      def visit_pattern(_node) = nil
+      def visit_placeable(_node) = nil
+
+      # Expression nodes
+      def visit_select_expression(_node) = nil
+      def visit_variant(_node) = nil
+      def visit_call_arguments(_node) = nil
+      def visit_named_argument(_node) = nil
+
+      # Reference nodes
+      def visit_message_reference(_node) = nil
+      def visit_term_reference(_node) = nil
+      def visit_function_reference(_node) = nil
+      def visit_variable_reference(_node) = nil
+
+      # Literal nodes
+      def visit_string_literal(_node) = nil
+      def visit_number_literal(_node) = nil
+      def visit_text_element(_node) = nil
+      def visit_identifier(_node) = nil
+
+      # Comment nodes
+      def visit_comment(_node) = nil
+      def visit_group_comment(_node) = nil
+      def visit_resource_comment(_node) = nil
+
+      # Error nodes
+      def visit_junk(_node) = nil
+      def visit_annotation(_node) = nil
+
+      # Metadata nodes
+      def visit_span(_node) = nil
+
+      # Helper method to recursively visit all children of a node
+      def visit_children(node)
+        node.children.each {|child| child&.accept(self) }
+      end
+    end
+  end
+end

--- a/foxtail-tools/lib/foxtail/syntax/visitor.rb
+++ b/foxtail-tools/lib/foxtail/syntax/visitor.rb
@@ -5,7 +5,8 @@ module Foxtail
     # Visitor module for traversing AST nodes
     #
     # Include this module and override the visit_* methods you need.
-    # All visit_* methods return nil by default (no-op).
+    # By default, all visit_* methods traverse children automatically.
+    # Override a method and omit `super` to stop traversal at that node.
     #
     # @example Collecting message IDs
     #   class MessageIdCollector
@@ -19,7 +20,7 @@ module Foxtail
     #
     #     def visit_message(node)
     #       @ids << node.id.name
-    #       visit_children(node)
+    #       super  # continue traversal
     #     end
     #   end
     #
@@ -28,42 +29,42 @@ module Foxtail
     #   collector.ids # => ["hello", "goodbye", ...]
     module Visitor
       # Container nodes
-      def visit_resource(_node) = nil
-      def visit_message(_node) = nil
-      def visit_term(_node) = nil
-      def visit_attribute(_node) = nil
-      def visit_pattern(_node) = nil
-      def visit_placeable(_node) = nil
+      def visit_resource(node) = visit_children(node)
+      def visit_message(node) = visit_children(node)
+      def visit_term(node) = visit_children(node)
+      def visit_attribute(node) = visit_children(node)
+      def visit_pattern(node) = visit_children(node)
+      def visit_placeable(node) = visit_children(node)
 
       # Expression nodes
-      def visit_select_expression(_node) = nil
-      def visit_variant(_node) = nil
-      def visit_call_arguments(_node) = nil
-      def visit_named_argument(_node) = nil
+      def visit_select_expression(node) = visit_children(node)
+      def visit_variant(node) = visit_children(node)
+      def visit_call_arguments(node) = visit_children(node)
+      def visit_named_argument(node) = visit_children(node)
 
       # Reference nodes
-      def visit_message_reference(_node) = nil
-      def visit_term_reference(_node) = nil
-      def visit_function_reference(_node) = nil
-      def visit_variable_reference(_node) = nil
+      def visit_message_reference(node) = visit_children(node)
+      def visit_term_reference(node) = visit_children(node)
+      def visit_function_reference(node) = visit_children(node)
+      def visit_variable_reference(node) = visit_children(node)
 
       # Literal nodes
-      def visit_string_literal(_node) = nil
-      def visit_number_literal(_node) = nil
-      def visit_text_element(_node) = nil
-      def visit_identifier(_node) = nil
+      def visit_string_literal(node) = visit_children(node)
+      def visit_number_literal(node) = visit_children(node)
+      def visit_text_element(node) = visit_children(node)
+      def visit_identifier(node) = visit_children(node)
 
       # Comment nodes
-      def visit_comment(_node) = nil
-      def visit_group_comment(_node) = nil
-      def visit_resource_comment(_node) = nil
+      def visit_comment(node) = visit_children(node)
+      def visit_group_comment(node) = visit_children(node)
+      def visit_resource_comment(node) = visit_children(node)
 
       # Error nodes
-      def visit_junk(_node) = nil
-      def visit_annotation(_node) = nil
+      def visit_junk(node) = visit_children(node)
+      def visit_annotation(node) = visit_children(node)
 
       # Metadata nodes
-      def visit_span(_node) = nil
+      def visit_span(node) = visit_children(node)
 
       # Helper method to recursively visit all children of a node
       def visit_children(node)

--- a/foxtail-tools/spec/foxtail/syntax/visitor_spec.rb
+++ b/foxtail-tools/spec/foxtail/syntax/visitor_spec.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+RSpec.describe Foxtail::Syntax::Visitor do
+  let(:parser) { Foxtail::Syntax::Parser.new }
+
+  describe "visit_* methods" do
+    it "has visit methods for all AST node types" do
+      visitor_class = Class.new { include Foxtail::Syntax::Visitor }
+      visitor = visitor_class.new
+
+      expected_methods = %i[
+        visit_resource
+        visit_message
+        visit_term
+        visit_attribute
+        visit_pattern
+        visit_placeable
+        visit_select_expression
+        visit_variant
+        visit_call_arguments
+        visit_named_argument
+        visit_message_reference
+        visit_term_reference
+        visit_function_reference
+        visit_variable_reference
+        visit_string_literal
+        visit_number_literal
+        visit_text_element
+        visit_identifier
+        visit_comment
+        visit_group_comment
+        visit_resource_comment
+        visit_junk
+        visit_annotation
+        visit_span
+        visit_children
+      ]
+
+      expected_methods.each do |method|
+        expect(visitor).to respond_to(method)
+      end
+    end
+
+    it "returns nil by default for all visit methods" do
+      visitor_class = Class.new { include Foxtail::Syntax::Visitor }
+      visitor = visitor_class.new
+
+      resource = parser.parse("hello = world")
+      expect(visitor.visit_resource(resource)).to be_nil
+      expect(visitor.visit_message(resource.body.first)).to be_nil
+    end
+  end
+
+  describe "#accept" do
+    it "dispatches to the correct visit method" do
+      visited_types = []
+      visitor_class = Class.new do
+        include Foxtail::Syntax::Visitor
+
+        define_method(:initialize) do
+          @visited_types = visited_types
+        end
+
+        define_method(:visit_resource) do |node|
+          @visited_types << :resource
+          visit_children(node)
+        end
+
+        define_method(:visit_message) do |node|
+          @visited_types << :message
+          visit_children(node)
+        end
+
+        define_method(:visit_identifier) do |_node|
+          @visited_types << :identifier
+        end
+
+        define_method(:visit_pattern) do |node|
+          @visited_types << :pattern
+          visit_children(node)
+        end
+
+        define_method(:visit_text_element) do |_node|
+          @visited_types << :text_element
+        end
+      end
+
+      resource = parser.parse("hello = world")
+      visitor = visitor_class.new
+      resource.accept(visitor)
+
+      expect(visited_types).to eq(%i[resource message identifier pattern text_element])
+    end
+  end
+
+  describe "#children" do
+    it "returns correct children for Resource" do
+      resource = parser.parse("hello = world\ngoodbye = bye")
+      expect(resource.children.length).to eq(2)
+      expect(resource.children).to all(be_a(Foxtail::Syntax::Parser::AST::Message))
+    end
+
+    it "returns correct children for Message" do
+      resource = parser.parse("hello = world")
+      message = resource.body.first
+      children = message.children
+
+      expect(children.length).to eq(2) # id and value (no attributes, no comment)
+      expect(children[0]).to be_a(Foxtail::Syntax::Parser::AST::Identifier)
+      expect(children[1]).to be_a(Foxtail::Syntax::Parser::AST::Pattern)
+    end
+
+    it "returns correct children for Pattern" do
+      resource = parser.parse("hello = Hello { $name }")
+      message = resource.body.first
+      pattern = message.value
+
+      expect(pattern.children.length).to eq(2)
+      expect(pattern.children[0]).to be_a(Foxtail::Syntax::Parser::AST::TextElement)
+      expect(pattern.children[1]).to be_a(Foxtail::Syntax::Parser::AST::Placeable)
+    end
+
+    it "returns correct children for SelectExpression" do
+      ftl = <<~FTL
+        count = { $num ->
+            [one] One item
+           *[other] { $num } items
+        }
+      FTL
+      resource = parser.parse(ftl)
+      message = resource.body.first
+      placeable = message.value.elements.first
+      select_expr = placeable.expression
+
+      expect(select_expr.children.length).to eq(3) # selector + 2 variants
+      expect(select_expr.children[0]).to be_a(Foxtail::Syntax::Parser::AST::VariableReference)
+      expect(select_expr.children[1]).to be_a(Foxtail::Syntax::Parser::AST::Variant)
+      expect(select_expr.children[2]).to be_a(Foxtail::Syntax::Parser::AST::Variant)
+    end
+
+    it "returns empty array for leaf nodes" do
+      resource = parser.parse("hello = world")
+      message = resource.body.first
+      identifier = message.id
+      text_element = message.value.elements.first
+
+      expect(identifier.children).to eq([])
+      expect(text_element.children).to eq([])
+    end
+  end
+
+  describe "practical usage" do
+    it "can collect all message IDs" do
+      ids = []
+      visitor_class = Class.new do
+        include Foxtail::Syntax::Visitor
+
+        define_method(:initialize) do
+          @ids = ids
+        end
+
+        define_method(:visit_resource) do |node|
+          visit_children(node)
+        end
+
+        define_method(:visit_message) do |node|
+          @ids << node.id.name
+        end
+      end
+
+      ftl = <<~FTL
+        hello = Hello
+        goodbye = Goodbye
+        -brand = Firefox
+        welcome = Welcome
+      FTL
+      resource = parser.parse(ftl)
+      visitor = visitor_class.new
+      resource.accept(visitor)
+
+      expect(ids).to eq(%w[hello goodbye welcome])
+    end
+
+    it "can count all variable references" do
+      count = {value: 0}
+      visitor_class = Class.new do
+        include Foxtail::Syntax::Visitor
+
+        define_method(:initialize) do
+          @count = count
+        end
+
+        define_method(:visit_resource) do |node|
+          visit_children(node)
+        end
+
+        define_method(:visit_message) do |node|
+          visit_children(node)
+        end
+
+        define_method(:visit_pattern) do |node|
+          visit_children(node)
+        end
+
+        define_method(:visit_placeable) do |node|
+          visit_children(node)
+        end
+
+        define_method(:visit_variable_reference) do |_node|
+          @count[:value] += 1
+        end
+      end
+
+      ftl = <<~FTL
+        greeting = Hello { $name }, you have { $count } messages from { $sender }
+      FTL
+      resource = parser.parse(ftl)
+      visitor = visitor_class.new
+      resource.accept(visitor)
+
+      expect(count[:value]).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add Visitor pattern support to foxtail-tools AST for reusable tree traversal without ad-hoc case statements.

## Changes

- Add `Foxtail::Syntax::Visitor` module with `visit_*` hooks for all 23 AST node types
- Add `accept(visitor)` and `children` methods to AST nodes
- Default `visit_*` methods auto-traverse children; omit `super` to stop traversal
- Refactor example to demonstrate Visitor pattern usage

## Test Plan

```bash
bundle exec rake spec:tools
bundle exec rake rubocop:tools
cd foxtail-tools && bundle exec ruby examples/01_prefix_message_ids.rb
```

Closes #155
