### PR TITLE
:bug: Fix NUMBER() selector and adapt dungeon_game to new API

### DIFF
--- a/foxtail-runtime/examples/dungeon_game/README.md
+++ b/foxtail-runtime/examples/dungeon_game/README.md
@@ -4,7 +4,6 @@ Demonstrates advanced localization for game items with grammatical gender, numbe
 
 ## Features
 
-- **Two-layer Bundle architecture**: Separate bundles for items (Terms) and messages
 - **Custom functions**: Language-specific functions for dynamic item embedding
   - All languages: `ITEM`, `ITEM_WITH_COUNT`
 - **German grammatical cases**: nominative, accusative, dative, genitive
@@ -19,6 +18,8 @@ Demonstrates advanced localization for game items with grammatical gender, numbe
 dungeon_game/
   main.rb                    # Main application
   functions/
+    item.rb                  # Item Value type
+    item_with_count.rb       # ItemWithCount Value type
     base.rb                  # Base class for item functions
     de.rb                    # German-specific (case declension)
     en.rb                    # English-specific (a/an selection)
@@ -53,34 +54,21 @@ bundle exec ruby examples/dungeon_game/main.rb
 
 ## Architecture
 
-### Two-layer Bundle Design
-
 ```
 ┌─────────────────────────────────────────────────┐
-│  Items Bundle (per language)                    │
+│  Bundle (per locale)                            │
 │  - Terms: items, articles, counters             │
+│  - Messages                                     │
 │  - All linguistic data in FTL                   │
 └─────────────────────────────────────────────────┘
-                      ↓ Captured via closure
+                      ↓ Registered as functions
 ┌─────────────────────────────────────────────────┐
 │  Custom Functions (ItemFunctions module)        │
 │  - Language-specific subclasses                 │
+│  - Returns Value objects for deferred formatting│
 │  - Resolves terms and formats output            │
 └─────────────────────────────────────────────────┘
-                      ↓ Injected into functions:
-┌─────────────────────────────────────────────────┐
-│  Messages Bundle (per language)                 │
-│  - Messages only                                │
-│  - Uses custom functions to embed item names    │
-└─────────────────────────────────────────────────┘
 ```
-
-### Why Two Bundles?
-
-1. **Separation of concerns**: Item vocabulary vs. game messages
-2. **Translator efficiency**: Edit item declensions directly in FTL
-3. **No circular references**: Items Bundle created first, then used by functions
-4. **Reusability**: Items Bundle can be shared across multiple Messages Bundles
 
 ## Key Concepts
 

--- a/foxtail-runtime/examples/dungeon_game/functions/base.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/base.rb
@@ -9,11 +9,6 @@ module ItemFunctions
   # Provides common fluent functions (ITEM, ITEM_WITH_COUNT) and template methods
   # for subclasses to override language-specific behavior.
   #
-  # Note on the `locale` parameter:
-  # Foxtail::Bundle passes `locale:` to all custom functions. This class uses it
-  # with ICU4X::NumberFormat to provide locale-aware number formatting
-  # (e.g., 1,000 for en, 1.000 for de, 1 000 for fr).
-  #
   # Note on the `cap` parameter:
   # Capitalization at sentence start is technically a message-layer concern,
   # not an item-layer concern. However, Fluent does not support function nesting
@@ -21,8 +16,8 @@ module ItemFunctions
   # pragmatic workaround. The message layer passes `cap: "true"` as a hint
   # when the result will appear at sentence start.
   class Base
-    def initialize(items_bundle)
-      @items_bundle = items_bundle
+    def initialize(bundle)
+      @bundle = bundle
     end
 
     # Returns the custom Fluent functions provided by this handler.
@@ -35,17 +30,37 @@ module ItemFunctions
       }
     end
 
-    # Fluent function: ITEM - Returns a localized item name with optional article.
+    # Fluent function: ITEM - Returns a Value object for deferred formatting.
     #
     # @param item_id [String] the item term reference (e.g., "-sword", "-potion")
     # @param count [Integer] the quantity of items (affects pluralization and article)
