### PR TITLE
:bug: Inject term call arguments into isolated scope during resolution

### DIFF
--- a/foxtail-runtime/CHANGELOG.md
+++ b/foxtail-runtime/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Fixed
+- Fix term call arguments being silently ignored during resolution (#182)
+
 ## [0.6.0] - 2026-05-09
 
 ### Added

--- a/foxtail-runtime/lib/foxtail/bundle/resolver.rb
+++ b/foxtail-runtime/lib/foxtail/bundle/resolver.rb
@@ -185,16 +185,26 @@ module Foxtail
           return "{-#{name}}"
         end
 
+        # Build an isolated scope containing only the named call arguments.
+        # Per the Fluent spec, term scope must not inherit the caller's external variables.
+        named_args = expr.args.filter_map {|arg|
+          next unless arg.is_a?(Parser::AST::NamedArgument)
+
+          [arg.name.to_sym, resolve_expression(arg.value, scope)]
+        }.to_h
+        term_scope = scope.term_scope(**named_args)
+
         # Resolve term value
         if attr
-          result = resolve_term_attribute(term, attr, scope)
+          result = resolve_term_attribute(term, attr, term_scope)
         elsif term.value
-          result = resolve_pattern(term.value, scope)
+          result = resolve_pattern(term.value, term_scope)
         else
           scope.add_error("No value: -#{name}")
           result = "{-#{name}}"
         end
 
+        scope.errors.concat(term_scope.errors)
         scope.release(name)
         result
       end

--- a/foxtail-runtime/lib/foxtail/bundle/scope.rb
+++ b/foxtail-runtime/lib/foxtail/bundle/scope.rb
@@ -53,6 +53,15 @@ module Foxtail
         child
       end
 
+      # Create an isolated scope for term resolution.
+      # Unlike child_scope, this does NOT inherit external variables — only the
+      # explicitly passed named call arguments are visible as variables inside the term.
+      def term_scope(**named_args)
+        child = self.class.new(@bundle, **named_args)
+        child.instance_variable_set(:@dirty, @dirty.dup)
+        child
+      end
+
       # Reset locals (used in some resolution contexts)
       def clear_locals = @locals.clear
 

--- a/foxtail-runtime/spec/foxtail/bundle/resolver_spec.rb
+++ b/foxtail-runtime/spec/foxtail/bundle/resolver_spec.rb
@@ -117,6 +117,53 @@ RSpec.describe Foxtail::Bundle::Resolver do
       expect(result).to match(/\{-[ab]\}/)
       expect(scope.errors.any? {|e| e.include?("Circular reference detected") }).to be true
     end
+
+    context "with call arguments" do
+      before do
+        bundle.add_resource(
+          Foxtail::Resource.from_string(<<~FTL),
+            -parameterized = Value {$arg}
+            -with-selector =
+                { $case ->
+                    [instrumental] Discordem
+                   *[other] Discord
+                }
+          FTL
+          allow_overrides: true
+        )
+      end
+
+      it "injects named call arguments as variables inside the term" do
+        narg = ast::NamedArgument[name: "arg", value: ast::StringLiteral[value: "bar"]]
+        expr = ast::TermReference[name: "parameterized", args: [narg]]
+        result = resolver.resolve_expression(expr, scope)
+        expect(result).to eq("Value bar")
+      end
+
+      it "does not expose external variables inside the term scope" do
+        # scope has name: "World", but term scope must be isolated from caller's externals
+        bundle.add_resource(
+          Foxtail::Resource.from_string("-uses-name = {$name}"),
+          allow_overrides: true
+        )
+        expr = ast::TermReference[name: "uses-name"]
+        result = resolver.resolve_expression(expr, scope)
+        expect(result).to eq("{$name}")
+      end
+
+      it "resolves the matching selector branch when the call argument is provided" do
+        narg = ast::NamedArgument[name: "case", value: ast::StringLiteral[value: "instrumental"]]
+        expr = ast::TermReference[name: "with-selector", args: [narg]]
+        result = resolver.resolve_expression(expr, scope)
+        expect(result).to eq("Discordem")
+      end
+
+      it "falls back to the default selector branch when no matching call argument is provided" do
+        expr = ast::TermReference[name: "with-selector"]
+        result = resolver.resolve_expression(expr, scope)
+        expect(result).to eq("Discord")
+      end
+    end
   end
 
   describe "#resolve_message_reference" do


### PR DESCRIPTION
## Summary

Term call arguments (e.g. `{ -term(key: "val") }`) were parsed correctly into the AST but silently discarded during resolution, causing variables inside the term to always be undefined.

## Changes

- Add `Scope#term_scope` to create an isolated scope with only the named call arguments as variables (no inheritance of caller's external variables, per the Fluent spec)
- Fix `resolve_term_reference` to resolve `expr.args`, build a `term_scope`, and use it when resolving the term value and attributes
- Propagate errors from the term scope back to the caller scope
- Add tests covering: argument injection, external variable isolation, selector resolution with args, and default fallback

## Before / After

```ftl
-discord =
    { $case ->
        [instrumental] Discordem
       *[other] Discord
    }

msg = { -discord(case: "instrumental") }
```

- **Before**: `"Discord"` (`$case` always undefined → default branch)
- **After**: `"Discordem"`

Fixes #182
