### PR TITLE
:recycle: Replace ICU4XCache mutex with Dry::Core::Cache

### DIFF
--- a/foxtail-runtime/foxtail-runtime.gemspec
+++ b/foxtail-runtime/foxtail-runtime.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "bigdecimal", ">= 3.1"
+  spec.add_dependency "dry-core", "~> 1.1"
   spec.add_dependency "icu4x", "~> 0.9"
   spec.add_dependency "zeitwerk", "~> 2.7"
 end


### PR DESCRIPTION
## Summary

Replace explicit `Mutex` handling in `ICU4XCache` with `Dry::Core::Cache`, which uses `Concurrent::Map` internally for thread-safe caching.

## Changes

- Add `dry-core` (~> 1.1) as explicit dependency in gemspec
- Replace `ICU4XCache` implementation to use `fetch_or_store` from `Dry::Core::Cache`
- Remove manual mutex management and instance variables

Fixes #163