+    # @param options [Hash] formatting options (type:, case:, cap:, etc.)
+    # @return [Item] a Value object that will format when #format is called
+    def fluent_item(item_id, count=1, **)
+      Item.new(self, item_id, count:, **)
+    end
+
+    # Fluent function: ITEM_WITH_COUNT - Returns a Value object for deferred formatting.
+    #
+    # @param item_id [String] the item term reference (e.g., "-sword", "-potion")
+    # @param count [Integer] the quantity of items
+    # @param options [Hash] formatting options (type:, case:, cap:, etc.)
+    # @return [ItemWithCount] a Value object that will format when #format is called
+    def fluent_item_with_count(item_id, count, **)
+      ItemWithCount.new(self, item_id, count, **)
+    end
+
+    # Format an item with optional article.
+    # Called by Item#format with the bundle context.
+    #
+    # @param item_id [String] the item term reference
+    # @param bundle [Foxtail::Bundle] the bundle providing locale context
+    # @param count [Integer] the quantity of items
     # @param type [String] article type (language-dependent)
     # @param case [String] grammatical case (language-dependent)
     # @param cap [String] capitalize first letter: "true" or "false"
     # @return [String] the formatted item name with article
-    # @note The trailing ** is required because Foxtail::Bundle passes additional
-    #   keyword arguments (e.g., locale:) that this function does not use.
-    def fluent_item(item_id, count=1, type: "indefinite", case: "nominative", cap: "false", **)
+    def format_item(item_id, count: 1, type: "indefinite", case: "nominative", cap: "false", **)
       grammatical_case = {case:}[:case]
 
       item = resolve_item(item_id, count, grammatical_case)
@@ -54,28 +69,29 @@ module ItemFunctions
       cap == "true" ? capitalize_first(result) : result
     end
 
-    # Fluent function: ITEM_WITH_COUNT - Returns a localized item name with count.
+    # Format an item with count.
+    # Called by ItemWithCount#format with the bundle context.
     #
-    # @param item_id [String] the item term reference (e.g., "-sword", "-potion")
+    # @param item_id [String] the item term reference
     # @param count [Integer] the quantity of items
+    # @param bundle [Foxtail::Bundle] the bundle providing locale context
     # @param type [String] article type (language-dependent)
     # @param case [String] grammatical case (language-dependent)
     # @param cap [String] capitalize first letter: "true" or "false"
-    # @param locale [ICU4X::Locale] the locale for number formatting
-    # @return [String] the formatted item name with count (e.g., "3 swords", "a flask of potion")
-    def fluent_item_with_count(item_id, count, locale:, type: "none", case: "nominative", cap: "false", **)
+    # @return [String] the formatted item name with count
+    def format_item_with_count(item_id, count, bundle:, type: "none", case: "nominative", cap: "false", **)
       grammatical_case = {case:}[:case]
 
       counter_term = resolve_counter_term(item_id)
 
       result = if counter_term
-                 format_count_item_with_counter(counter_term, item_id, count, type, grammatical_case, locale)
+                 format_count_item_with_counter(counter_term, item_id, count, type, grammatical_case, bundle.locale)
                elsif count == 1 && type != "none"
                  item = resolve_item(item_id, count, grammatical_case)
                  article = resolve_article(item_id, count, type, grammatical_case)
                  format_article_item(article, item)
                else
-                 "#{format_count(count, locale)} #{resolve_item(item_id, count, grammatical_case)}"
+                 "#{format_count(count, bundle.locale)} #{resolve_item(item_id, count, grammatical_case)}"
                end
 
       cap == "true" ? capitalize_first(result) : result
@@ -88,9 +104,9 @@ module ItemFunctions
     private def format_article_counter_item(article, counter, item)
       return [counter, item].compact.join(" ") unless article
 
-      term = @items_bundle.term("-fmt-article-counter-item")
+      term = @bundle.term("-fmt-article-counter-item")
       if term
-        @items_bundle.format_pattern(term.value, article:, counter:, item:)
+        @bundle.format_pattern(term.value, article:, counter:, item:)
       else
         "#{article} #{counter} #{item}"
       end
@@ -99,9 +115,9 @@ module ItemFunctions
     private def format_article_item(article, item)
       return item unless article
 
-      term = @items_bundle.term("-fmt-article-item")
+      term = @bundle.term("-fmt-article-item")
       if term
-        @items_bundle.format_pattern(term.value, article:, item:)
+        @bundle.format_pattern(term.value, article:, item:)
       else
         "#{article} #{item}"
       end
@@ -109,7 +125,7 @@ module ItemFunctions
 
     private def format_count_item_with_counter(counter_term, item_id, count, type, grammatical_case, locale)
       item = resolve_item(item_id, 1, grammatical_case)
-      counter = @items_bundle.format_pattern(counter_term.value, count:, case: grammatical_case)
+      counter = @bundle.format_pattern(counter_term.value, count:, case: grammatical_case)
 
       if count == 1 && type != "none"
         counter_gender = counter_term.attributes&.dig("gender")
