### PR TITLE
:sparkles: Add convenience iterators for Resource entries

### DIFF
--- a/foxtail-tools/lib/foxtail/cli/commands/ids.rb
+++ b/foxtail-tools/lib/foxtail/cli/commands/ids.rb
@@ -46,7 +46,7 @@ module Foxtail
           parser = Foxtail::Syntax::Parser.new
           resource = parser.parse(content)
 
-          resource.body.each do |entry|
+          resource.each_entry do |entry|
             case entry
             when Foxtail::Syntax::Parser::AST::Message
               next if only_terms

--- a/foxtail-tools/lib/foxtail/syntax/parser/ast/resource.rb
+++ b/foxtail-tools/lib/foxtail/syntax/parser/ast/resource.rb
@@ -15,6 +15,39 @@ module Foxtail
           end
 
           def children = body
+
+          # Iterate over Message entries only
+          # @yield [Message] each message entry
+          # @return [Enumerator] if no block given
+          # @return [self] if block given
+          def each_message(&block)
+            return enum_for(__method__) unless block
+
+            body.each {|entry| yield(entry) if entry.is_a?(Message) }
+            self
+          end
+
+          # Iterate over Term entries only
+          # @yield [Term] each term entry
+          # @return [Enumerator] if no block given
+          # @return [self] if block given
+          def each_term(&block)
+            return enum_for(__method__) unless block
+
+            body.each {|entry| yield(entry) if entry.is_a?(Term) }
+            self
+          end
+
+          # Iterate over Message and Term entries (excludes comments and junk)
+          # @yield [Message, Term] each message or term entry
+          # @return [Enumerator] if no block given
+          # @return [self] if block given
+          def each_entry(&block)
+            return enum_for(__method__) unless block
+
+            body.each {|entry| yield(entry) if entry.is_a?(Message) || entry.is_a?(Term) }
+            self
+          end
         end
       end
     end

--- a/foxtail-tools/spec/foxtail/syntax/parser/ast_spec.rb
+++ b/foxtail-tools/spec/foxtail/syntax/parser/ast_spec.rb
@@ -77,6 +77,78 @@ RSpec.describe Foxtail::Syntax::Parser::AST::Resource do
     expect(hash["body"][0]["id"]["type"]).to eq("Identifier")
     expect(hash["body"][0]["id"]["name"]).to eq("test")
   end
+
+  describe "entry iterators" do
+    let(:hello_message) { Foxtail::Syntax::Parser::AST::Message.new(Foxtail::Syntax::Parser::AST::Identifier.new("hello")) }
+    let(:world_message) { Foxtail::Syntax::Parser::AST::Message.new(Foxtail::Syntax::Parser::AST::Identifier.new("world")) }
+    let(:term) { Foxtail::Syntax::Parser::AST::Term.new(Foxtail::Syntax::Parser::AST::Identifier.new("brand"), Foxtail::Syntax::Parser::AST::Pattern.new([])) }
+    let(:comment) { Foxtail::Syntax::Parser::AST::Comment.new("A comment") }
+    let(:junk) { Foxtail::Syntax::Parser::AST::Junk.new("bad content") }
+    let(:resource) { Foxtail::Syntax::Parser::AST::Resource.new([hello_message, comment, term, junk, world_message]) }
+
+    describe "#each_message" do
+      it "iterates over Message entries only" do
+        messages = []
+        resource.each_message {|msg| messages << msg }
+        expect(messages).to eq([hello_message, world_message])
+      end
+
+      it "returns Enumerator when no block given" do
+        enumerator = resource.each_message
+        expect(enumerator).to be_a(Enumerator)
+        expect(enumerator.to_a).to eq([hello_message, world_message])
+      end
+
+      it "returns self when block given" do
+        result = resource.each_message {|_msg| nil }
+        expect(result).to be(resource)
+      end
+    end
+
+    describe "#each_term" do
+      it "iterates over Term entries only" do
+        terms = []
+        resource.each_term {|t| terms << t }
+        expect(terms).to eq([term])
+      end
+
+      it "returns Enumerator when no block given" do
+        enumerator = resource.each_term
+        expect(enumerator).to be_a(Enumerator)
+        expect(enumerator.to_a).to eq([term])
+      end
+
+      it "returns self when block given" do
+        result = resource.each_term {|_t| nil }
+        expect(result).to be(resource)
+      end
+    end
+
+    describe "#each_entry" do
+      it "iterates over Message and Term entries only" do
+        entries = []
+        resource.each_entry {|e| entries << e }
+        expect(entries).to eq([hello_message, term, world_message])
+      end
+
+      it "excludes comments and junk" do
+        entries = resource.each_entry.to_a
+        expect(entries).not_to include(comment)
+        expect(entries).not_to include(junk)
+      end
+
+      it "returns Enumerator when no block given" do
+        enumerator = resource.each_entry
+        expect(enumerator).to be_a(Enumerator)
+        expect(enumerator.to_a).to eq([hello_message, term, world_message])
+      end
+
+      it "returns self when block given" do
+        result = resource.each_entry {|_e| nil }
+        expect(result).to be(resource)
+      end
+    end
+  end
 end
 
 RSpec.describe Foxtail::Syntax::Parser::AST::Message do


### PR DESCRIPTION
## Summary
Add convenience iterator methods to `AST::Resource` for iterating over specific entry types without manual type checking.

## Changes
- Add `each_message`, `each_term`, `each_entry` methods to `AST::Resource`
- Update `ids` command to use `each_entry` iterator
- Simplify example script using `each_message` iterator

## Before
```ruby
resource.body.each do |entry|
  next unless entry.is_a?(Foxtail::Syntax::Parser::AST::Message)
  # process message
end
```

## After
```ruby
resource.each_message { |msg| ... }   # Messages only
resource.each_term { |term| ... }     # Terms only
resource.each_entry { |entry| ... }   # Messages + Terms
```

Fixes #158
