### PR TITLE
Normalize function arguments to Function::Value

### DIFF
--- a/foxtail-runtime/examples/dungeon_game/functions/handler.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/handler.rb
@@ -31,7 +31,12 @@ module ItemFunctions
     # @param cap [String] capitalize first letter: "true" or "false"
     # @return [String] the formatted item name with article
     def format_item(item_id, count: 1, type: "indefinite", case: "nominative", cap: "false", **)
-      grammatical_case = {case:}[:case]
+      # Unwrap Function::Value arguments
+      item_id = unwrap(item_id)
+      count = unwrap(count)
+      type = unwrap(type)
+      cap = unwrap(cap)
+      grammatical_case = unwrap({case:}[:case])
 
       item = resolve_item(item_id, count, grammatical_case)
       article = resolve_article(item_id, count, type, grammatical_case)
@@ -50,7 +55,12 @@ module ItemFunctions
     # @param cap [String] capitalize first letter: "true" or "false"
     # @return [String] the formatted item name with count
     def format_item_with_count(item_id, count, bundle:, type: "none", case: "nominative", cap: "false", **)
-      grammatical_case = {case:}[:case]
+      # Unwrap Function::Value arguments
+      item_id = unwrap(item_id)
+      count = unwrap(count)
+      type = unwrap(type)
+      cap = unwrap(cap)
+      grammatical_case = unwrap({case:}[:case])
 
       counter_term = resolve_counter_term(item_id)
 
@@ -66,6 +76,8 @@ module ItemFunctions
 
       cap == "true" ? capitalize_first(result) : result
     end
+
+    private def unwrap(value) = value.is_a?(Foxtail::Function::Value) ? value.value : value
 
     private def capitalize_first(str) = str.sub(/\A\p{Ll}/, &:upcase)
 

--- a/foxtail-runtime/examples/dungeon_game/functions/ja_handler.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/ja_handler.rb
@@ -18,6 +18,7 @@ module ItemFunctions
     # @param bundle [Foxtail::Bundle] the bundle providing locale context
     # @return [String] the localized item name
     def format_item(item_id, **)
+      item_id = unwrap(item_id)
       resolve_item(item_id, 1, "nominative")
     end
 
@@ -30,6 +31,8 @@ module ItemFunctions
     # @param bundle [Foxtail::Bundle] the bundle providing locale context
     # @return [String] the formatted item with count and counter
     def format_item_with_count(item_id, count, bundle:, **)
+      item_id = unwrap(item_id)
+      count = unwrap(count)
       item = resolve_item(item_id, count, "nominative")
       counter = resolve_counter(item_id) || "個"
       "#{format_count(count, bundle.locale)}#{counter}の#{item}"

--- a/foxtail-runtime/lib/foxtail/function/value.rb
+++ b/foxtail-runtime/lib/foxtail/function/value.rb
@@ -23,6 +23,10 @@ module Foxtail
       # @param bundle [Foxtail::Bundle] The bundle providing locale and context (unused in base implementation)
       # @return [String] The formatted value
       def format(**) = @value.to_s
+
+      # String representation for interpolation
+      # @return [String] The string representation of the wrapped value
+      def to_s = @value.to_s
     end
   end
 end


### PR DESCRIPTION
## Summary
- Add `wrap_as_value` in Resolver to normalize function arguments before passing to custom functions
- NUMBER/DATETIME functions unwrap values and merge options from nested function calls (aligning with fluent.js behavior)
- Add `to_s` to `Function::Value` for string interpolation
- Custom functions unwrap `Function::Value` arguments at entry points
- Update custom-functions.md documentation

## Test plan
- [x] All existing tests pass
- [x] dungeon_game example works correctly with normalized arguments

Closes #169