@@ -121,10 +137,10 @@ module ItemFunctions
     end
 
     private def format_count_counter_item(count, counter, item, locale)
-      term = @items_bundle.term("-fmt-count-counter-item")
+      term = @bundle.term("-fmt-count-counter-item")
       formatted_count = format_count(count, locale)
       if term
-        @items_bundle.format_pattern(term.value, count: formatted_count, counter:, item:)
+        @bundle.format_pattern(term.value, count: formatted_count, counter:, item:)
       else
         "#{formatted_count} #{counter} #{item}"
       end
@@ -141,21 +157,21 @@ module ItemFunctions
     private def resolve_article_for_gender(_gender, _count, _type, _grammatical_case) = nil
 
     private def resolve_counter_term(item_id)
-      term = @items_bundle.term(item_id)
+      term = @bundle.term(item_id)
       return nil unless term&.attributes&.dig("counter")
 
       counter_attr = term.attributes["counter"]
-      counter_str = counter_attr.is_a?(String) ? counter_attr : @items_bundle.format_pattern(counter_attr)
+      counter_str = counter_attr.is_a?(String) ? counter_attr : @bundle.format_pattern(counter_attr)
       return nil unless counter_str.start_with?("-")
 
-      @items_bundle.term(counter_str)
+      @bundle.term(counter_str)
     end
 
     private def resolve_item(item_id, count, grammatical_case)
-      term = @items_bundle.term(item_id)
+      term = @bundle.term(item_id)
       return "{#{item_id}}" unless term
 
-      @items_bundle.format_pattern(term.value, count:, case: grammatical_case)
+      @bundle.format_pattern(term.value, count:, case: grammatical_case)
     end
   end
 end

--- a/foxtail-runtime/examples/dungeon_game/functions/de.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/de.rb
@@ -16,10 +16,10 @@ module ItemFunctions
       return nil unless gender
 
       term_name = type == "definite" ? "-def-article" : "-indef-article"
-      term = @items_bundle.term(term_name)
+      term = @bundle.term(term_name)
       return nil unless term
 
