### PR TITLE
Convert Function::Value to Data class

### DIFF
--- a/foxtail-runtime/doc/custom-functions.md
+++ b/foxtail-runtime/doc/custom-functions.md
@@ -46,7 +46,7 @@ shout = ->(text, **) { text.to_s.upcase }
 
 # Numeric value for plural matching: Use Function::Number
 item_count = ->(count, **) do
-  Foxtail::Function::Number.new(count)
+  Foxtail::Function::Number[count, {}]
 end
 ```
 
@@ -88,7 +88,7 @@ format_price = ->(amount, currency:, **) do
   # Unwrap Function::Value arguments
   raw_amount = amount.value
   raw_currency = currency.value
-  Foxtail::Function::Number.new(raw_amount, style: :currency, currency: raw_currency)
+  Foxtail::Function::Number[raw_amount, {style: :currency, currency: raw_currency}]
 end
 
 bundle = Foxtail::Bundle.new(locale, functions: { "PRICE" => format_price })

--- a/foxtail-runtime/examples/dungeon_game/functions/item.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/item.rb
@@ -8,6 +8,6 @@ module ItemFunctions
     # Format the item for display
     # @param bundle [Foxtail::Bundle] the bundle providing locale context
     # @return [String] the formatted item name with article
-    def format(bundle:) = ItemFunctions.handler_for(bundle).format_item(value, bundle:, **@options)
+    def format(bundle:) = ItemFunctions.handler_for(bundle).format_item(value, bundle:, **options)
   end
 end

--- a/foxtail-runtime/examples/dungeon_game/functions/item_with_count.rb
+++ b/foxtail-runtime/examples/dungeon_game/functions/item_with_count.rb
@@ -4,15 +4,11 @@
 # These inherit from Foxtail::Function::Value to integrate with the resolver.
 module ItemFunctions
   # Value type for ITEM_WITH_COUNT function - wraps item_id and count with formatting options.
+  # value is [item_id, count] array
   class ItemWithCount < Foxtail::Function::Value
-    # @param item_id [String] the item term reference (e.g., "-sword")
-    # @param count [Integer] the quantity of items
-    # @param options [Hash] formatting options (type:, case:, cap:, etc.)
-    def initialize(item_id, count, **) = super([item_id, count], **)
-
     # Format the item with count for display
     # @param bundle [Foxtail::Bundle] the bundle providing locale context
     # @return [String] the formatted item name with count
-    def format(bundle:) = ItemFunctions.handler_for(bundle).format_item_with_count(*value, bundle:, **@options)
+    def format(bundle:) = ItemFunctions.handler_for(bundle).format_item_with_count(*value, bundle:, **options)
   end
 end

--- a/foxtail-runtime/examples/dungeon_game/main.rb
+++ b/foxtail-runtime/examples/dungeon_game/main.rb
@@ -38,8 +38,8 @@ module ItemFunctions
   # Custom functions for item localization
   # @return [Hash{String => #call}] Custom functions hash
   FUNCTIONS = {
-    "ITEM" => ->(item_id, count=1, **options) { Item.new(item_id, count:, **options) },
-    "ITEM_WITH_COUNT" => ->(item_id, count, **options) { ItemWithCount.new(item_id, count, **options) }
+    "ITEM" => ->(item_id, count=1, **options) { Item[item_id, {count:, **options}] },
+    "ITEM_WITH_COUNT" => ->(item_id, count, **options) { ItemWithCount[[item_id, count], options] }
   }.freeze
   public_constant :FUNCTIONS
 

--- a/foxtail-runtime/lib/foxtail/bundle/resolver.rb
+++ b/foxtail-runtime/lib/foxtail/bundle/resolver.rb
@@ -424,14 +424,14 @@ module Foxtail
         when Function::Value
           value
         when Numeric
-          Function::Number.new(value)
+          Function::Number[value, {}]
         when Time
-          Function::DateTime.new(value)
+          Function::DateTime[value, {}]
         else
           if value.respond_to?(:to_time)
-            Function::DateTime.new(value)
+            Function::DateTime[value, {}]
           else
-            Function::Value.new(value)
+            Function::Value[value, {}]
           end
         end
       end

--- a/foxtail-runtime/lib/foxtail/function.rb
+++ b/foxtail-runtime/lib/foxtail/function.rb
@@ -12,13 +12,13 @@ module Foxtail
           # Unwrap value and merge options from nested function calls (like fluent.js)
           raw_value, existing_options = unwrap_value(value)
           unwrapped_options = unwrap_options(options)
-          Number.new(raw_value, **existing_options, **unwrapped_options)
+          Number[raw_value, existing_options.merge(unwrapped_options)]
         },
         "DATETIME" => ->(value, **options) {
           # Unwrap value and merge options from nested function calls (like fluent.js)
           raw_value, existing_options = unwrap_value(value)
           unwrapped_options = unwrap_options(options)
-          DateTime.new(raw_value, **existing_options, **unwrapped_options)
+          DateTime[raw_value, existing_options.merge(unwrapped_options)]
         }
       }
     end

--- a/foxtail-runtime/lib/foxtail/function/datetime.rb
+++ b/foxtail-runtime/lib/foxtail/function/datetime.rb
@@ -29,8 +29,8 @@ module Foxtail
       # @param bundle [Foxtail::Bundle] The bundle providing locale and context
       # @return [String] The formatted datetime
       def format(bundle:)
-        icu_options = self.class.convert_options(@options)
-        ICU4XCache.instance.datetime_formatter(bundle.locale, **icu_options).format(@value)
+        icu_options = self.class.convert_options(options)
+        ICU4XCache.instance.datetime_formatter(bundle.locale, **icu_options).format(value)
       end
     end
   end

--- a/foxtail-runtime/lib/foxtail/function/number.rb
+++ b/foxtail-runtime/lib/foxtail/function/number.rb
@@ -35,8 +35,8 @@ module Foxtail
       # @param bundle [Foxtail::Bundle] The bundle providing locale and context
       # @return [String] The formatted number
       def format(bundle:)
-        icu_options = self.class.convert_options(@options)
-        ICU4XCache.instance.number_formatter(bundle.locale, **icu_options).format(@value)
+        icu_options = self.class.convert_options(options)
+        ICU4XCache.instance.number_formatter(bundle.locale, **icu_options).format(value)
       end
     end
   end

--- a/foxtail-runtime/lib/foxtail/function/value.rb
+++ b/foxtail-runtime/lib/foxtail/function/value.rb
@@ -2,31 +2,25 @@
 
 module Foxtail
   module Function
+    Value = Data.define(:value, :options)
+
     # Base class for deferred-formatting values
     # Wraps a value with formatting options, deferring locale-specific formatting until display time
+    #
+    # @!attribute [r] value
+    #   @return [Object] The wrapped raw value
+    # @!attribute [r] options
+    #   @return [Hash] Formatting options
     class Value
-      # @return [Object] The wrapped raw value
-      attr_reader :value
-
-      # @return [Hash] Formatting options
-      attr_reader :options
-
-      # @param value [Object] The value to wrap
-      # @param options [Hash] Formatting options (camelCase keys from FTL)
-      def initialize(value, **options)
-        @value = value
-        @options = options
-      end
-
       # Format the value for display
       # Subclasses may override for locale-specific formatting
       # @param bundle [Foxtail::Bundle] The bundle providing locale and context (unused in base implementation)
       # @return [String] The formatted value
-      def format(**) = @value.to_s
+      def format(**) = value.to_s
 
       # String representation for interpolation
       # @return [String] The string representation of the wrapped value
-      def to_s = @value.to_s
+      def to_s = value.to_s
     end
   end
 end


### PR DESCRIPTION
## Summary

Convert `Function::Value` from a regular class to a Ruby Data class for immutability and simpler code.

## Changes

- Replace class definition with `Data.define(:value, :options)`
- Use `[]` constructor instead of `.new` (Data class idiom)
- Remove `initialize` overrides from subclasses (Number, DateTime)
- Update all call sites to use new constructor syntax
- Update documentation examples

## Benefits

- Immutability guaranteed by Data class
- Value-based equality
- Simpler, more idiomatic Ruby code

## Dependencies

This PR is based on #174 and should be merged after it.

Closes #172