### PR TITLE
Remove handler instance variable from Item/ItemWithCount

### DIFF
--- a/foxtail-runtime/examples/dungeon_game/functions/item.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/item.rb
@@ -5,19 +5,9 @@
 module ItemFunctions
   # Value type for ITEM function - wraps item_id with formatting options.
   class Item < Foxtail::Function::Value
-    attr_reader :handler
-
-    # @param handler [ItemFunctions::Handler] the locale-specific handler
-    # @param item_id [String] the item term reference (e.g., "-sword")
-    # @param options [Hash] formatting options (type:, case:, cap:, etc.)
-    def initialize(handler, item_id, **)
-      super(item_id, **)
-      @handler = handler
-    end
-
     # Format the item for display
     # @param bundle [Foxtail::Bundle] the bundle providing locale context
     # @return [String] the formatted item name with article
-    def format(bundle:) = @handler.format_item(value, bundle:, **@options)
+    def format(bundle:) = ItemFunctions.handler_for(bundle).format_item(value, bundle:, **@options)
   end
 end

--- a/foxtail-runtime/examples/dungeon_game/functions/item_with_count.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/item_with_count.rb
@@ -5,20 +5,14 @@
 module ItemFunctions
   # Value type for ITEM_WITH_COUNT function - wraps item_id and count with formatting options.
   class ItemWithCount < Foxtail::Function::Value
-    attr_reader :handler
-
-    # @param handler [ItemFunctions::Handler] the locale-specific handler
     # @param item_id [String] the item term reference (e.g., "-sword")
     # @param count [Integer] the quantity of items
     # @param options [Hash] formatting options (type:, case:, cap:, etc.)
-    def initialize(handler, item_id, count, **)
-      super([item_id, count], **)
-      @handler = handler
-    end
+    def initialize(item_id, count, **) = super([item_id, count], **)
 
     # Format the item with count for display
     # @param bundle [Foxtail::Bundle] the bundle providing locale context
     # @return [String] the formatted item name with count
-    def format(bundle:) = @handler.format_item_with_count(*value, bundle:, **@options)
+    def format(bundle:) = ItemFunctions.handler_for(bundle).format_item_with_count(*value, bundle:, **@options)
   end
 end


### PR DESCRIPTION
## Summary

- Remove `@handler` instance variable from `Item` and `ItemWithCount`
- Derive handler from bundle in `format` method via `ItemFunctions.handler_for`
- Replace `functions_for` method with `FUNCTIONS` constant

## Benefits

- Simpler object structure without extra instance variable
- Unblocks #172 (Function::Value to Data class conversion)

Closes #173