-      @items_bundle.format_pattern(
+      @bundle.format_pattern(
         term.value,
         gender:,
         count:,
@@ -32,10 +32,10 @@ module ItemFunctions
       return nil if type == "indefinite" && count != 1
 
       term_name = type == "definite" ? "-def-article" : "-indef-article"
-      term = @items_bundle.term(term_name)
+      term = @bundle.term(term_name)
       return nil unless term
 
-      @items_bundle.format_pattern(
+      @bundle.format_pattern(
         term.value,
         gender:,
         count:,
@@ -44,7 +44,7 @@ module ItemFunctions
     end
 
     private def resolve_gender(item_id)
-      term = @items_bundle.term(item_id)
+      term = @bundle.term(item_id)
       term&.attributes&.dig("gender")
     end
   end

--- a/foxtail-runtime/examples/dungeon_game/functions/en.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/en.rb
@@ -28,24 +28,24 @@ module ItemFunctions
     end
 
     private def resolve_definite_article
-      term = @items_bundle.term("-def-article")
+      term = @bundle.term("-def-article")
       return "the" unless term
 
-      @items_bundle.format_pattern(term.value)
+      @bundle.format_pattern(term.value)
     end
 
     private def resolve_indefinite_article(item_id, count)
       # Check explicit .indef attribute first
-      item_term = @items_bundle.term(item_id)
+      item_term = @bundle.term(item_id)
       return item_term.attributes["indef"] if item_term&.attributes&.key?("indef")
 
       # Use FTL term with first_letter selector
-      term = @items_bundle.term("-indef-article")
+      term = @bundle.term("-indef-article")
       return "a" unless term
 
       item = resolve_item(item_id, count, "nominative")
       first_letter = extract_first_letter(item)
-      @items_bundle.format_pattern(term.value, first_letter:)
+      @bundle.format_pattern(term.value, first_letter:)
     end
 
     private def resolve_indefinite_article_for_counter(counter_term, count)
@@ -53,12 +53,12 @@ module ItemFunctions
       return counter_term.attributes["indef"] if counter_term.attributes&.key?("indef")
 
       # Use FTL term with first_letter selector
-      term = @items_bundle.term("-indef-article")
+      term = @bundle.term("-indef-article")
       return "a" unless term
 
-      counter = @items_bundle.format_pattern(counter_term.value, count:)
+      counter = @bundle.format_pattern(counter_term.value, count:)
       first_letter = extract_first_letter(counter)
-      @items_bundle.format_pattern(term.value, first_letter:)
+      @bundle.format_pattern(term.value, first_letter:)
     end
 
     # Extract first letter, handling accented characters via NFD normalization

--- a/foxtail-runtime/examples/dungeon_game/functions/fr.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/fr.rb
@@ -9,13 +9,13 @@ module ItemFunctions
   class Fr < Base
     private def format_article_counter_item(article, counter, item, counter_elision: false)
       unless article
-        term = @items_bundle.term("-fmt-counter-item")
-        return @items_bundle.format_pattern(term.value, counter:, item:, elision: counter_elision.to_s)
+        term = @bundle.term("-fmt-counter-item")
+        return @bundle.format_pattern(term.value, counter:, item:, elision: counter_elision.to_s)
       end
 
       article_elision = article.end_with?("'")
-      term = @items_bundle.term("-fmt-article-counter-item")
-      @items_bundle.format_pattern(
+      term = @bundle.term("-fmt-article-counter-item")
+      @bundle.format_pattern(
         term.value,
         article:,
         counter:,
@@ -29,14 +29,14 @@ module ItemFunctions
       return item unless article
 
       elision = article.end_with?("'")
-      term = @items_bundle.term("-fmt-article-item")
-      @items_bundle.format_pattern(term.value, article:, item:, elision: elision.to_s)
+      term = @bundle.term("-fmt-article-item")
+      @bundle.format_pattern(term.value, article:, item:, elision: elision.to_s)
     end
 
     private def format_count_item_with_counter(counter_term, item_id, count, type, grammatical_case, locale)
       item = resolve_item(item_id, 1, grammatical_case)
       item_elision = should_elide_for_item?(item_id)
-      counter = @items_bundle.format_pattern(counter_term.value, count:, elision: item_elision.to_s)
+      counter = @bundle.format_pattern(counter_term.value, count:, elision: item_elision.to_s)
 
       if count == 1 && type != "none"
         counter_gender = counter_term.attributes&.dig("gender") || "feminine"
@@ -48,15 +48,15 @@ module ItemFunctions
     end
 
     private def format_count_counter_item(count, counter, item, elision, locale)
-      term = @items_bundle.term("-fmt-count-counter-item")
+      term = @bundle.term("-fmt-count-counter-item")
       formatted_count = format_count(count, locale)
-      @items_bundle.format_pattern(term.value, count: formatted_count, counter:, item:, elision: elision.to_s)
+      @bundle.format_pattern(term.value, count: formatted_count, counter:, item:, elision: elision.to_s)
     end
 
     private def resolve_article(item_id, count, type, _grammatical_case=nil)
       return nil if type == "none"
 
-      term = @items_bundle.term(item_id)
+      term = @bundle.term(item_id)
       gender = term&.attributes&.dig("gender") || "masculine"
       elision = should_elide?(term, item_id, count)
 
@@ -78,10 +78,10 @@ module ItemFunctions
     end
 
     private def resolve_definite_article(gender, count, elision)
-      term = @items_bundle.term("-def-article")
+      term = @bundle.term("-def-article")
       return nil unless term
 
-      @items_bundle.format_pattern(
+      @bundle.format_pattern(
         term.value,
         gender:,
         count:,
@@ -90,10 +90,10 @@ module ItemFunctions
     end
 
     private def resolve_indefinite_article(gender, count)
-      term = @items_bundle.term("-indef-article")
+      term = @bundle.term("-indef-article")
       return nil unless term
 
-      @items_bundle.format_pattern(
+      @bundle.format_pattern(
         term.value,
         gender:,
         count:
@@ -112,7 +112,7 @@ module ItemFunctions
     end
 
     private def should_elide_for_item?(item_id)
-      term = @items_bundle.term(item_id)
+      term = @bundle.term(item_id)
 
       # Check explicit .elision attribute first
       if term&.attributes&.key?("elision")
@@ -129,7 +129,7 @@ module ItemFunctions
         return counter_term.attributes["elision"] != "false"
       end
 
-      counter = @items_bundle.format_pattern(counter_term.value, count:)
+      counter = @bundle.format_pattern(counter_term.value, count:)
       starts_with_vowel?(counter)
     end
 

--- a/foxtail-runtime/examples/dungeon_game/functions/item.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/item.rb
@@ -6,7 +6,6 @@ module ItemFunctions
   # Value type for ITEM function - wraps item_id with formatting options.
   class Item < Foxtail::Function::Value
     attr_reader :handler
-    attr_reader :item_id
 
     # @param handler [ItemFunctions::Base] the locale-specific handler
     # @param item_id [String] the item term reference (e.g., "-sword")
@@ -14,14 +13,13 @@ module ItemFunctions
     def initialize(handler, item_id, **)
       super(item_id, **)
       @handler = handler
-      @item_id = item_id
     end
 
     # Format the item for display
     # @param bundle [Foxtail::Bundle] the bundle providing locale context
     # @return [String] the formatted item name with article
     def format(bundle:)
-      @handler.format_item(@item_id, bundle:, **@options)
+      @handler.format_item(value, bundle:, **@options)
     end
   end
 end

--- a/foxtail-runtime/examples/dungeon_game/functions/item.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/item.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Value types for ItemFunctions that defer formatting until display time.
+# These inherit from Foxtail::Function::Value to integrate with the resolver.
+module ItemFunctions
+  # Value type for ITEM function - wraps item_id with formatting options.
+  class Item < Foxtail::Function::Value
+    attr_reader :handler
+    attr_reader :item_id
+
+    # @param handler [ItemFunctions::Base] the locale-specific handler
+    # @param item_id [String] the item term reference (e.g., "-sword")
+    # @param options [Hash] formatting options (type:, case:, cap:, etc.)
+    def initialize(handler, item_id, **)
+      super(item_id, **)
+      @handler = handler
+      @item_id = item_id
+    end
+
+    # Format the item for display
+    # @param bundle [Foxtail::Bundle] the bundle providing locale context
+    # @return [String] the formatted item name with article
+    def format(bundle:)
+      @handler.format_item(@item_id, bundle:, **@options)
+    end
+  end
+end

--- a/foxtail-runtime/examples/dungeon_game/functions/item_with_count.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/item_with_count.rb
@@ -12,7 +12,7 @@ module ItemFunctions
     # @param count [Integer] the quantity of items
     # @param options [Hash] formatting options (type:, case:, cap:, etc.)
     def initialize(handler, item_id, count, **)
-      super({item_id:, count:}, **)
+      super([item_id, count], **)
       @handler = handler
     end
 
@@ -20,7 +20,7 @@ module ItemFunctions
     # @param bundle [Foxtail::Bundle] the bundle providing locale context
     # @return [String] the formatted item name with count
     def format(bundle:)
-      @handler.format_item_with_count(value[:item_id], value[:count], bundle:, **@options)
+      @handler.format_item_with_count(*value, bundle:, **@options)
     end
   end
 end

--- a/foxtail-runtime/examples/dungeon_game/functions/item_with_count.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/item_with_count.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Value types for ItemFunctions that defer formatting until display time.
+# These inherit from Foxtail::Function::Value to integrate with the resolver.
+module ItemFunctions
+  # Value type for ITEM_WITH_COUNT function - wraps item_id and count with formatting options.
+  class ItemWithCount < Foxtail::Function::Value
+    attr_reader :handler
+    attr_reader :item_id
+    attr_reader :count
+
+    # @param handler [ItemFunctions::Base] the locale-specific handler
+    # @param item_id [String] the item term reference (e.g., "-sword")
+    # @param count [Integer] the quantity of items
+    # @param options [Hash] formatting options (type:, case:, cap:, etc.)
+    def initialize(handler, item_id, count, **)
+      super(count, **)
+      @handler = handler
+      @item_id = item_id
+      @count = count
+    end
+
+    # Format the item with count for display
+    # @param bundle [Foxtail::Bundle] the bundle providing locale context
+    # @return [String] the formatted item name with count
+    def format(bundle:)
+      @handler.format_item_with_count(@item_id, @count, bundle:, **@options)
+    end
+  end
+end

--- a/foxtail-runtime/examples/dungeon_game/functions/item_with_count.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/item_with_count.rb
@@ -6,25 +6,21 @@ module ItemFunctions
   # Value type for ITEM_WITH_COUNT function - wraps item_id and count with formatting options.
   class ItemWithCount < Foxtail::Function::Value
     attr_reader :handler
-    attr_reader :item_id
-    attr_reader :count
 
     # @param handler [ItemFunctions::Base] the locale-specific handler
     # @param item_id [String] the item term reference (e.g., "-sword")
     # @param count [Integer] the quantity of items
     # @param options [Hash] formatting options (type:, case:, cap:, etc.)
     def initialize(handler, item_id, count, **)
-      super(count, **)
+      super({item_id:, count:}, **)
       @handler = handler
-      @item_id = item_id
-      @count = count
     end
 
     # Format the item with count for display
     # @param bundle [Foxtail::Bundle] the bundle providing locale context
     # @return [String] the formatted item name with count
     def format(bundle:)
-      @handler.format_item_with_count(@item_id, @count, bundle:, **@options)
+      @handler.format_item_with_count(value[:item_id], value[:count], bundle:, **@options)
     end
   end
 end

--- a/foxtail-runtime/examples/dungeon_game/functions/ja.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/ja.rb
@@ -7,47 +7,38 @@ module ItemFunctions
   # Provides counter word (助数詞) support for items. Each item can have a
   # counter defined via .counter attribute (e.g., 振 for swords, 瓶 for bottles).
   class Ja < Base
-    # @return [Hash{String => #call}] ITEM and ITEM_WITH_COUNT functions
-    def functions
-      {
-        "ITEM" => method(:fluent_item),
-        "ITEM_WITH_COUNT" => method(:fluent_item_with_count)
-      }
-    end
-
-    # Fluent function: ITEM - Returns a localized item name.
+    # Format an item name.
     #
     # Japanese items do not require articles or grammatical case handling,
     # so this is a simplified version of the base class method.
     #
     # @param item_id [String] the item term reference (e.g., "-sword", "-potion")
+    # @param bundle [Foxtail::Bundle] the bundle providing locale context
     # @return [String] the localized item name
-    # @note The trailing ** is required because Foxtail::Bundle passes additional
-    #   keyword arguments (e.g., locale:) that this function does not use.
-    def fluent_item(item_id, **)
+    def format_item(item_id, **)
       resolve_item(item_id, 1, "nominative")
     end
 
-    # Fluent function: ITEM_WITH_COUNT - Returns count + counter + item name.
+    # Format an item with count using counter words.
     #
     # Formats as: "<count><counter>の<item>" (e.g., "5瓶の回復薬")
     #
     # @param item_id [String] the item term reference (e.g., "-sword", "-healing-potion")
     # @param count [Integer] the quantity of items
-    # @param locale [ICU4X::Locale] the locale for number formatting
+    # @param bundle [Foxtail::Bundle] the bundle providing locale context
     # @return [String] the formatted item with count and counter
-    def fluent_item_with_count(item_id, count, locale:, **)
+    def format_item_with_count(item_id, count, bundle:, **)
       item = resolve_item(item_id, count, "nominative")
       counter = resolve_counter(item_id) || "個"
-      "#{format_count(count, locale)}#{counter}の#{item}"
+      "#{format_count(count, bundle.locale)}#{counter}の#{item}"
     end
 
     private def resolve_counter(item_id)
-      term = @items_bundle.term(item_id)
+      term = @bundle.term(item_id)
       return nil unless term&.attributes&.dig("counter")
 
       counter_attr = term.attributes["counter"]
-      counter_attr.is_a?(String) ? counter_attr : @items_bundle.format_pattern(counter_attr)
+      counter_attr.is_a?(String) ? counter_attr : @bundle.format_pattern(counter_attr)
     end
   end
 end

--- a/foxtail-runtime/spec/examples_spec.rb
+++ b/foxtail-runtime/spec/examples_spec.rb
@@ -19,9 +19,7 @@ RSpec.describe "Examples" do
       expected_file = example.dirname.join("expected.txt")
       next unless expected_file.exist?
 
-      it example.dirname.basename.to_s do |ex|
-        # TODO: dungeon_game uses custom functions with locale: parameter (see issue #165)
-        pending "custom function API change" if ex.description == "dungeon_game"
+      it example.dirname.basename.to_s do
         expect(example).to produce_expected_output(example.dirname.join("expected.txt"))
       end
     end


### PR DESCRIPTION
## Summary
Fix NUMBER() selector failing plural matching for formatted numbers and adapt dungeon_game example to new custom function API.

## Changes
- Add Function::Value class hierarchy for deferred locale formatting
- Custom functions now return Value objects instead of formatted strings
- Migrate dungeon_game from two-bundle to single-bundle architecture
- Add Item and ItemWithCount Value types for custom functions

## Test Plan
- `bundle exec rake` passes all tests
- dungeon_game example produces correct output for all locales (en, de, fr, ja)

Fixes #165
