### PR TITLE
:sparkles: Add format_attribute to Bundle and Sequence

### DIFF
--- a/foxtail-runtime/CHANGELOG.md
+++ b/foxtail-runtime/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Added
+- Add `format_attribute` to `Bundle` and `Sequence` for formatting message attributes directly (#179)
+
 ## [0.5.0] - 2026-05-08
 
 ### Added

--- a/foxtail-runtime/lib/foxtail/bundle.rb
+++ b/foxtail-runtime/lib/foxtail/bundle.rb
@@ -123,6 +123,20 @@ module Foxtail
       format_pattern(message.value, errors, **)
     end
 
+    # Format a message attribute with the given arguments.
+    #
+    # @param id [String, Symbol] Message identifier
+    # @param attr [String, Symbol] Attribute name
+    # @param errors [Array, nil] If provided, errors are collected into this array instead of being ignored.
+    # @return [String] Formatted attribute string, or "id.attr" if message or attribute not found
+    def format_attribute(id, attr, errors=nil, **)
+      msg = message(id)
+      pattern = msg&.attributes&.[](attr.to_s)
+      return "#{id}.#{attr}" unless pattern
+
+      format_pattern(pattern, errors, **)
+    end
+
     # Format a pattern with the given arguments (using Resolver)
     #
     # @param pattern [String, Array] The pattern to format

--- a/foxtail-runtime/lib/foxtail/sequence.rb
+++ b/foxtail-runtime/lib/foxtail/sequence.rb
@@ -44,6 +44,18 @@ module Foxtail
       bundle ? bundle.format(id, errors, **) : id.to_s
     end
 
+    # Formats a message attribute using the first bundle that contains the message.
+    # Keyword arguments are passed through to the bundle's format_attribute method.
+    #
+    # @param id [String] The message ID
+    # @param attr [String, Symbol] Attribute name
+    # @param errors [Array, nil] If provided, errors are collected into this array instead of being ignored.
+    # @return [String] The formatted attribute, or "id.attr" if not found
+    def format_attribute(id, attr, errors=nil, **)
+      bundle = find_bundle(id)
+      bundle ? bundle.format_attribute(id, attr, errors, **) : "#{id}.#{attr}"
+    end
+
     private def find_bundle(id) = @bundles.find {|bundle| bundle.message?(id) }
   end
 end

--- a/foxtail-runtime/spec/foxtail/bundle_spec.rb
+++ b/foxtail-runtime/spec/foxtail/bundle_spec.rb
@@ -256,6 +256,52 @@ RSpec.describe Foxtail::Bundle do
     end
   end
 
+  describe "#format_attribute" do
+    let(:bundle) { Foxtail::Bundle.new(ICU4X::Locale.parse("en"), use_isolating: false) }
+
+    before do
+      ftl = <<~FTL
+        login-button =
+            .label = Sign in
+            .tooltip = Click to sign in
+        greeting =
+            .aria-label = Hello, {$name}!
+      FTL
+      bundle.add_resource(Foxtail::Resource.from_string(ftl))
+    end
+
+    it "formats a simple attribute" do
+      expect(bundle.format_attribute("login-button", "label")).to eq("Sign in")
+    end
+
+    it "formats a second attribute" do
+      expect(bundle.format_attribute("login-button", "tooltip")).to eq("Click to sign in")
+    end
+
+    it "formats an attribute with variable substitution" do
+      expect(bundle.format_attribute("greeting", "aria-label", name: "Alice")).to eq("Hello, Alice!")
+    end
+
+    it "accepts symbol as attr" do
+      expect(bundle.format_attribute("login-button", :label)).to eq("Sign in")
+    end
+
+    it "returns 'id.attr' when message does not exist" do
+      expect(bundle.format_attribute("nonexistent", "label")).to eq("nonexistent.label")
+    end
+
+    it "returns 'id.attr' when attribute does not exist" do
+      expect(bundle.format_attribute("login-button", "nonexistent")).to eq("login-button.nonexistent")
+    end
+
+    it "collects errors when errors array is provided" do
+      errors = []
+      result = bundle.format_attribute("greeting", "aria-label", errors)
+      expect(result).to eq("Hello, {$name}!")
+      expect(errors).to include("Unknown variable: $name")
+    end
+  end
+
   describe "#format_pattern" do
     let(:bundle) { Foxtail::Bundle.new(ICU4X::Locale.parse("en"), use_isolating: false) }
 

--- a/foxtail-runtime/spec/foxtail/sequence_spec.rb
+++ b/foxtail-runtime/spec/foxtail/sequence_spec.rb
@@ -86,6 +86,60 @@ RSpec.describe Foxtail::Sequence do
     end
   end
 
+  describe "#format_attribute" do
+    let(:en_us_bundle_with_attrs) do
+      bundle = Foxtail::Bundle.new(en_us_locale, use_isolating: false)
+      resource = Foxtail::Resource.from_string(<<~FTL)
+        login-button =
+            .label = Sign in
+            .tooltip = Click to sign in
+        greeting =
+            .aria-label = Hello, {$name}!
+      FTL
+      bundle.add_resource(resource)
+      bundle
+    end
+
+    let(:en_bundle_with_attrs) do
+      bundle = Foxtail::Bundle.new(en_locale, use_isolating: false)
+      resource = Foxtail::Resource.from_string(<<~FTL)
+        en-only-button =
+            .label = English only
+      FTL
+      bundle.add_resource(resource)
+      bundle
+    end
+
+    let(:attr_sequence) { Foxtail::Sequence.new(en_us_bundle_with_attrs, en_bundle_with_attrs) }
+
+    it "formats attribute from the first matching bundle" do
+      expect(attr_sequence.format_attribute("login-button", "label")).to eq("Sign in")
+    end
+
+    it "formats attribute with variable substitution" do
+      expect(attr_sequence.format_attribute("greeting", "aria-label", name: "World")).to eq("Hello, World!")
+    end
+
+    it "uses fallback bundle when primary does not have the message" do
+      expect(attr_sequence.format_attribute("en-only-button", "label")).to eq("English only")
+    end
+
+    it "returns 'id.attr' when message is not found in any bundle" do
+      expect(attr_sequence.format_attribute("nonexistent", "label")).to eq("nonexistent.label")
+    end
+
+    it "returns 'id.attr' when attribute is not found" do
+      expect(attr_sequence.format_attribute("login-button", "nonexistent")).to eq("login-button.nonexistent")
+    end
+
+    it "collects errors when errors array is provided" do
+      errors = []
+      result = attr_sequence.format_attribute("greeting", "aria-label", errors)
+      expect(result).to eq("Hello, {$name}!")
+      expect(errors).to include("Unknown variable: $name")
+    end
+  end
+
   describe "with empty sequence" do
     let(:empty_sequence) { Foxtail::Sequence.new }
 


### PR DESCRIPTION
## Summary
Add `format_attribute` convenience methods to `Bundle` and `Sequence` for formatting message attributes directly without manual three-step lookups.

## Changes
- Add `Bundle#format_attribute(id, attr, errors=nil, **)` — looks up the attribute pattern and delegates to `format_pattern`
- Add `Sequence#format_attribute(id, attr, errors=nil, **)` — finds the bundle and delegates to `bundle#format_attribute`
- Both return `"id.attr"` as fallback when message or attribute is not found, mirroring `format`'s behavior

## Before
```ruby
bundle = sequence.find(id)
message = bundle.message(id)
pattern = message&.attributes&.[](attr)
bundle.format_pattern(pattern, nil, **args)
```

## After
```ruby
sequence.format_attribute(id, attr, **args)
```

Closes #179
