### PR TITLE
:bug: Fix silent skip of compat specs when fixtures missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          submodules: true
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/spec/support/compat/base.rb
+++ b/spec/support/compat/base.rb
@@ -26,7 +26,11 @@ module FluentCompatBase
   # @param extra_fields [Hash] additional fields to include in each pair
   # @return [Array<Hash>] sorted array of fixture pairs
   module_function def find_fixture_pairs(json_dir:, ftl_dir:, **extra_fields)
-    return [] unless json_dir.exist?
+    unless json_dir.exist?
+      warn "[WARNING] Fixtures directory not found: #{json_dir}"
+      warn "          Tests will be skipped. Run 'git submodule update --init' to fetch fixtures."
+      return []
+    end
 
     pairs = []
     json_dir.glob("*.json").each do |json_path|


### PR DESCRIPTION
## Summary
Fix compat specs silently skipping when fluent.js submodule fixtures are missing.

## Changes
- Enable submodule checkout in CI workflow to automatically fetch fluent.js fixtures
- Add warning message when fixture directory is not found so developers are informed

Fixes #156
