### PR TITLE
:arrow_up: Update Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.3", "3.4", "4.0"]
+        ruby: ["3.3", "3.4", "4.0"]
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.2"
+        ruby-version: "3.3"
         bundler-cache: true
 
     - name: Build gems

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.2"
+        ruby-version: "3.3"
         bundler-cache: true
 
     - name: Extract version from branch name

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ AllCops:
   ExtraDetails: true
   NewCops: enable
   SuggestExtensions: false
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   UseCache: true
 
 inherit_mode:

--- a/foxtail-runtime/.rubocop.yml
+++ b/foxtail-runtime/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
   EnabledByDefault: true
   ExtraDetails: true
   NewCops: enable
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   UseCache: true
 
 inherit_mode:

--- a/foxtail-runtime/foxtail-runtime.gemspec
+++ b/foxtail-runtime/foxtail-runtime.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.homepage = "https://github.com/sakuro/foxtail"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.2"
+  spec.required_ruby_version = ">= 3.3"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "#{spec.homepage}.git"

--- a/foxtail-tools/.rubocop.yml
+++ b/foxtail-tools/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
   EnabledByDefault: true
   ExtraDetails: true
   NewCops: enable
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   UseCache: true
 
 inherit_mode:

--- a/foxtail-tools/foxtail-tools.gemspec
+++ b/foxtail-tools/foxtail-tools.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.homepage = "https://github.com/sakuro/foxtail"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.2"
+  spec.required_ruby_version = ">= 3.3"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "#{spec.homepage}.git"

--- a/foxtail-tools/lib/foxtail/syntax/parser.rb
+++ b/foxtail-tools/lib/foxtail/syntax/parser.rb
@@ -10,7 +10,7 @@ module Foxtail
 
       # Define Indent as a Struct for temporary indentation tokens
       # Note: Uses Struct instead of Data.define because the value field is mutated in dedent()
-      Indent = Struct.new(:value, :start, :end, :span, keyword_init: true)
+      Indent = Struct.new(:value, :start, :end, :span)
 
       # Create a new Parser instance
       # @param with_spans [Boolean] Whether to include span information in AST nodes (default: true)

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-ruby = "3.2"
+ruby = "3.3"
 
 [env]
 _.path = ["bin", "exe"]


### PR DESCRIPTION
Automated update of maintained Ruby versions from Ruby's official branches.yml.

This PR updates:
- `.github/workflows/ci.yml` test matrix to include all maintained Ruby versions
- `.github/workflows/release-*.yml` ruby-version to match the minimum Ruby version
- `.rubocop.yml` files TargetRubyVersion to match the minimum Ruby version
- `*.gemspec` required_ruby_version to match the minimum Ruby version
- `mise.toml` ruby version to match the minimum Ruby version
