### PR TITLE
:recycle: Separate handler from functions in ItemFunctions

### DIFF
--- a/foxtail-runtime/examples/dungeon_game/functions/de_handler.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/de_handler.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
+require_relative "handler"
+
 # German-specific item localization functions
 module ItemFunctions
   # German item localization handler.
   #
   # Provides article declension based on grammatical gender (masculine, feminine, neuter),
   # number (singular, plural), and case (nominative, accusative, dative, genitive).
-  class De < Base
+  class DeHandler < Handler
     private def resolve_article(item_id, count, type, grammatical_case)
       return nil if type == "none"
       # Indefinite only for singular

--- a/foxtail-runtime/examples/dungeon_game/functions/en_handler.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/en_handler.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
+require_relative "handler"
+
 # English-specific item localization functions
 module ItemFunctions
   # English item localization handler.
   #
   # Provides indefinite article selection (a/an) based on first letter,
   # with support for explicit overrides via .indef attribute.
-  class En < Base
+  class EnHandler < Handler
     private def resolve_article(item_id, count, type, _grammatical_case=nil)
       return nil if type == "none"
       # Indefinite only for singular

--- a/foxtail-runtime/examples/dungeon_game/functions/fr_handler.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/fr_handler.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
+require_relative "handler"
+
 # French-specific item localization functions
 module ItemFunctions
   # French item localization handler.
   #
   # Provides article selection with elision handling (le/la → l' before vowels),
   # with support for h aspiré exceptions via .elision attribute.
-  class Fr < Base
+  class FrHandler < Handler
     private def format_article_counter_item(article, counter, item, counter_elision: false)
       unless article
         term = @bundle.term("-fmt-counter-item")

--- a/foxtail-runtime/examples/dungeon_game/functions/handler.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/handler.rb
@@ -4,10 +4,10 @@ require "icu4x"
 
 # Namespace for item localization function handlers
 module ItemFunctions
-  # Base class for language-specific item localization functions.
+  # Base handler class for language-specific item localization.
   #
-  # Provides common fluent functions (ITEM, ITEM_WITH_COUNT) and template methods
-  # for subclasses to override language-specific behavior.
+  # Provides formatting methods for ITEM and ITEM_WITH_COUNT functions.
+  # Subclasses override template methods for language-specific behavior.
   #
   # Note on the `cap` parameter:
   # Capitalization at sentence start is technically a message-layer concern,
@@ -15,39 +15,9 @@ module ItemFunctions
   # (e.g., CAPITALIZE(ITEM_WITH_COUNT(...))), so we use the `cap` parameter as a
   # pragmatic workaround. The message layer passes `cap: "true"` as a hint
   # when the result will appear at sentence start.
-  class Base
+  class Handler
     def initialize(bundle)
       @bundle = bundle
-    end
-
-    # Returns the custom Fluent functions provided by this handler.
-    # Subclasses may override this method to provide different functions.
-    # @return [Hash{String => #call}] function name to callable mapping
-    def functions
-      {
-        "ITEM" => method(:fluent_item),
-        "ITEM_WITH_COUNT" => method(:fluent_item_with_count)
-      }
-    end
-
-    # Fluent function: ITEM - Returns a Value object for deferred formatting.
-    #
-    # @param item_id [String] the item term reference (e.g., "-sword", "-potion")
-    # @param count [Integer] the quantity of items (affects pluralization and article)
-    # @param options [Hash] formatting options (type:, case:, cap:, etc.)
-    # @return [Item] a Value object that will format when #format is called
-    def fluent_item(item_id, count=1, **)
-      Item.new(self, item_id, count:, **)
-    end
-
-    # Fluent function: ITEM_WITH_COUNT - Returns a Value object for deferred formatting.
-    #
-    # @param item_id [String] the item term reference (e.g., "-sword", "-potion")
-    # @param count [Integer] the quantity of items
-    # @param options [Hash] formatting options (type:, case:, cap:, etc.)
-    # @return [ItemWithCount] a Value object that will format when #format is called
-    def fluent_item_with_count(item_id, count, **)
-      ItemWithCount.new(self, item_id, count, **)
     end
 
     # Format an item with optional article.

--- a/foxtail-runtime/examples/dungeon_game/functions/item.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/item.rb
@@ -7,7 +7,7 @@ module ItemFunctions
   class Item < Foxtail::Function::Value
     attr_reader :handler
 
-    # @param handler [ItemFunctions::Base] the locale-specific handler
+    # @param handler [ItemFunctions::Handler] the locale-specific handler
     # @param item_id [String] the item term reference (e.g., "-sword")
     # @param options [Hash] formatting options (type:, case:, cap:, etc.)
     def initialize(handler, item_id, **)

--- a/foxtail-runtime/examples/dungeon_game/functions/item_with_count.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/item_with_count.rb
@@ -7,7 +7,7 @@ module ItemFunctions
   class ItemWithCount < Foxtail::Function::Value
     attr_reader :handler
 
-    # @param handler [ItemFunctions::Base] the locale-specific handler
+    # @param handler [ItemFunctions::Handler] the locale-specific handler
     # @param item_id [String] the item term reference (e.g., "-sword")
     # @param count [Integer] the quantity of items
     # @param options [Hash] formatting options (type:, case:, cap:, etc.)

--- a/foxtail-runtime/examples/dungeon_game/functions/ja_handler.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/ja_handler.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
+require_relative "handler"
+
 # Japanese-specific item localization functions
 module ItemFunctions
   # Japanese item localization handler.
   #
   # Provides counter word (助数詞) support for items. Each item can have a
   # counter defined via .counter attribute (e.g., 振 for swords, 瓶 for bottles).
-  class Ja < Base
+  class JaHandler < Handler
     # Format an item name.
     #
     # Japanese items do not require articles or grammatical case handling,


### PR DESCRIPTION
## Summary
Refactor ItemFunctions to separate handler (formatting logic) from function factory.

## Changes
- Extract `Handler` class for formatting and locale-specific behavior
- Rename locale classes to `*Handler` (EnHandler, DeHandler, FrHandler, JaHandler)
- Move function factory to module-level `functions_for` using closures that capture handler

## Benefits
- Clearer separation of concerns
- Easier to test Handler independently
- More flexible function registration

Closes #168
